### PR TITLE
feat(player): lecteur vidéo embarqué multi-format (VLCKit)

### DIFF
--- a/Rclone GUI.xcodeproj/project.pbxproj
+++ b/Rclone GUI.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		27C31F802FBDA917005F4083 /* RclonePhotoSyncActivityExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 27C31F6A2FBDA916005F4083 /* RclonePhotoSyncActivityExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		27DAEDA1000000000000A001 /* RcloneKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27DAEDA0000000000000A001 /* RcloneKit.xcframework */; };
 		27DAEDA2000000000000A001 /* RcloneKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 27DAEDA0000000000000A001 /* RcloneKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		27FFEE0100000000000F0003 /* VLCKitSPM in Frameworks */ = {isa = PBXBuildFile; platformFilters = (ios, macos, ); productRef = 27FFEE0100000000000F0002 /* VLCKitSPM */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -189,6 +190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				27DAEDA1000000000000A001 /* RcloneKit.xcframework in Frameworks */,
+				27FFEE0100000000000F0003 /* VLCKitSPM in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -331,6 +333,9 @@
 				2796AC742FAE017400640D86 /* Rclone GUI */,
 			);
 			name = "Rclone GUI";
+			packageProductDependencies = (
+				27FFEE0100000000000F0002 /* VLCKitSPM */,
+			);
 			productName = "Rclone GUI";
 			productReference = 2796AC722FAE017400640D86 /* RcloneGUI.app */;
 			productType = "com.apple.product-type.application";
@@ -452,6 +457,9 @@
 			);
 			mainGroup = 2796AC692FAE017400640D86;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				27FFEE0100000000000F0001 /* XCRemoteSwiftPackageReference "vlckit-spm" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2796AC732FAE017400640D86 /* Products */;
 			projectDirPath = "";
@@ -1256,6 +1264,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		27FFEE0100000000000F0001 /* XCRemoteSwiftPackageReference "vlckit-spm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tylerjonesio/vlckit-spm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.6.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		27FFEE0100000000000F0002 /* VLCKitSPM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 27FFEE0100000000000F0001 /* XCRemoteSwiftPackageReference "vlckit-spm" */;
+			productName = VLCKitSPM;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 2796AC6A2FAE017400640D86 /* Project object */;
 }

--- a/Rclone GUI/Core/MediaFormat.swift
+++ b/Rclone GUI/Core/MediaFormat.swift
@@ -1,0 +1,110 @@
+//
+//  MediaFormat.swift
+//  Rclone GUI — Core
+//
+//  Source unique de vérité pour : « est-ce un média ? », « vidéo vs audio ? »
+//  et surtout « quel moteur de lecture ? ».
+//
+//  Le lecteur in-app est *hybride* :
+//    - AVFoundation (AVPlayer) pour ce qu'Apple décode nativement
+//      (MP4/MOV/M4V + audio courant) → PiP, décodage matériel, batterie,
+//      AirPlay, sélecteur de sous-titres natif.
+//    - libVLC (VLCKit) pour tout le reste (MKV/AVI/WebM/TS…) qu'AVPlayer
+//      ne sait pas ouvrir — sinon l'utilisateur n'a qu'un écran noir.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+/// Moteur de lecture in-app retenu pour un fichier donné.
+public enum PlaybackEngine: Sendable, Equatable {
+    /// AVPlayer / AVKit — conteneurs et codecs supportés nativement par Apple.
+    case avFoundation
+    /// libVLC — décodage logiciel pour les formats qu'AVPlayer refuse.
+    case vlc
+}
+
+public enum MediaFormat {
+
+    // Extensions qu'AVFoundation lit nativement (décodage matériel possible).
+    static let avFoundationVideoExtensions: Set<String> = [
+        "mp4", "mov", "m4v"
+    ]
+    static let avFoundationAudioExtensions: Set<String> = [
+        "mp3", "m4a", "aac", "wav", "aif", "aiff", "caf", "flac", "alac"
+    ]
+
+    // Formats vidéo qui nécessitent libVLC (AVPlayer échoue dessus).
+    static let vlcVideoExtensions: Set<String> = [
+        "mkv", "avi", "webm", "ts", "m2ts", "mts", "mpg", "mpeg", "flv",
+        "wmv", "ogv", "3gp", "3g2", "divx", "vob", "asf", "rm", "rmvb",
+        "f4v", "mxf", "m2v", "dav"
+    ]
+    // Formats audio qui nécessitent libVLC.
+    static let vlcAudioExtensions: Set<String> = [
+        "ogg", "oga", "opus", "wma", "ape", "dsf", "dff", "mka", "ac3",
+        "dts", "amr", "tta", "wv"
+    ]
+
+    static func ext(_ name: String) -> String {
+        (name as NSString).pathExtension.lowercased()
+    }
+
+    public static func isVideo(_ name: String) -> Bool {
+        let e = ext(name)
+        if avFoundationVideoExtensions.contains(e) || vlcVideoExtensions.contains(e) {
+            return true
+        }
+        if let type = UTType(filenameExtension: e), type.conforms(to: .movie) {
+            return true
+        }
+        return false
+    }
+
+    public static func isAudio(_ name: String) -> Bool {
+        let e = ext(name)
+        if avFoundationAudioExtensions.contains(e) || vlcAudioExtensions.contains(e) {
+            return true
+        }
+        // Évite de classer une vidéo connue comme audio.
+        if isVideo(name) { return false }
+        if let type = UTType(filenameExtension: e), type.conforms(to: .audio) {
+            return true
+        }
+        return false
+    }
+
+    public static func isMedia(_ name: String) -> Bool {
+        isVideo(name) || isAudio(name)
+    }
+
+    /// Extensions de sous-titres « sidecar » qu'on cherche à côté du média.
+    static let subtitleExtensions: Set<String> = [
+        "srt", "ass", "ssa", "vtt", "sub", "idx"
+    ]
+
+    public static func isSubtitle(_ name: String) -> Bool {
+        subtitleExtensions.contains(ext(name))
+    }
+
+    /// Moteur recommandé pour ce nom de fichier. Par défaut on penche vers
+    /// VLC (le plus tolérant) pour les extensions inconnues afin d'éviter
+    /// l'écran noir d'AVPlayer.
+    public static func engine(for name: String) -> PlaybackEngine {
+        let e = ext(name)
+        if avFoundationVideoExtensions.contains(e) || avFoundationAudioExtensions.contains(e) {
+            return .avFoundation
+        }
+        if vlcVideoExtensions.contains(e) || vlcAudioExtensions.contains(e) {
+            return .vlc
+        }
+        // Extension inconnue : si le système la reconnaît comme un format
+        // typiquement compatible AVFoundation, on tente AVPlayer ; sinon VLC.
+        if let type = UTType(filenameExtension: e) {
+            for compatible: UTType in [.mpeg4Movie, .quickTimeMovie, .mpeg4Audio, .mp3, .wav, .aiff] {
+                if type.conforms(to: compatible) { return .avFoundation }
+            }
+        }
+        return .vlc
+    }
+}

--- a/Rclone GUI/Info.plist
+++ b/Rclone GUI/Info.plist
@@ -4,6 +4,7 @@
 <dict>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>remote-notification</string>
 		<string>fetch</string>
 		<string>processing</string>

--- a/Rclone GUI/Services/NowPlayingService.swift
+++ b/Rclone GUI/Services/NowPlayingService.swift
@@ -1,0 +1,154 @@
+//
+//  NowPlayingService.swift
+//  Rclone GUI — Services
+//
+//  Audio en arrière-plan + contrôles sur l'écran verrouillé / centre de
+//  contrôle. Configure l'AVAudioSession en `.playback` (continue à jouer
+//  quand l'app passe en arrière-plan, requiert UIBackgroundModes=audio) et
+//  publie les métadonnées + commandes distantes via MediaPlayer.
+//
+//  iOS uniquement : sur macOS la lecture en arrière-plan est implicite et
+//  l'API AVAudioSession n'existe pas. Les appels deviennent des no-op.
+//
+
+import Foundation
+
+#if os(iOS)
+import MediaPlayer
+import AVFoundation
+
+@MainActor
+final class NowPlayingService {
+    static let shared = NowPlayingService()
+    private init() {}
+
+    private var commandsConfigured = false
+
+    // Callbacks fournis par le lecteur actif.
+    private var onPlay: (() -> Void)?
+    private var onPause: (() -> Void)?
+    private var onNext: (() -> Void)?
+    private var onPrevious: (() -> Void)?
+    private var onSeek: ((Double) -> Void)?
+
+    /// Active la session audio en lecture (autorise l'arrière-plan + ignore
+    /// le switch silencieux pour la vidéo).
+    func beginPlaybackSession() {
+        let session = AVAudioSession.sharedInstance()
+        try? session.setCategory(.playback, mode: .moviePlayback, options: [])
+        try? session.setActive(true, options: [])
+    }
+
+    func endPlaybackSession() {
+        removeRemoteCommands()
+        clearNowPlaying()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    /// Retire nos cibles de commandes distantes. Indispensable entre deux
+    /// lecteurs : sinon un handler VLC périmé resterait branché et entrerait
+    /// en conflit avec le lecteur système (AVPlayerViewController) qui gère
+    /// lui-même l'écran verrouillé.
+    private func removeRemoteCommands() {
+        let center = MPRemoteCommandCenter.shared()
+        center.playCommand.removeTarget(nil)
+        center.pauseCommand.removeTarget(nil)
+        center.togglePlayPauseCommand.removeTarget(nil)
+        center.nextTrackCommand.removeTarget(nil)
+        center.previousTrackCommand.removeTarget(nil)
+        center.changePlaybackPositionCommand.removeTarget(nil)
+        commandsConfigured = false
+        onPlay = nil
+        onPause = nil
+        onNext = nil
+        onPrevious = nil
+        onSeek = nil
+    }
+
+    /// Branche les commandes distantes (play/pause/skip/scrub) sur le lecteur.
+    func configureRemoteCommands(
+        onPlay: @escaping () -> Void,
+        onPause: @escaping () -> Void,
+        onNext: (() -> Void)?,
+        onPrevious: (() -> Void)?,
+        onSeek: @escaping (Double) -> Void
+    ) {
+        self.onPlay = onPlay
+        self.onPause = onPause
+        self.onNext = onNext
+        self.onPrevious = onPrevious
+        self.onSeek = onSeek
+
+        let center = MPRemoteCommandCenter.shared()
+
+        if !commandsConfigured {
+            center.playCommand.addTarget { [weak self] _ in
+                self?.onPlay?(); return .success
+            }
+            center.pauseCommand.addTarget { [weak self] _ in
+                self?.onPause?(); return .success
+            }
+            center.togglePlayPauseCommand.addTarget { [weak self] _ in
+                self?.onPlay?(); return .success
+            }
+            center.nextTrackCommand.addTarget { [weak self] _ in
+                guard let next = self?.onNext else { return .commandFailed }
+                next(); return .success
+            }
+            center.previousTrackCommand.addTarget { [weak self] _ in
+                guard let prev = self?.onPrevious else { return .commandFailed }
+                prev(); return .success
+            }
+            center.changePlaybackPositionCommand.addTarget { [weak self] event in
+                guard let e = event as? MPChangePlaybackPositionCommandEvent else { return .commandFailed }
+                self?.onSeek?(e.positionTime); return .success
+            }
+            commandsConfigured = true
+        }
+
+        center.nextTrackCommand.isEnabled = (onNext != nil)
+        center.previousTrackCommand.isEnabled = (onPrevious != nil)
+        center.changePlaybackPositionCommand.isEnabled = true
+    }
+
+    /// Met à jour la fiche Now Playing (titre, durée, position, état).
+    func updateNowPlaying(title: String, durationSeconds: Double, elapsedSeconds: Double, rate: Float) {
+        var info: [String: Any] = [:]
+        info[MPMediaItemPropertyTitle] = title
+        if durationSeconds > 0, durationSeconds.isFinite {
+            info[MPMediaItemPropertyPlaybackDuration] = durationSeconds
+        }
+        if elapsedSeconds.isFinite {
+            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = max(0, elapsedSeconds)
+        }
+        info[MPNowPlayingInfoPropertyPlaybackRate] = rate
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+    }
+
+    func clearNowPlaying() {
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+    }
+}
+
+#else
+
+/// Stub no-op (macOS / autres) : la lecture en arrière-plan y est implicite.
+@MainActor
+final class NowPlayingService {
+    static let shared = NowPlayingService()
+    private init() {}
+
+    func beginPlaybackSession() {}
+    func endPlaybackSession() {}
+    func configureRemoteCommands(
+        onPlay: @escaping () -> Void,
+        onPause: @escaping () -> Void,
+        onNext: (() -> Void)?,
+        onPrevious: (() -> Void)?,
+        onSeek: @escaping (Double) -> Void
+    ) {}
+    func updateNowPlaying(title: String, durationSeconds: Double, elapsedSeconds: Double, rate: Float) {}
+    func clearNowPlaying() {}
+}
+
+#endif

--- a/Rclone GUI/Services/PlaybackProgressStore.swift
+++ b/Rclone GUI/Services/PlaybackProgressStore.swift
@@ -1,0 +1,61 @@
+//
+//  PlaybackProgressStore.swift
+//  Rclone GUI — Services
+//
+//  Mémorise la position de lecture par (remote, chemin) pour reprendre une
+//  vidéo là où on l'a laissée. Persisté dans UserDefaults (léger, survit aux
+//  relaunchs). Partagé par les deux moteurs (AVPlayer et VLC).
+//
+
+import Foundation
+
+struct PlaybackProgress: Codable, Sendable {
+    let positionSeconds: Double
+    let durationSeconds: Double
+    let updatedAt: Date
+}
+
+public enum PlaybackProgressStore {
+    private static let prefix = "playback.progress."
+
+    // En-deçà : pas la peine de mémoriser (on était au tout début).
+    private static let minResumeSeconds: Double = 8
+    // Marge de fin : si on est à moins de ça de la fin, on considère « vu »
+    // et on efface la reprise (relancer repart du début).
+    private static let endMarginSeconds: Double = 15
+
+    private static func key(remote: String, path: String) -> String {
+        prefix + remote + ":" + path
+    }
+
+    /// Enregistre la position courante. Efface l'entrée si on est trop tôt
+    /// ou quasiment à la fin.
+    public static func save(remote: String, path: String, position: Double, duration: Double) {
+        guard duration > 0, position.isFinite, duration.isFinite else { return }
+        if position < minResumeSeconds || position > duration - endMarginSeconds {
+            clear(remote: remote, path: path)
+            return
+        }
+        let progress = PlaybackProgress(
+            positionSeconds: position,
+            durationSeconds: duration,
+            updatedAt: Date()
+        )
+        if let data = try? JSONEncoder().encode(progress) {
+            UserDefaults.standard.set(data, forKey: key(remote: remote, path: path))
+        }
+    }
+
+    /// Position de reprise en secondes, ou nil si rien à reprendre.
+    public static func resumePosition(remote: String, path: String) -> Double? {
+        guard let data = UserDefaults.standard.data(forKey: key(remote: remote, path: path)),
+              let progress = try? JSONDecoder().decode(PlaybackProgress.self, from: data) else {
+            return nil
+        }
+        return progress.positionSeconds
+    }
+
+    public static func clear(remote: String, path: String) {
+        UserDefaults.standard.removeObject(forKey: key(remote: remote, path: path))
+    }
+}

--- a/Rclone GUI/Services/SubtitleService.swift
+++ b/Rclone GUI/Services/SubtitleService.swift
@@ -1,0 +1,62 @@
+//
+//  SubtitleService.swift
+//  Rclone GUI — Services
+//
+//  Découverte des sous-titres « sidecar » (fichiers .srt/.ass/… portant le
+//  même nom de base que la vidéo, dans le même dossier du remote) et
+//  préparation d'une URL locale à passer à `addPlaybackSlave` de VLCKit.
+//
+
+import Foundation
+
+public struct SidecarSubtitle: Identifiable, Sendable, Hashable {
+    public var id: String { pathInRemote }
+    public let pathInRemote: String
+    public let name: String
+    /// Langue devinée depuis le nom (« film.en.srt » → "en"), best-effort.
+    public let language: String?
+}
+
+public actor SubtitleService {
+    public static let shared = SubtitleService()
+    private init() {}
+
+    /// Liste les sous-titres portant le même nom de base que `videoPath`,
+    /// dans le dossier qui le contient.
+    public func discover(remote: String, videoPath: String) async -> [SidecarSubtitle] {
+        let dir = (videoPath as NSString).deletingLastPathComponent
+        let videoBase = ((videoPath as NSString).lastPathComponent as NSString)
+            .deletingPathExtension
+            .lowercased()
+        guard !videoBase.isEmpty,
+              let entries = try? await RemoteService.shared.list(remote: remote, path: dir) else {
+            return []
+        }
+        return entries.compactMap { entry -> SidecarSubtitle? in
+            guard !entry.isDirectory, MediaFormat.isSubtitle(entry.name) else { return nil }
+            let subBase = (entry.name as NSString).deletingPathExtension.lowercased()
+            // Accepte « film.srt » et « film.en.srt » / « film.eng.forced.srt ».
+            guard subBase == videoBase || subBase.hasPrefix(videoBase + ".") else { return nil }
+            var lang: String?
+            if subBase.hasPrefix(videoBase + ".") {
+                lang = subBase
+                    .dropFirst(videoBase.count + 1)
+                    .split(separator: ".")
+                    .first
+                    .map(String.init)
+            }
+            return SidecarSubtitle(pathInRemote: entry.pathInRemote, name: entry.name, language: lang)
+        }
+    }
+
+    /// Télécharge le sous-titre (petit fichier) et renvoie l'URL locale prête
+    /// pour `addPlaybackSlave`.
+    public func localURL(remote: String, subtitle: SidecarSubtitle) async throws -> URL {
+        try await MediaCacheService.shared.localPlayableURL(
+            remote: remote,
+            path: subtitle.pathInRemote,
+            sizeHint: nil,
+            policy: .reuseIfCached
+        )
+    }
+}

--- a/Rclone GUI/Views/Folders/EntryActionsMenu.swift
+++ b/Rclone GUI/Views/Folders/EntryActionsMenu.swift
@@ -43,7 +43,8 @@ struct EntryActionsMenu: View {
                         previewTarget = entry
                     }
                 } label: {
-                    Label("Ouvrir dans l'app", systemImage: Self.isMediaFile(entry.name) ? "play.circle" : "doc.viewfinder")
+                    Label(Self.isMediaFile(entry.name) ? "Lire dans l'app" : "Ouvrir dans l'app",
+                          systemImage: Self.isMediaFile(entry.name) ? "play.circle" : "doc.viewfinder")
                 }
 
                 if Self.isVideoFile(entry.name) {
@@ -59,7 +60,7 @@ struct EntryActionsMenu: View {
                             Label("VLC", systemImage: "play.tv.fill")
                         }
                     } label: {
-                        Label("Streamer dans…", systemImage: "play.rectangle.on.rectangle")
+                        Label("Lire dans une app externe", systemImage: "play.rectangle.on.rectangle")
                     }
                 }
 
@@ -198,27 +199,10 @@ struct EntryActionsMenu: View {
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
     }
 
-    static func isMediaFile(_ name: String) -> Bool {
-        let ext = (name as NSString).pathExtension.lowercased()
-        if let type = UTType(filenameExtension: ext),
-           type.conforms(to: .movie) || type.conforms(to: .audio) {
-            return true
-        }
-        return [
-            // Video
-            "mp4", "mkv", "mov", "avi", "webm", "m4v", "ts", "mpg", "mpeg",
-            // Audio
-            "mp3", "m4a", "wav", "flac", "ogg", "aac", "alac", "opus"
-        ].contains(ext)
-    }
-
-    static func isVideoFile(_ name: String) -> Bool {
-        let ext = (name as NSString).pathExtension.lowercased()
-        if let type = UTType(filenameExtension: ext), type.conforms(to: .movie) {
-            return true
-        }
-        return ["mp4", "mkv", "mov", "avi", "webm", "m4v", "ts", "mpg", "mpeg"].contains(ext)
-    }
+    // Détection centralisée dans MediaFormat (source unique de vérité, voir
+    // aussi le routage AVPlayer ↔ VLC du lecteur embarqué).
+    static func isMediaFile(_ name: String) -> Bool { MediaFormat.isMedia(name) }
+    static func isVideoFile(_ name: String) -> Bool { MediaFormat.isVideo(name) }
 
     enum ExternalPlayerScheme {
         case infuse

--- a/Rclone GUI/Views/Folders/FolderView.swift
+++ b/Rclone GUI/Views/Folders/FolderView.swift
@@ -236,7 +236,11 @@ struct FolderView: View {
             .rgFullScreenCover(item: $playTarget, onDismiss: {
                 openingEntryID = nil
             }) { entry in
-                MediaPlayerHost(remote: remote, entry: entry)
+                MediaPlayerHost(
+                    remote: remote,
+                    entry: entry,
+                    playlist: displayedEntries.filter { !$0.isDirectory && MediaFormat.isMedia($0.name) }
+                )
             }
             .sheet(item: $previewTarget, onDismiss: {
                 openingEntryID = nil

--- a/Rclone GUI/Views/Player/MediaPlayerView.swift
+++ b/Rclone GUI/Views/Player/MediaPlayerView.swift
@@ -2,17 +2,22 @@
 //  MediaPlayerView.swift
 //  Rclone GUI — Views/Player
 //
-//  AVPlayerViewController wrapper for SwiftUI. Hands a local URL —
-//  obtained via MediaCacheService — to AVPlayer.
-//
-//  Phase D v1: download-then-play. Phase D2 will swap the source for a
-//  custom AVAssetResourceLoaderDelegate that streams via librclone
-//  range reads (loopback fallback per FR-030b).
+//  Routeur de lecture in-app. `MediaPlayerHost` :
+//    1. prépare une session de streaming (RcloneStreamingService — bridge
+//       loopback HTTP seekable, fallback download).
+//    2. choisit le moteur via MediaFormat.engine(for:) :
+//         - .avFoundation → AVPlayerViewController (PiP, déco HW, AirPlay,
+//           sélecteur de sous-titres natif) pour MP4/MOV/M4V + audio.
+//         - .vlc → EmbeddedVLCPlayerView (libVLC) pour MKV/AVI/WebM/TS…
+//    3. gère la playlist du dossier (suivant/précédent + auto-enchaînement),
+//       la reprise de position, et propose l'ouverture dans une app externe.
 //
 
 import SwiftUI
 import AVKit
 import AVFoundation
+
+// MARK: - AVPlayer surface (formats nativement compatibles)
 
 #if canImport(UIKit)
 import UIKit
@@ -20,19 +25,22 @@ import UIKit
 struct MediaPlayerView: UIViewControllerRepresentable {
     let url: URL
     let title: String?
-    /// Taille du média en octets — sert à décider si PiP/full-screen valent
-    /// le coût d'init (skip pour les très petits clips).
+    let remote: String
+    let path: String
     var sizeHint: Int64 = 0
+    /// Appelé en fin de lecture (enchaînement playlist).
+    var onEnded: (() -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(remote: remote, path: path, title: title, onEnded: onEnded)
+    }
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
         let player = AVPlayer(url: url)
-        // Preroll buffer 2s : limite le stalling initial sans dégrader le TTFP.
         player.automaticallyWaitsToMinimizeStalling = true
         let controller = AVPlayerViewController()
         controller.player = player
 
-        // Feature-gate PiP : init est coûteuse (~50-100ms) et inutile pour
-        // les petits clips audio/vidéo. Activé pour ≥ ~5MB ou taille inconnue.
         let isPiPEligible = sizeHint == 0 || sizeHint >= 5_000_000
         controller.allowsPictureInPicturePlayback = isPiPEligible
         controller.canStartPictureInPictureAutomaticallyFromInline = isPiPEligible
@@ -40,56 +48,173 @@ struct MediaPlayerView: UIViewControllerRepresentable {
         controller.exitsFullScreenWhenPlaybackEnds = false
         controller.modalPresentationStyle = .fullScreen
         if let title {
-            // iOS 16+ : show title via Now Playing metadata
             let item = AVMutableMetadataItem()
             item.identifier = .commonIdentifierTitle
             item.value = title as NSString
             item.extendedLanguageTag = "und"
             player.currentItem?.externalMetadata = [item]
         }
-
-        // Preroll 2s pour limiter les stalls initiaux.
         player.currentItem?.preferredForwardBufferDuration = 2.0
-        // Auto-play
+
+        context.coordinator.attach(to: player)
         player.play()
         return controller
     }
 
     func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {}
 
-    static func dismantleUIViewController(_ uiViewController: AVPlayerViewController, coordinator: ()) {
-        // Cleanup explicite : libère decodage HW, buffers HTTP, et casse les
-        // observers KVO internes avant que le controller ne soit dealloc.
+    static func dismantleUIViewController(_ uiViewController: AVPlayerViewController, coordinator: Coordinator) {
+        coordinator.teardown()
         if let player = uiViewController.player {
             player.pause()
             player.replaceCurrentItem(with: nil)
         }
         uiViewController.player = nil
     }
+
+    /// Gère reprise, sauvegarde de position, Now Playing et fin de lecture
+    /// pour le chemin AVPlayer.
+    final class Coordinator {
+        private let remote: String
+        private let path: String
+        private let title: String?
+        private let onEnded: (() -> Void)?
+
+        private weak var player: AVPlayer?
+        private var timeObserver: Any?
+        private var endObserver: NSObjectProtocol?
+        private var didResume = false
+        private var lastSavedSecond = -1
+
+        init(remote: String, path: String, title: String?, onEnded: (() -> Void)?) {
+            self.remote = remote
+            self.path = path
+            self.title = title
+            self.onEnded = onEnded
+        }
+
+        func attach(to player: AVPlayer) {
+            self.player = player
+
+            let interval = CMTime(seconds: 1, preferredTimescale: 1)
+            timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+                self?.tick(time)
+            }
+
+            endObserver = NotificationCenter.default.addObserver(
+                forName: .AVPlayerItemDidPlayToEndTime,
+                object: player.currentItem,
+                queue: .main
+            ) { [weak self] _ in
+                guard let self else { return }
+                PlaybackProgressStore.clear(remote: self.remote, path: self.path)
+                self.onEnded?()
+            }
+        }
+
+        private func tick(_ time: CMTime) {
+            guard let player, let item = player.currentItem else { return }
+            let elapsed = time.seconds
+            let duration = item.duration.seconds
+            guard elapsed.isFinite else { return }
+
+            // Reprise : une seule fois, quand la durée est connue.
+            if !didResume, duration.isFinite, duration > 0 {
+                didResume = true
+                if let resume = PlaybackProgressStore.resumePosition(remote: remote, path: path),
+                   resume > 1, resume < duration - 15 {
+                    player.seek(to: CMTime(seconds: resume, preferredTimescale: 600))
+                }
+            }
+
+            let second = Int(elapsed)
+            if second != lastSavedSecond {
+                lastSavedSecond = second
+                if duration.isFinite, duration > 0 {
+                    PlaybackProgressStore.save(remote: remote, path: path, position: elapsed, duration: duration)
+                }
+                NowPlayingService.shared.updateNowPlaying(
+                    title: title ?? path,
+                    durationSeconds: duration.isFinite ? duration : 0,
+                    elapsedSeconds: elapsed,
+                    rate: player.rate
+                )
+            }
+        }
+
+        func teardown() {
+            if let player, let timeObserver {
+                player.removeTimeObserver(timeObserver)
+            }
+            timeObserver = nil
+            if let endObserver {
+                NotificationCenter.default.removeObserver(endObserver)
+            }
+            endObserver = nil
+            // Sauvegarde finale.
+            if let player, let item = player.currentItem {
+                let elapsed = player.currentTime().seconds
+                let duration = item.duration.seconds
+                if elapsed.isFinite, duration.isFinite {
+                    PlaybackProgressStore.save(remote: remote, path: path, position: elapsed, duration: duration)
+                }
+            }
+        }
+    }
 }
 #else
-// macOS : lecteur natif via le VideoPlayer SwiftUI (AVKit), avec contrôles de
-// transport macOS. Même signature que la version iOS pour ne pas toucher
-// MediaPlayerHost.
+// macOS : VideoPlayer SwiftUI (AVKit) avec reprise + fin de lecture.
 struct MediaPlayerView: View {
     let url: URL
     let title: String?
+    let remote: String
+    let path: String
     var sizeHint: Int64 = 0
+    var onEnded: (() -> Void)?
 
     @State private var player: AVPlayer?
+    @State private var endObserver: NSObjectProtocol?
 
     var body: some View {
         VideoPlayer(player: player)
             .onAppear {
-                // Note : AVPlayerItem.externalMetadata (titre Now Playing) est
-                // indisponible sur macOS — on s'en passe ici.
                 let p = AVPlayer(url: url)
                 p.automaticallyWaitsToMinimizeStalling = true
                 p.currentItem?.preferredForwardBufferDuration = 2.0
                 player = p
+                if let resume = PlaybackProgressStore.resumePosition(remote: remote, path: path), resume > 1 {
+                    // Attendre que l'item soit prêt avant de seek, sinon
+                    // AVFoundation ignore le seek et repart du début.
+                    Task { @MainActor in
+                        for _ in 0..<40 {
+                            if p.currentItem?.status == .readyToPlay { break }
+                            try? await Task.sleep(for: .milliseconds(100))
+                        }
+                        p.seek(to: CMTime(seconds: resume, preferredTimescale: 600))
+                    }
+                }
+                endObserver = NotificationCenter.default.addObserver(
+                    forName: .AVPlayerItemDidPlayToEndTime,
+                    object: p.currentItem,
+                    queue: .main
+                ) { _ in
+                    PlaybackProgressStore.clear(remote: remote, path: path)
+                    onEnded?()
+                }
                 p.play()
             }
             .onDisappear {
+                if let p = player, let item = p.currentItem {
+                    let elapsed = p.currentTime().seconds
+                    let duration = item.duration.seconds
+                    if elapsed.isFinite, duration.isFinite {
+                        PlaybackProgressStore.save(remote: remote, path: path, position: elapsed, duration: duration)
+                    }
+                }
+                if let endObserver {
+                    NotificationCenter.default.removeObserver(endObserver)
+                }
+                endObserver = nil
                 player?.pause()
                 player?.replaceCurrentItem(with: nil)
                 player = nil
@@ -98,38 +223,141 @@ struct MediaPlayerView: View {
 }
 #endif
 
-/// Convenience host that handles the "download then play" lifecycle.
+// MARK: - Host / routeur
+
 struct MediaPlayerHost: View {
     let remote: String
-    let entry: RemoteEntryDTO
+    let playlist: [RemoteEntryDTO]
 
+    @State private var index: Int
     @State private var session: StreamingSession?
+    @State private var subtitles: [SidecarSubtitle] = []
     @State private var preparing = true
     @State private var error: String?
+    @State private var engine: PlaybackEngine = .avFoundation
     @Environment(\.dismiss) private var dismiss
+
+    init(remote: String, entry: RemoteEntryDTO, playlist: [RemoteEntryDTO]? = nil) {
+        self.remote = remote
+        let resolved = (playlist?.isEmpty == false) ? playlist! : [entry]
+        self.playlist = resolved
+        _index = State(initialValue: resolved.firstIndex(of: entry) ?? 0)
+    }
+
+    private var entry: RemoteEntryDTO {
+        playlist[min(max(index, 0), playlist.count - 1)]
+    }
+    private var hasNext: Bool { index < playlist.count - 1 }
+    private var hasPrevious: Bool { index > 0 }
 
     var body: some View {
         Group {
-            if preparing {
+            if let error {
+                errorState(error)
+            } else if preparing {
                 preparingState
             } else if let session {
-                MediaPlayerView(url: session.url, title: entry.name, sizeHint: entry.size)
-                    .ignoresSafeArea()
-            } else if let error {
-                errorState(error)
+                player(for: session)
             }
         }
-        .task { await prepare() }
+        .task(id: index) { await prepare() }
         .onDisappear {
-            if let session {
-                Task { await RcloneStreamingService.shared.stop(session) }
-            }
+            stopCurrentSession()
+            NowPlayingService.shared.endPlaybackSession()
         }
     }
 
-    /// Crypt-forward "préparation de la lecture" surface — mirrors the
-    /// design's player loading idiom (purple seal + STREAM badge while we
-    /// resolve a local URL or set up the streaming session).
+    @ViewBuilder
+    private func player(for session: StreamingSession) -> some View {
+        switch engine {
+        case .vlc:
+            EmbeddedVLCPlayerView(
+                streamURL: session.url,
+                title: entry.name,
+                remote: remote,
+                path: entry.pathInRemote,
+                subtitles: subtitles,
+                hasNext: hasNext,
+                hasPrevious: hasPrevious,
+                onNext: hasNext ? { advance(by: 1) } : nil,
+                onPrevious: hasPrevious ? { advance(by: -1) } : nil,
+                onOpenExternal: { openExternal(session) },
+                onClose: { dismiss() }
+            )
+            .ignoresSafeArea()
+            .id(index)
+        case .avFoundation:
+            MediaPlayerView(
+                url: session.url,
+                title: entry.name,
+                remote: remote,
+                path: entry.pathInRemote,
+                sizeHint: entry.size,
+                onEnded: { advanceOrClose() }
+            )
+            .ignoresSafeArea()
+            .id(index)
+        }
+    }
+
+    // MARK: Playlist
+
+    private func advance(by delta: Int) {
+        let next = index + delta
+        guard next >= 0, next < playlist.count else { return }
+        stopCurrentSession()
+        index = next
+    }
+
+    private func advanceOrClose() {
+        if hasNext { advance(by: 1) } else { dismiss() }
+    }
+
+    // MARK: Préparation
+
+    private func prepare() async {
+        preparing = true
+        error = nil
+        engine = MediaFormat.engine(for: entry.name)
+        NowPlayingService.shared.beginPlaybackSession()
+        do {
+            let s = try await RcloneStreamingService.shared.session(
+                remote: remote,
+                path: entry.pathInRemote,
+                sizeHint: entry.size
+            )
+            self.session = s
+            // Sous-titres sidecar (best-effort, n'échoue pas la lecture).
+            if MediaFormat.isVideo(entry.name) {
+                self.subtitles = await SubtitleService.shared.discover(remote: remote, videoPath: entry.pathInRemote)
+            } else {
+                self.subtitles = []
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+        preparing = false
+    }
+
+    private func stopCurrentSession() {
+        if let session {
+            let s = session
+            Task { await RcloneStreamingService.shared.stop(s) }
+            self.session = nil
+        }
+    }
+
+    private func openExternal(_ session: StreamingSession) {
+        guard let callbackURL = EntryActionsMenu.ExternalPlayerScheme.vlc.callbackURL(for: session.url) else { return }
+        #if canImport(UIKit)
+        UIApplication.shared.open(callbackURL)
+        #elseif canImport(AppKit)
+        NSWorkspace.shared.open(callbackURL)
+        #endif
+    }
+
+    // MARK: États de chargement / erreur
+
     private var preparingState: some View {
         ZStack {
             LinearGradient(
@@ -162,7 +390,7 @@ struct MediaPlayerHost: View {
                     Circle()
                         .fill(Color.red)
                         .frame(width: 6, height: 6)
-                    Text("STREAM")
+                    Text(engine == .vlc ? "VLC · STREAM" : "STREAM")
                         .font(.system(size: 11, weight: .bold))
                         .tracking(0.6)
                         .foregroundStyle(.white.opacity(0.85))
@@ -208,20 +436,5 @@ struct MediaPlayerHost: View {
     private var entrySizeText: String? {
         guard entry.size > 0 else { return nil }
         return ByteCountFormatter.string(fromByteCount: entry.size, countStyle: .file)
-    }
-
-    private func prepare() async {
-        preparing = true
-        do {
-            let session = try await RcloneStreamingService.shared.session(
-                remote: remote,
-                path: entry.pathInRemote,
-                sizeHint: entry.size
-            )
-            self.session = session
-        } catch {
-            self.error = error.localizedDescription
-        }
-        preparing = false
     }
 }

--- a/Rclone GUI/Views/Player/VLCPlayerView.swift
+++ b/Rclone GUI/Views/Player/VLCPlayerView.swift
@@ -1,0 +1,636 @@
+//
+//  VLCPlayerView.swift
+//  Rclone GUI — Views/Player
+//
+//  Lecteur vidéo embarqué basé sur libVLC (VLCKit). Sert les formats
+//  qu'AVPlayer ne sait pas décoder (MKV, AVI, WebM, TS…). Alimenté par
+//  l'URL loopback HTTP seekable de RcloneStreamingService — donc streaming
+//  par plages, crypt transparent, pas de téléchargement complet.
+//
+//  Contrôles maison : lecture/pause, barre de progression scrubbable,
+//  sous-titres (sidecar + intégrés), pistes audio, vitesse, suivant/précédent.
+//  Reprise de position + Now Playing/écran verrouillé gérés ici aussi.
+//
+
+import SwiftUI
+
+#if canImport(VLCKitSPM)
+import VLCKitSPM
+
+// MARK: - Model
+
+/// Encapsule un `VLCMediaPlayer` et publie son état pour SwiftUI.
+/// VLCKit délivre ses callbacks de délégué sur le thread principal, donc les
+/// mutations de `@Published` y sont sûres.
+final class VLCPlayerModel: NSObject, ObservableObject {
+    let player = VLCMediaPlayer()
+
+    @Published var isPlaying = false
+    @Published var isBuffering = true
+    @Published var failed = false
+    @Published var positionSeconds: Double = 0
+    @Published var durationSeconds: Double = 0
+    @Published var rate: Float = 1.0
+
+    struct Track: Identifiable, Hashable {
+        let id: Int32
+        let name: String
+    }
+    @Published var subtitleTracks: [Track] = []
+    @Published var audioTracks: [Track] = []
+    @Published var currentSubtitleID: Int32 = -1
+    @Published var currentAudioID: Int32 = -1
+
+    /// Appelé quand la lecture atteint la fin (pour enchaîner la playlist).
+    var onEnded: (() -> Void)?
+
+    override init() {
+        super.init()
+        player.delegate = self
+    }
+
+    func attach(to drawable: Any) {
+        player.drawable = drawable
+    }
+
+    func load(url: URL, startAtSeconds: Double?) {
+        let media = VLCMedia(url: url)
+        player.media = media
+        player.play()
+        if let start = startAtSeconds, start > 1 {
+            // Le seek doit attendre que le média soit prêt : on le tente après
+            // le passage en lecture (cf. mediaPlayerStateChanged → .playing).
+            pendingSeekSeconds = start
+        }
+    }
+
+    private var pendingSeekSeconds: Double?
+
+    func togglePlayPause() {
+        if player.isPlaying { player.pause() } else { player.play() }
+    }
+    func play() { if !player.isPlaying { player.play() } }
+    func pause() { if player.isPlaying { player.pause() } }
+
+    func seek(toSeconds seconds: Double) {
+        guard seconds.isFinite, seconds >= 0 else { return }
+        player.time = VLCTime(int: Int32(seconds * 1000))
+    }
+
+    func skip(bySeconds delta: Double) {
+        seek(toSeconds: max(0, positionSeconds + delta))
+    }
+
+    func setRate(_ newRate: Float) {
+        player.rate = newRate
+        rate = newRate
+    }
+
+    func selectSubtitle(id: Int32) {
+        player.currentVideoSubTitleIndex = id
+        currentSubtitleID = id
+    }
+
+    func selectAudio(id: Int32) {
+        player.currentAudioTrackIndex = id
+        currentAudioID = id
+    }
+
+    /// Ajoute un sous-titre externe (fichier local) et le sélectionne.
+    func addExternalSubtitle(_ url: URL) {
+        _ = player.addPlaybackSlave(url, type: .subtitle, enforce: true)
+        // Les pistes seront rafraîchies au prochain changement d'état.
+    }
+
+    func stop() {
+        player.delegate = nil
+        player.stop()
+    }
+
+    private func refreshTracks() {
+        let subIDs = (player.videoSubTitlesIndexes as? [NSNumber])?.map { $0.int32Value } ?? []
+        // Noms de pistes : robuste à un éventuel type ObjC non bridgé en String.
+        let subNames = (player.videoSubTitlesNames as? [AnyObject])?.map { String(describing: $0) } ?? []
+        subtitleTracks = zip(subIDs, subNames).map { Track(id: $0.0, name: $0.1) }
+        currentSubtitleID = player.currentVideoSubTitleIndex
+
+        let audIDs = (player.audioTrackIndexes as? [NSNumber])?.map { $0.int32Value } ?? []
+        let audNames = (player.audioTrackNames as? [AnyObject])?.map { String(describing: $0) } ?? []
+        audioTracks = zip(audIDs, audNames).map { Track(id: $0.0, name: $0.1) }
+        currentAudioID = player.currentAudioTrackIndex
+    }
+
+    private func refreshTime() {
+        let ms = player.time?.intValue ?? 0
+        positionSeconds = Double(ms) / 1000.0
+        // `player.media` est optionnel ; `length` peut être importé optionnel
+        // ou IUO → passer par une variable pour rester robuste à la nullabilité.
+        let lengthTime = player.media?.length
+        if let lengthMs = lengthTime?.intValue, lengthMs > 0 {
+            durationSeconds = Double(lengthMs) / 1000.0
+        } else if player.position > 0.0001 {
+            // Estimation si la durée n'est pas encore connue.
+            durationSeconds = positionSeconds / Double(player.position)
+        }
+    }
+}
+
+// MARK: VLCMediaPlayerDelegate
+
+extension VLCPlayerModel: VLCMediaPlayerDelegate {
+    func mediaPlayerStateChanged(_ aNotification: Notification!) {
+        let state = player.state
+        switch state {
+        case .buffering, .opening:
+            isBuffering = true
+        case .playing:
+            isBuffering = false
+            isPlaying = true
+            failed = false
+            refreshTracks()
+            if let pending = pendingSeekSeconds {
+                pendingSeekSeconds = nil
+                seek(toSeconds: pending)
+            }
+        case .paused:
+            isPlaying = false
+        case .stopped:
+            isPlaying = false
+        case .ended:
+            isPlaying = false
+            onEnded?()
+        case .error:
+            failed = true
+            isBuffering = false
+            isPlaying = false
+        default:
+            // .esAdded et autres : mettre à jour les pistes au cas où.
+            refreshTracks()
+        }
+        rate = player.rate
+    }
+
+    func mediaPlayerTimeChanged(_ aNotification: Notification!) {
+        refreshTime()
+    }
+}
+
+// MARK: - Drawable surface
+
+#if canImport(UIKit)
+import UIKit
+
+private struct VLCDrawableRepresentable: UIViewRepresentable {
+    let model: VLCPlayerModel
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .black
+        model.attach(to: view)
+        return view
+    }
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+#elseif canImport(AppKit)
+import AppKit
+
+private struct VLCDrawableRepresentable: NSViewRepresentable {
+    let model: VLCPlayerModel
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.black.cgColor
+        model.attach(to: view)
+        return view
+    }
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+#endif
+
+// MARK: - Embedded player view
+
+struct EmbeddedVLCPlayerView: View {
+    let streamURL: URL
+    let title: String
+    let remote: String
+    let path: String
+    let subtitles: [SidecarSubtitle]
+
+    var hasNext: Bool = false
+    var hasPrevious: Bool = false
+    var onNext: (() -> Void)?
+    var onPrevious: (() -> Void)?
+    var onOpenExternal: (() -> Void)?
+    var onClose: (() -> Void)?
+
+    @StateObject private var model = VLCPlayerModel()
+    @State private var showControls = true
+    @State private var scrubbing = false
+    @State private var scrubValue: Double = 0
+    @State private var lastSavedSecond: Int = -1
+    @State private var loadingSubtitle = false
+
+    private let speeds: [Float] = [0.5, 1.0, 1.25, 1.5, 2.0]
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            VLCDrawableRepresentable(model: model)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.2)) { showControls.toggle() }
+                }
+
+            if model.isBuffering && !model.failed {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .tint(.white)
+                    .scaleEffect(1.4)
+            }
+
+            if model.failed {
+                failureOverlay
+            } else if showControls {
+                controlsOverlay
+                    .transition(.opacity)
+            }
+        }
+        .task {
+            // La session audio est possédée par MediaPlayerHost (évite une
+            // course de désactivation lors des enchaînements de playlist).
+            let resume = PlaybackProgressStore.resumePosition(remote: remote, path: path)
+            model.load(url: streamURL, startAtSeconds: resume)
+            model.onEnded = {
+                PlaybackProgressStore.clear(remote: remote, path: path)
+                if let onNext { onNext() } else { onClose?() }
+            }
+            configureRemoteCommands()
+        }
+        .onChange(of: model.positionSeconds) { _, newValue in
+            if !scrubbing { scrubValue = newValue }
+            persistAndPublish(position: newValue)
+        }
+        .onChange(of: model.isPlaying) { _, _ in
+            updateNowPlaying()
+        }
+        .task(id: autoHideKey) {
+            // Auto-masquage des contrôles après 4 s, dès que la lecture tourne.
+            // Clé sur (showControls, isPlaying) pour se relancer quand l'un
+            // ou l'autre change (sinon le démarrage de lecture ne relancerait
+            // pas la tâche).
+            guard showControls, model.isPlaying else { return }
+            try? await Task.sleep(for: .seconds(4))
+            if !Task.isCancelled, model.isPlaying {
+                withAnimation(.easeInOut(duration: 0.3)) { showControls = false }
+            }
+        }
+        .onDisappear {
+            PlaybackProgressStore.save(
+                remote: remote, path: path,
+                position: model.positionSeconds, duration: model.durationSeconds
+            )
+            model.stop()
+            // La session audio (et les commandes distantes) sont fermées par
+            // MediaPlayerHost à la sortie complète, pas ici.
+        }
+        #if os(iOS)
+        .statusBarHidden(!showControls)
+        #endif
+    }
+
+    // MARK: Controls
+
+    private var controlsOverlay: some View {
+        VStack(spacing: 0) {
+            topBar
+            Spacer()
+            centerTransport
+            Spacer()
+            bottomBar
+        }
+        .background(
+            LinearGradient(
+                colors: [.black.opacity(0.55), .clear, .clear, .black.opacity(0.65)],
+                startPoint: .top, endPoint: .bottom
+            )
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+        )
+    }
+
+    private var topBar: some View {
+        HStack(spacing: 14) {
+            Button {
+                onClose?()
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 38, height: 38)
+                    .background(.black.opacity(0.35), in: .circle)
+            }
+            Text(title)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            trackMenus
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 12)
+    }
+
+    private var centerTransport: some View {
+        HStack(spacing: 46) {
+            Button { model.skip(bySeconds: -10) } label: {
+                Image(systemName: "gobackward.10")
+                    .font(.system(size: 30, weight: .regular))
+                    .foregroundStyle(.white)
+            }
+            Button { model.togglePlayPause() } label: {
+                Image(systemName: model.isPlaying ? "pause.fill" : "play.fill")
+                    .font(.system(size: 46, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 72, height: 72)
+            }
+            Button { model.skip(bySeconds: 10) } label: {
+                Image(systemName: "goforward.10")
+                    .font(.system(size: 30, weight: .regular))
+                    .foregroundStyle(.white)
+            }
+        }
+    }
+
+    private var bottomBar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 10) {
+                Text(timeString(scrubbing ? scrubValue : model.positionSeconds))
+                    .font(.system(size: 12, weight: .medium).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.9))
+
+                Slider(
+                    value: $scrubValue,
+                    in: 0...max(model.durationSeconds, 1),
+                    onEditingChanged: { editing in
+                        scrubbing = editing
+                        if !editing { model.seek(toSeconds: scrubValue) }
+                    }
+                )
+                .tint(.white)
+
+                Text(timeString(model.durationSeconds))
+                    .font(.system(size: 12, weight: .medium).monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+
+            HStack(spacing: 20) {
+                if hasPrevious {
+                    Button { onPrevious?() } label: {
+                        Image(systemName: "backward.end.fill").foregroundStyle(.white)
+                    }
+                }
+                speedMenu
+                Spacer()
+                if let onOpenExternal {
+                    Button { onOpenExternal() } label: {
+                        Label("Externe", systemImage: "play.rectangle.on.rectangle")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.white)
+                    }
+                }
+                if hasNext {
+                    Button { onNext?() } label: {
+                        Image(systemName: "forward.end.fill").foregroundStyle(.white)
+                    }
+                }
+            }
+            .font(.system(size: 16))
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 18)
+    }
+
+    private var trackMenus: some View {
+        HStack(spacing: 8) {
+            // Sous-titres : sidecar + intégrés.
+            Menu {
+                Button {
+                    model.selectSubtitle(id: -1)
+                } label: {
+                    Label("Désactivés", systemImage: model.currentSubtitleID == -1 ? "checkmark" : "")
+                }
+                if !model.subtitleTracks.isEmpty {
+                    Section("Pistes intégrées") {
+                        ForEach(model.subtitleTracks) { track in
+                            if track.id != -1 {
+                                Button {
+                                    model.selectSubtitle(id: track.id)
+                                } label: {
+                                    Label(track.name, systemImage: model.currentSubtitleID == track.id ? "checkmark" : "")
+                                }
+                            }
+                        }
+                    }
+                }
+                if !subtitles.isEmpty {
+                    Section("Fichiers à côté") {
+                        ForEach(subtitles) { sub in
+                            Button {
+                                addSidecarSubtitle(sub)
+                            } label: {
+                                Text(sub.language.map { "\(sub.name) (\($0))" } ?? sub.name)
+                            }
+                        }
+                    }
+                }
+            } label: {
+                Image(systemName: "captions.bubble")
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(model.currentSubtitleID != -1 ? Color.accentColor : .white)
+                    .frame(width: 38, height: 38)
+                    .background(.black.opacity(0.35), in: .circle)
+            }
+
+            // Pistes audio (si plusieurs).
+            if model.audioTracks.count > 1 {
+                Menu {
+                    ForEach(model.audioTracks) { track in
+                        Button {
+                            model.selectAudio(id: track.id)
+                        } label: {
+                            Label(track.name, systemImage: model.currentAudioID == track.id ? "checkmark" : "")
+                        }
+                    }
+                } label: {
+                    Image(systemName: "waveform")
+                        .font(.system(size: 17, weight: .medium))
+                        .foregroundStyle(.white)
+                        .frame(width: 38, height: 38)
+                        .background(.black.opacity(0.35), in: .circle)
+                }
+            }
+        }
+    }
+
+    private var speedMenu: some View {
+        Menu {
+            ForEach(speeds, id: \.self) { speed in
+                Button {
+                    model.setRate(speed)
+                } label: {
+                    Label(speedLabel(speed), systemImage: model.rate == speed ? "checkmark" : "")
+                }
+            }
+        } label: {
+            Text(speedLabel(model.rate))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(.black.opacity(0.35), in: .capsule)
+        }
+    }
+
+    private var failureOverlay: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.red)
+            Text("Lecture impossible")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.white)
+            Text("Ce fichier n'a pas pu être lu dans l'app.")
+                .font(.system(size: 13))
+                .foregroundStyle(.white.opacity(0.7))
+                .multilineTextAlignment(.center)
+            if let onOpenExternal {
+                Button {
+                    onOpenExternal()
+                } label: {
+                    Label("Ouvrir dans une app externe", systemImage: "play.rectangle.on.rectangle")
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 4)
+            }
+            Button("Fermer") { onClose?() }
+                .foregroundStyle(.white)
+        }
+        .padding(28)
+    }
+
+    // MARK: Helpers
+
+    private func addSidecarSubtitle(_ sub: SidecarSubtitle) {
+        guard !loadingSubtitle else { return }
+        loadingSubtitle = true
+        Task {
+            defer { loadingSubtitle = false }
+            if let url = try? await SubtitleService.shared.localURL(remote: remote, subtitle: sub) {
+                model.addExternalSubtitle(url)
+            }
+        }
+    }
+
+    private var autoHideKey: String {
+        "\(showControls)|\(model.isPlaying)"
+    }
+
+    private func persistAndPublish(position: Double) {
+        let second = Int(position)
+        if second != lastSavedSecond, second % 5 == 0 {
+            lastSavedSecond = second
+            PlaybackProgressStore.save(
+                remote: remote, path: path,
+                position: position, duration: model.durationSeconds
+            )
+            updateNowPlaying()
+        }
+    }
+
+    private func updateNowPlaying() {
+        NowPlayingService.shared.updateNowPlaying(
+            title: title,
+            durationSeconds: model.durationSeconds,
+            elapsedSeconds: model.positionSeconds,
+            rate: model.isPlaying ? model.rate : 0
+        )
+    }
+
+    private func configureRemoteCommands() {
+        NowPlayingService.shared.configureRemoteCommands(
+            onPlay: { model.play() },
+            onPause: { model.pause() },
+            onNext: hasNext ? { onNext?() } : nil,
+            onPrevious: hasPrevious ? { onPrevious?() } : nil,
+            onSeek: { model.seek(toSeconds: $0) }
+        )
+    }
+
+    private func speedLabel(_ speed: Float) -> String {
+        speed == 1.0 ? "1×" : String(format: "%g×", speed)
+    }
+
+    private func timeString(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "0:00" }
+        let total = Int(seconds)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%d:%02d", m, s)
+    }
+}
+
+#else
+
+// MARK: - Stub (VLCKit absent du build)
+
+/// Repli si le package VLCKit n'est pas (encore) lié : on n'a pas de lecteur
+/// logiciel, donc on propose l'ouverture externe.
+struct EmbeddedVLCPlayerView: View {
+    let streamURL: URL
+    let title: String
+    let remote: String
+    let path: String
+    let subtitles: [SidecarSubtitle]
+    var hasNext: Bool = false
+    var hasPrevious: Bool = false
+    var onNext: (() -> Void)?
+    var onPrevious: (() -> Void)?
+    var onOpenExternal: (() -> Void)?
+    var onClose: (() -> Void)?
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            VStack(spacing: 14) {
+                Image(systemName: "film.stack")
+                    .font(.largeTitle)
+                    .foregroundStyle(.white.opacity(0.8))
+                Text("Lecteur VLC indisponible")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                Text("Le module de lecture multi-format n'est pas inclus dans ce build.")
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.7))
+                    .multilineTextAlignment(.center)
+                if let onOpenExternal {
+                    Button {
+                        onOpenExternal()
+                    } label: {
+                        Label("Ouvrir dans une app externe", systemImage: "play.rectangle.on.rectangle")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                Button("Fermer") { onClose?() }
+                    .foregroundStyle(.white)
+            }
+            .padding(28)
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Lecteur vidéo embarqué multi-format

Ajoute un **vrai lecteur vidéo embarqué** (in-app) en plus du handoff vers une app externe, avec le **choix** entre les deux.

### Architecture — hybride
- **AVPlayer** (AVKit) pour MP4/MOV/M4V + audio courant → PiP, décodage matériel, AirPlay, sélecteur de sous-titres natif.
- **VLCKit (libVLC)** pour tout ce qu'AVPlayer ne décode pas : MKV, AVI, WebM, TS, MPG… (corrige l'écran noir silencieux sur ces formats).
- Alimenté par l'URL **loopback HTTP seekable** existante (`RcloneStreamingService`) → streaming par plages, crypt transparent, pas de téléchargement complet.

### Fonctionnalités
- **Choix in-app / app externe** (Infuse, VLC) dans le menu d'actions.
- **Sous-titres** : sidecar (`.srt/.ass/.vtt` détectés à côté du fichier) + pistes intégrées + pistes audio.
- **Reprise de position** (par remote+chemin), partagée AVPlayer/VLC.
- **Playlist de dossier** : enchaînement automatique + suivant/précédent.
- **Audio en arrière-plan + écran verrouillé** (`UIBackgroundModes=audio`, MPNowPlayingInfoCenter / MPRemoteCommandCenter).

### Dépendance
- SPM `tylerjonesio/vlckit-spm` 3.6.0 (VLCKit 3.x, **LGPLv2.1**), liée **iOS + macOS uniquement** (filtre de plateforme, pas de slice visionOS).
- Résolue au checkout par Xcode Cloud (rien de binaire committé).

### ⚠️ Validation requise
Build local impossible (`RcloneKit.xcframework` gitignoré). Cette PR doit être **validée par une build Xcode Cloud** (résolution du package SPM + édition de liens) avant merge. Fichiers nouveaux auto-inclus via les groupes synchronisés Xcode 16 ; le `project.pbxproj` a été édité à la main (validé `plutil -lint`).