### PR TITLE
chore(fastlane): notes 1.4 dans les 6 langues manquantes de la fiche

### DIFF
--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,0 +1,7 @@
+Neu in Version 1.4:
+- Neue Clouds: Drime, Internxt und Filen ergänzen die über 70 unterstützten Dienste (Internxt und Filen sind Ende-zu-Ende-verschlüsselt).
+- Einfachere Einrichtung: Ein neuer Bereich „Wo du deine Zugangsdaten findest“ führt durch die Konfiguration von Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage und mehr.
+- Einfachere kombinierte Remotes: Eine Auswahl ermöglicht es, den zugrunde liegenden Speicher (und Ordner) für alias, union, combine usw. zu wählen – kein manuelles Eintippen von „remote:pfad“ mehr.
+- Zuverlässigkeit: Verbindung zu passwortgeschützten Remotes (SFTP, FTP, WebDAV, SMB …) korrigiert.
+- Gesperrte Remotes werden jetzt unter „Zuletzt“ und „Favoriten“ ausgeblendet.
+- Verbesserungen bei Übersetzung und Ordnerübersicht.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,0 +1,7 @@
+Novedades de la versión 1.4:
+- Nuevas nubes: Drime, Internxt y Filen se suman a los más de 70 servicios compatibles (Internxt y Filen están cifrados de extremo a extremo).
+- Conexión más sencilla: un nuevo panel «dónde obtener tus credenciales» guía la configuración de Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage y más.
+- Remotos compuestos más fáciles: un selector permite elegir el almacenamiento subyacente (y la carpeta) para alias, union, combine, etc.: ya no hay que escribir «remote:ruta» a mano.
+- Fiabilidad: corregida la conexión con remotos protegidos por contraseña (SFTP, FTP, WebDAV, SMB…).
+- Los remotos bloqueados ahora se ocultan en Recientes y Favoritos.
+- Mejoras de traducción y de la vista de resumen de carpetas.

--- a/fastlane/metadata/it/release_notes.txt
+++ b/fastlane/metadata/it/release_notes.txt
@@ -1,0 +1,7 @@
+Novità della versione 1.4:
+- Nuovi cloud: Drime, Internxt e Filen si aggiungono agli oltre 70 servizi supportati (Internxt e Filen sono cifrati end-to-end).
+- Connessione più semplice: un nuovo riquadro «dove trovare le tue credenziali» guida la configurazione di Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage e altri.
+- Remote composti più facili: un selettore consente di scegliere l'archivio sottostante (e la cartella) per alias, union, combine, ecc.: niente più «remote:percorso» da digitare a mano.
+- Affidabilità: risolta la connessione ai remote protetti da password (SFTP, FTP, WebDAV, SMB…).
+- I remote bloccati ora sono nascosti da Recenti e Preferiti.
+- Miglioramenti di traduzione e della vista riepilogo cartelle.

--- a/fastlane/metadata/ko/release_notes.txt
+++ b/fastlane/metadata/ko/release_notes.txt
@@ -1,0 +1,7 @@
+버전 1.4의 새로운 기능:
+- 새로운 클라우드: Drime, Internxt, Filen이 70개 이상의 지원 서비스에 추가되었습니다(Internxt와 Filen은 종단 간 암호화됩니다).
+- 더 쉬운 연결: 새로운 "자격 증명을 얻는 위치" 안내가 Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage 등의 설정을 도와줍니다.
+- 더 간단한 복합 리모트: 선택기로 alias, union, combine 등에 사용할 기본 저장소(및 폴더)를 고를 수 있어, 더 이상 "remote:경로"를 직접 입력할 필요가 없습니다.
+- 안정성: 비밀번호로 보호된 리모트(SFTP, FTP, WebDAV, SMB…) 연결 문제를 해결했습니다.
+- 잠긴 리모트는 이제 최근 항목과 즐겨찾기에서 숨겨집니다.
+- 번역 및 폴더 요약 표시가 개선되었습니다.

--- a/fastlane/metadata/pl/release_notes.txt
+++ b/fastlane/metadata/pl/release_notes.txt
@@ -1,0 +1,7 @@
+Nowości w wersji 1.4:
+- Nowe chmury: Drime, Internxt i Filen dołączają do ponad 70 obsługiwanych usług (Internxt i Filen są szyfrowane end-to-end).
+- Łatwiejsze łączenie: nowy panel „gdzie zdobyć dane logowania” prowadzi przez konfigurację Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage i innych.
+- Prostsze remote złożone: selektor pozwala wybrać bazowy magazyn (i folder) dla alias, union, combine itd. — koniec z ręcznym wpisywaniem „remote:ścieżka”.
+- Niezawodność: naprawiono łączenie z remote chronionymi hasłem (SFTP, FTP, WebDAV, SMB…).
+- Zablokowane remote są teraz ukrywane w sekcjach Ostatnie i Ulubione.
+- Ulepszenia tłumaczeń i widoku podsumowania folderów.

--- a/fastlane/metadata/zh-Hans/release_notes.txt
+++ b/fastlane/metadata/zh-Hans/release_notes.txt
@@ -1,0 +1,7 @@
+1.4 版本新功能：
+- 新增云服务：Drime、Internxt 和 Filen 加入 70 多项受支持的服务（Internxt 和 Filen 为端到端加密）。
+- 连接更简单：全新的"在哪里获取凭据"提示，引导你完成 Pixeldrain、1Fichier、ImageKit、Internet Archive、Gofile、Storj、NetStorage 等的设置。
+- 组合远程更轻松：通过选择器即可为 alias、union、combine 等选择底层存储（及文件夹），无需再手动输入"remote:路径"。
+- 可靠性：修复了连接受密码保护的远程（SFTP、FTP、WebDAV、SMB…）的问题。
+- 锁定的远程现在会在"最近"和"收藏"中隐藏。
+- 改进了翻译和文件夹摘要的显示。


### PR DESCRIPTION
App Store Connect bloquait la soumission 1.4 : le « Nouveautés » est obligatoire par langue de la fiche, mais seuls fr-FR + en-US étaient fournis. Ajoute les release_notes 1.4 pour de-DE, es-ES, it, ko, pl, zh-Hans (les 6 langues restantes de la fiche). Uploadées sur ASC (iOS + macOS) — toutes les langues ont désormais leur What's New.