### PR TITLE
Vitrine : pricing (à vie 29,99 €) + v1.4 + SEO

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2524,7 +2524,7 @@ const Hero = () => {
   }, /*#__PURE__*/React.createElement(Icon, {
     name: "bolt.fill",
     size: 14
-  }), t('1 MOIS OFFERT', '1 MONTH FREE'))), /*#__PURE__*/React.createElement("h1", {
+  }), t('v1.4 · ESSAI GRATUIT', 'v1.4 · FREE TRIAL'))), /*#__PURE__*/React.createElement("h1", {
     className: "title"
   }, ML(t('Tous vos clouds.\nChiffrés.', 'Every cloud.\nEncrypted.'))), /*#__PURE__*/React.createElement("p", {
     className: "sub"
@@ -2536,7 +2536,17 @@ const Hero = () => {
   }, /*#__PURE__*/React.createElement(Icon, {
     name: "bolt.fill",
     size: 18
-  }), t('Obtenir mon mois gratuit', 'Get my free month')), /*#__PURE__*/React.createElement(AppStoreBadge, null)), /*#__PURE__*/React.createElement("div", {
+  }), t('Essayer gratuitement', 'Try it free')), /*#__PURE__*/React.createElement(AppStoreBadge, null)), /*#__PURE__*/React.createElement("p", {
+    className: "priceline"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "free"
+  }, t('Essai gratuit', 'Free trial')), t(', puis ', ' · then '), /*#__PURE__*/React.createElement("b", null, t('29,99 € à vie', '€29.99 lifetime')), t(' ou dès ', ' or from '), /*#__PURE__*/React.createElement("b", null, t('2,99 €/mois', '€2.99/mo'))), /*#__PURE__*/React.createElement("p", {
+    className: "alt"
+  }, t('Ou ', 'Or '), /*#__PURE__*/React.createElement("a", {
+    href: GITHUB_URL,
+    target: "_blank",
+    rel: "noopener"
+  }, t('compilez-la gratuitement', 'build it for free')), t(' — c\'est open source', ' — it\'s open source')), /*#__PURE__*/React.createElement("div", {
     className: "trust"
   }, /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement(Icon, {
     name: "lock.fill",
@@ -2684,6 +2694,65 @@ const Features = () => {
     size: 24,
     weight: "semibold"
   })), /*#__PURE__*/React.createElement("h4", null, f.t), /*#__PURE__*/React.createElement("p", null, f.d))))));
+};
+const Pricing = () => {
+  const t = useT();
+  const plans = [{
+    id: 'lifetime',
+    featured: true,
+    name: t('À vie', 'Lifetime'),
+    price: '29,99 €',
+    per: t('paiement unique', 'one-time payment'),
+    badge: t('Meilleure offre', 'Best value'),
+    points: [t('Payé une fois, à vous pour toujours', 'Pay once, yours forever'), t('iPhone, iPad et Mac inclus', 'iPhone, iPad and Mac included'), t('Toutes les fonctionnalités, à vie', 'Every feature, forever')]
+  }, {
+    id: 'yearly',
+    name: t('Annuel', 'Yearly'),
+    price: '11,99 €',
+    per: t('par an', 'per year'),
+    points: [t('Environ 1 €/mois', 'About €1/month'), t('~67 % d\'économie vs mensuel', '~67% off vs monthly'), t('Renouvelable, annulable', 'Renews, cancel anytime')]
+  }, {
+    id: 'monthly',
+    name: t('Mensuel', 'Monthly'),
+    price: '2,99 €',
+    per: t('par mois', 'per month'),
+    points: [t('Sans engagement', 'No commitment'), t('Annulable à tout moment', 'Cancel anytime'), t('Idéal pour démarrer', 'Great to get started')]
+  }];
+  return /*#__PURE__*/React.createElement("section", {
+    id: "pricing"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "wrap"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "eyebrow"
+  }, t('Tarifs', 'Pricing')), /*#__PURE__*/React.createElement("h2", {
+    className: "sec"
+  }, t('Payez comme vous voulez', 'Pay your way')), /*#__PURE__*/React.createElement("p", {
+    className: "sec-sub"
+  }, t('Commencez par l\'essai gratuit. Ensuite, un achat unique à vie ou un abonnement — à vous de choisir.', 'Start with the free trial. Then a one-time lifetime purchase or a subscription — your call.')), /*#__PURE__*/React.createElement("div", {
+    className: "pricing-grid"
+  }, plans.map(p => /*#__PURE__*/React.createElement("div", {
+    key: p.id,
+    className: p.featured ? 'plan featured' : 'plan'
+  }, p.badge && /*#__PURE__*/React.createElement("div", {
+    className: "badge"
+  }, p.badge), /*#__PURE__*/React.createElement("div", {
+    className: "pname"
+  }, p.name), /*#__PURE__*/React.createElement("div", {
+    className: "pprice"
+  }, p.price), /*#__PURE__*/React.createElement("div", {
+    className: "pper"
+  }, p.per), /*#__PURE__*/React.createElement("ul", null, p.points.map(pt => /*#__PURE__*/React.createElement("li", {
+    key: pt
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "check.circle",
+    size: 18
+  }), pt)))))), /*#__PURE__*/React.createElement("p", {
+    className: "pricing-note"
+  }, t('Prix App Store, taxes incluses. L\'essai gratuit ne vous engage à rien.', 'App Store prices, taxes included. The free trial commits you to nothing.'), /*#__PURE__*/React.createElement("span", {
+    className: "solid"
+  }, t('Étudiant·e, emploi précaire, chômage ou budget serré ? ', 'Student, precarious job, unemployed or on a tight budget? '), /*#__PURE__*/React.createElement("a", {
+    href: "mailto:vitalys@rougetet.com?subject=Rclone%20GUI%20%E2%80%94%20Demande%20de%20r%C3%A9duction%20(selon%20mes%20moyens)"
+  }, t('Demandez une réduction selon vos moyens.', 'Ask for a discount based on your means.'))))));
 };
 const FreeMonth = () => {
   const t = useT();
@@ -2969,6 +3038,6 @@ const App = () => {
     setLang: setLang
   }), /*#__PURE__*/React.createElement(Hero, null), /*#__PURE__*/React.createElement(Gallery, {
     lang: lang
-  }), /*#__PURE__*/React.createElement(Features, null), /*#__PURE__*/React.createElement(FreeMonth, null), /*#__PURE__*/React.createElement(Footer, null));
+  }), /*#__PURE__*/React.createElement(Features, null), /*#__PURE__*/React.createElement(Pricing, null), /*#__PURE__*/React.createElement(FreeMonth, null), /*#__PURE__*/React.createElement(Footer, null));
 };
 ReactDOM.createRoot(document.getElementById('root')).render(/*#__PURE__*/React.createElement(App, null));

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -603,13 +603,15 @@ const Hero = () => {
     <section className="hero" id="top">
       <div className="wrap">
         <img className="icon" src="icon.png" alt="Rclone GUI"/>
-        <div><span className="pill"><Icon name="bolt.fill" size={14}/>{t('1 MOIS OFFERT','1 MONTH FREE')}</span></div>
+        <div><span className="pill"><Icon name="bolt.fill" size={14}/>{t('v1.4 · ESSAI GRATUIT','v1.4 · FREE TRIAL')}</span></div>
         <h1 className="title">{ML(t('Tous vos clouds.\nChiffrés.','Every cloud.\nEncrypted.'))}</h1>
         <p className="sub">{t('Parcourez 80+ services cloud — y compris vos remotes rclone chiffrés — directement dans Fichiers. iPhone, iPad & Mac.','Browse 80+ cloud services — including your encrypted rclone crypt remotes — right inside Files. iPhone, iPad & Mac.')}</p>
         <div className="cta-row">
-          <a className="btn btn-violet" href="#free"><Icon name="bolt.fill" size={18}/>{t('Obtenir mon mois gratuit','Get my free month')}</a>
+          <a className="btn btn-violet" href="#free"><Icon name="bolt.fill" size={18}/>{t('Essayer gratuitement','Try it free')}</a>
           <AppStoreBadge/>
         </div>
+        <p className="priceline"><span className="free">{t('Essai gratuit','Free trial')}</span>{t(', puis ',' · then ')}<b>{t('29,99 € à vie','€29.99 lifetime')}</b>{t(' ou dès ',' or from ')}<b>{t('2,99 €/mois','€2.99/mo')}</b></p>
+        <p className="alt">{t('Ou ','Or ')}<a href={GITHUB_URL} target="_blank" rel="noopener">{t('compilez-la gratuitement','build it for free')}</a>{t(' — c\'est open source',' — it\'s open source')}</p>
         <div className="trust">
           <span><Icon name="lock.fill" size={15} style={{ color:ACCENT }}/>{t('Chiffrement de bout en bout','End-to-end crypt')}</span>
           <span><Icon name="shield.fill" size={15} style={{ color:ACCENT }}/>{t('Zéro tracker','Zero trackers')}</span>
@@ -684,6 +686,60 @@ const Features = () => {
             </div>
           ))}
         </div>
+      </div>
+    </section>
+  );
+};
+
+const Pricing = () => {
+  const t = useT();
+  const plans = [
+    { id:'lifetime', featured:true, name:t('À vie','Lifetime'), price:'29,99 €', per:t('paiement unique','one-time payment'),
+      badge:t('Meilleure offre','Best value'),
+      points:[
+        t('Payé une fois, à vous pour toujours','Pay once, yours forever'),
+        t('iPhone, iPad et Mac inclus','iPhone, iPad and Mac included'),
+        t('Toutes les fonctionnalités, à vie','Every feature, forever'),
+      ] },
+    { id:'yearly', name:t('Annuel','Yearly'), price:'11,99 €', per:t('par an','per year'),
+      points:[
+        t('Environ 1 €/mois','About €1/month'),
+        t('~67 % d\'économie vs mensuel','~67% off vs monthly'),
+        t('Renouvelable, annulable','Renews, cancel anytime'),
+      ] },
+    { id:'monthly', name:t('Mensuel','Monthly'), price:'2,99 €', per:t('par mois','per month'),
+      points:[
+        t('Sans engagement','No commitment'),
+        t('Annulable à tout moment','Cancel anytime'),
+        t('Idéal pour démarrer','Great to get started'),
+      ] },
+  ];
+  return (
+    <section id="pricing">
+      <div className="wrap">
+        <div className="eyebrow">{t('Tarifs','Pricing')}</div>
+        <h2 className="sec">{t('Payez comme vous voulez','Pay your way')}</h2>
+        <p className="sec-sub">{t('Commencez par l\'essai gratuit. Ensuite, un achat unique à vie ou un abonnement — à vous de choisir.','Start with the free trial. Then a one-time lifetime purchase or a subscription — your call.')}</p>
+        <div className="pricing-grid">
+          {plans.map(p => (
+            <div key={p.id} className={p.featured ? 'plan featured' : 'plan'}>
+              {p.badge && <div className="badge">{p.badge}</div>}
+              <div className="pname">{p.name}</div>
+              <div className="pprice">{p.price}</div>
+              <div className="pper">{p.per}</div>
+              <ul>
+                {p.points.map(pt => <li key={pt}><Icon name="check.circle" size={18}/>{pt}</li>)}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <p className="pricing-note">
+          {t('Prix App Store, taxes incluses. L\'essai gratuit ne vous engage à rien.','App Store prices, taxes included. The free trial commits you to nothing.')}
+          <span className="solid">
+            {t('Étudiant·e, emploi précaire, chômage ou budget serré ? ','Student, precarious job, unemployed or on a tight budget? ')}
+            <a href="mailto:vitalys@rougetet.com?subject=Rclone%20GUI%20%E2%80%94%20Demande%20de%20r%C3%A9duction%20(selon%20mes%20moyens)">{t('Demandez une réduction selon vos moyens.','Ask for a discount based on your means.')}</a>
+          </span>
+        </p>
       </div>
     </section>
   );
@@ -850,6 +906,7 @@ const App = () => {
       <Hero/>
       <Gallery lang={lang}/>
       <Features/>
+      <Pricing/>
       <FreeMonth/>
       <Footer/>
     </LangContext.Provider>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
 <title>Rclone GUI for iPhone, iPad &amp; Mac — rclone client iOS app</title>
-<meta name="description" content="Rclone GUI is the native iOS and Mac app for rclone — browse and sync 80+ cloud services (S3, Google Drive, Dropbox, SFTP, B2, R2) with rclone crypt encryption, directly in Files. Free 1-month trial."/>
+<meta name="description" content="Rclone GUI is the native iOS &amp; Mac app for rclone — browse and sync 80+ cloud services (S3, Google Drive, Dropbox, SFTP, B2, R2) with rclone crypt encryption, right inside Files. Free trial, then €29.99 lifetime or from €2.99/month. Open source."/>
 <meta name="keywords" content="rclone iOS, rclone iPhone, rclone app, rclone GUI, rclone Mac, rclone client, cloud storage iOS, S3 iOS, rclone crypt, FileProvider"/>
 <link rel="canonical" href="https://rclone.rougetet.com/"/>
 <meta property="og:type" content="website"/>
@@ -31,13 +31,20 @@
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "iOS 17, iPadOS 17, macOS 14",
   "offers": {
-    "@type": "Offer",
-    "price": "0",
+    "@type": "AggregateOffer",
     "priceCurrency": "EUR",
-    "description": "1 month free trial"
+    "lowPrice": "2.99",
+    "highPrice": "29.99",
+    "offerCount": 3,
+    "description": "Free trial, then €29.99 lifetime (one-time) or subscription from €2.99/month. Open source — you can also build it for free.",
+    "offers": [
+      { "@type": "Offer", "name": "Lifetime", "price": "29.99", "priceCurrency": "EUR" },
+      { "@type": "Offer", "name": "Yearly", "price": "11.99", "priceCurrency": "EUR" },
+      { "@type": "Offer", "name": "Monthly", "price": "2.99", "priceCurrency": "EUR" }
+    ]
   },
   "downloadUrl": "https://apps.apple.com/app/id6770088773",
-  "softwareVersion": "1.3",
+  "softwareVersion": "1.4",
   "author": {
     "@type": "Person",
     "name": "Vitalys Rougetet"
@@ -52,6 +59,39 @@
     "No backend server, no data collection"
   ],
   "screenshot": "https://rclone.rougetet.com/icon.png"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Rclone GUI free?",
+      "acceptedAnswer": { "@type": "Answer", "text": "There is a free trial. After that you can buy it once for €29.99 (lifetime, iPhone + iPad + Mac) or subscribe from €2.99/month (€11.99/year). It is also open source, so you can build it yourself for free." }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I get a discount?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yes. Students, unemployed people or anyone on a tight budget can ask the developer for a discount code based on what they can afford — no proof required." }
+    },
+    {
+      "@type": "Question",
+      "name": "Which cloud services does it support?",
+      "acceptedAnswer": { "@type": "Answer", "text": "80+ backends through the rclone engine, including Amazon S3, Cloudflare R2, Google Drive, Dropbox, OneDrive, Backblaze B2, SFTP, WebDAV, Storj and Wasabi." }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it open source?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yes, Rclone GUI is open source (MPL-2.0) and auditable on GitHub. There is no backend server and no analytics or trackers." }
+    },
+    {
+      "@type": "Question",
+      "name": "Does it support rclone crypt encryption?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yes. rclone crypt is supported natively with on-the-fly filename decryption (AES-256 + NaCl secretbox). Your encryption keys never leave the device." }
+    }
+  ]
 }
 </script>
 <style>
@@ -177,8 +217,38 @@
   .foot a{font-weight:600}
   .foot a:hover{color:var(--accent)}
   .legal{margin-top:18px;font-size:12.5px;opacity:.8;max-width:760px}
+  /* hero pricing line */
+  .hero .priceline{margin-top:14px;color:var(--muted);font-size:14.5px;font-weight:600}
+  .hero .priceline b{color:var(--ink)}
+  .hero .priceline .free{color:var(--accent)}
+  .hero .alt{margin-top:10px;font-size:13px;color:var(--muted);font-weight:600}
+  .hero .alt a{color:var(--accent);font-weight:700}
+  /* pricing */
+  .pricing-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:38px;align-items:stretch}
+  .plan{background:#fff;border:1px solid var(--line);border-radius:22px;padding:30px 24px 26px;position:relative;
+    display:flex;flex-direction:column;box-shadow:0 8px 26px rgba(11,8,32,.05)}
+  .plan.featured{border:2px solid var(--accent);box-shadow:0 18px 46px rgba(124,58,237,.20)}
+  .plan .badge{position:absolute;top:-13px;left:50%;transform:translateX(-50%);background:var(--accent);color:#fff;
+    font-size:11px;font-weight:800;letter-spacing:.5px;padding:5px 13px;border-radius:999px;white-space:nowrap;
+    box-shadow:0 6px 16px rgba(124,58,237,.35)}
+  .plan .pname{font-size:14px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.5px}
+  .plan .pprice{font-size:40px;font-weight:800;letter-spacing:-1.5px;margin:8px 0 0}
+  .plan .pper{font-size:13.5px;color:var(--muted);font-weight:600;margin-top:2px}
+  .plan ul{list-style:none;padding:0;margin:18px 0 0;display:flex;flex-direction:column;gap:10px;flex:1}
+  .plan li{display:flex;gap:9px;font-size:14.5px;font-weight:500;align-items:flex-start;line-height:1.35}
+  .plan li svg{flex:0 0 auto;margin-top:2px;color:#34C759}
+  .plan.featured li svg{color:var(--accent)}
+  .pricing-note{text-align:center;color:var(--muted);font-size:14px;margin:26px auto 0;font-weight:500;max-width:620px;line-height:1.5}
+  .pricing-note a{color:var(--accent);font-weight:700}
+  .pricing-note .solid{display:block;margin-top:10px}
+  /* a11y */
+  :focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:8px}
+  @media(prefers-reduced-motion:reduce){
+    *{animation-duration:.001ms!important;animation-iteration-count:1!important;transition:none!important}
+    html{scroll-behavior:auto}
+  }
   @media(max-width:760px){
-    .grid,.steps{grid-template-columns:1fr}
+    .grid,.steps,.pricing-grid{grid-template-columns:1fr}
     .hero{padding-top:44px}
   }
 </style>


### PR DESCRIPTION
## Vitrine : pricing + v1.4 + SEO

Met le site vitrine (rclone.rougetet.com) en cohérence avec l'app : il annonçait encore la v1.3 et seulement l'essai gratuit, sans le nouveau pricing.

### Pricing
- Nouvelle section **« Payez comme vous voulez »** : 3 cartes — **À vie 29,99 €** (Meilleure offre), **Annuel 11,99 €**, **Mensuel 2,99 €**
- Note **tarif solidaire** : « Étudiant·e, emploi précaire, chômage ou budget serré ? Demandez une réduction selon vos moyens » → ouvre un mail vers le développeur
- Cartes blanches qui respirent (équilibre la dominante violette)

### Hero
- Pastille **v1.4 · Essai gratuit**
- CTA **« Essayer gratuitement »** (au lieu de « mois gratuit » qui masquait le passage payant)
- Ligne prix sous le CTA + lien **« compilez-la gratuitement — open source »**

### SEO / structured data (index.html)
- `softwareVersion` → **1.4**, `Offer` → **AggregateOffer** (3 prix)
- Meta description mise à jour
- Nouveau schéma **FAQPage** (5 Q/R : prix, réduction, services, open source, crypt)
- Styles pricing + **focus-visible** + **prefers-reduced-motion**

### Build
- `app.js` recompilé depuis `app.src.jsx` (Babel, runtime classic — `React` global)

### Vérification
- Rendu OK (Pricing + hero), **0 erreur console**, layout vérifié au pixel
- Différé (hors scope) : conversion des maquettes en images statiques (perf), témoignages (pas de faux avis)

> ℹ️ Merger ce PR **déploie en live** (GitHub Pages sert `main/docs`).
