### PR TITLE
fix(site): collision CSS .free (blob violet dans le hero)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2539,7 +2539,7 @@ const Hero = () => {
   }), t('Essayer gratuitement', 'Try it free')), /*#__PURE__*/React.createElement(AppStoreBadge, null)), /*#__PURE__*/React.createElement("p", {
     className: "priceline"
   }, /*#__PURE__*/React.createElement("span", {
-    className: "free"
+    className: "freetag"
   }, t('Essai gratuit', 'Free trial')), t(', puis ', ' · then '), /*#__PURE__*/React.createElement("b", null, t('29,99 € à vie', '€29.99 lifetime')), t(' ou dès ', ' or from '), /*#__PURE__*/React.createElement("b", null, t('2,99 €/mois', '€2.99/mo'))), /*#__PURE__*/React.createElement("p", {
     className: "alt"
   }, t('Ou ', 'Or '), /*#__PURE__*/React.createElement("a", {

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -610,7 +610,7 @@ const Hero = () => {
           <a className="btn btn-violet" href="#free"><Icon name="bolt.fill" size={18}/>{t('Essayer gratuitement','Try it free')}</a>
           <AppStoreBadge/>
         </div>
-        <p className="priceline"><span className="free">{t('Essai gratuit','Free trial')}</span>{t(', puis ',' · then ')}<b>{t('29,99 € à vie','€29.99 lifetime')}</b>{t(' ou dès ',' or from ')}<b>{t('2,99 €/mois','€2.99/mo')}</b></p>
+        <p className="priceline"><span className="freetag">{t('Essai gratuit','Free trial')}</span>{t(', puis ',' · then ')}<b>{t('29,99 € à vie','€29.99 lifetime')}</b>{t(' ou dès ',' or from ')}<b>{t('2,99 €/mois','€2.99/mo')}</b></p>
         <p className="alt">{t('Ou ','Or ')}<a href={GITHUB_URL} target="_blank" rel="noopener">{t('compilez-la gratuitement','build it for free')}</a>{t(' — c\'est open source',' — it\'s open source')}</p>
         <div className="trust">
           <span><Icon name="lock.fill" size={15} style={{ color:ACCENT }}/>{t('Chiffrement de bout en bout','End-to-end crypt')}</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -218,9 +218,9 @@
   .foot a:hover{color:var(--accent)}
   .legal{margin-top:18px;font-size:12.5px;opacity:.8;max-width:760px}
   /* hero pricing line */
-  .hero .priceline{margin-top:14px;color:var(--muted);font-size:14.5px;font-weight:600}
+  .hero .priceline{margin-top:16px;color:var(--muted);font-size:14.5px;font-weight:600}
   .hero .priceline b{color:var(--ink)}
-  .hero .priceline .free{color:var(--accent)}
+  .hero .priceline .freetag{color:var(--accent);font-weight:700}
   .hero .alt{margin-top:10px;font-size:13px;color:var(--muted);font-weight:600}
   .hero .alt a{color:var(--accent);font-weight:700}
   /* pricing */


### PR DESCRIPTION
Le span « Free trial » de la ligne de prix avait class="free", qui héritait de l'encart promo `.free` (dégradé + padding 48px + box-shadow) → rendu en blob violet sur le texte. Renommé en `.freetag`. app.js recompilé. Vérifié au navigateur : hero propre.