### PR TITLE
fix(spm): committe Package.resolved (requis par Xcode Cloud)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ xcuserdata/
 .swiftpm/
 .build/
 Package.resolved
+# Exception : le lockfile du projet DOIT être committé — Xcode Cloud a la
+# résolution automatique des packages désactivée et l'exige (sinon erreur
+# ResolvePackageDependenciesStep).
+!Rclone GUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 
 # --- CocoaPods (not used, just in case) ---------------------------------
 Pods/

--- a/Rclone GUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Rclone GUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "294b5443f2fd75dbed7a00528cc25cb27baf812b2346df53611fbd2af4f2803d",
+  "pins" : [
+    {
+      "identity" : "vlckit-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tylerjonesio/vlckit-spm",
+      "state" : {
+        "revision" : "e932bbd488872fdb74f6654d28c2f291eae03daf",
+        "version" : "3.6.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
La build #41 a échoué à `ResolvePackageDependenciesStep` : Xcode Cloud a la résolution automatique des packages désactivée et **exige un `Package.resolved` committé**.

- Lockfile généré par Xcode (`xcodebuild` a bien résolu `vlckit-spm @ 3.6.0`, revision `e932bbd`) → mes éditions pbxproj sont valides.
- Exception ajoutée au `.gitignore` (qui ignorait `Package.resolved` globalement).

Débloque la build du lecteur vidéo embarqué (PR #12).