### PR TITLE
chore(fastlane): pin app_version 1.4 sur upload_metadata (iOS)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,6 +33,7 @@ platform :ios do
   lane :upload_metadata do
     deliver(
       api_key: asc_key,
+      app_version: "1.4",    # cible explicitement la version 1.4 (ne touche pas la 1.3 en ligne)
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: false,


### PR DESCRIPTION
Aligne la lane iOS sur les lanes macOS (qui ciblent déjà 1.4) pour que l'upload de métadonnées vise explicitement la version 1.4 et jamais la version en ligne.