### PR TITLE
fix(player): compile VLCKit + correctifs de revue + attribution LGPL

### DIFF
--- a/Rclone GUI/Services/NowPlayingService.swift
+++ b/Rclone GUI/Services/NowPlayingService.swift
@@ -45,6 +45,14 @@ final class NowPlayingService {
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
+    /// Comme `removeRemoteCommands` mais sans désactiver la session audio :
+    /// à appeler au changement de lecteur/moteur (ex. piste VLC → piste
+    /// AVPlayer dans une playlist) pour purger les handlers VLC périmés avant
+    /// que le nouveau moteur ne s'installe.
+    func resetRemoteCommands() {
+        removeRemoteCommands()
+    }
+
     /// Retire nos cibles de commandes distantes. Indispensable entre deux
     /// lecteurs : sinon un handler VLC périmé resterait branché et entrerait
     /// en conflit avec le lecteur système (AVPlayerViewController) qui gère
@@ -140,6 +148,7 @@ final class NowPlayingService {
 
     func beginPlaybackSession() {}
     func endPlaybackSession() {}
+    func resetRemoteCommands() {}
     func configureRemoteCommands(
         onPlay: @escaping () -> Void,
         onPause: @escaping () -> Void,

--- a/Rclone GUI/Views/Player/MediaPlayerView.swift
+++ b/Rclone GUI/Views/Player/MediaPlayerView.swift
@@ -80,7 +80,10 @@ struct MediaPlayerView: UIViewControllerRepresentable {
         private let title: String?
         private let onEnded: (() -> Void)?
 
-        private weak var player: AVPlayer?
+        // Référence forte : garantit que `removeTimeObserver` puisse être
+        // appelé sur le même player au teardown (AVFoundation l'exige avant
+        // la libération, sinon l'observer fuit / peut firer après dealloc).
+        private var player: AVPlayer?
         private var timeObserver: Any?
         private var endObserver: NSObjectProtocol?
         private var didResume = false
@@ -101,14 +104,20 @@ struct MediaPlayerView: UIViewControllerRepresentable {
                 self?.tick(time)
             }
 
-            endObserver = NotificationCenter.default.addObserver(
-                forName: .AVPlayerItemDidPlayToEndTime,
-                object: player.currentItem,
-                queue: .main
-            ) { [weak self] _ in
-                guard let self else { return }
-                PlaybackProgressStore.clear(remote: self.remote, path: self.path)
-                self.onEnded?()
+            // Observer de fin lié à CET item précis. Si currentItem était nil,
+            // s'enregistrer avec object:nil capterait la fin de TOUS les players
+            // de l'app → onEnded parasite. AVPlayer(url:) crée l'item de façon
+            // synchrone, mais on garde la garde par sûreté.
+            if let item = player.currentItem {
+                endObserver = NotificationCenter.default.addObserver(
+                    forName: .AVPlayerItemDidPlayToEndTime,
+                    object: item,
+                    queue: .main
+                ) { [weak self] _ in
+                    guard let self else { return }
+                    PlaybackProgressStore.clear(remote: self.remote, path: self.path)
+                    self.onEnded?()
+                }
             }
         }
 
@@ -159,6 +168,7 @@ struct MediaPlayerView: UIViewControllerRepresentable {
                     PlaybackProgressStore.save(remote: remote, path: path, position: elapsed, duration: duration)
                 }
             }
+            player = nil
         }
     }
 }
@@ -193,13 +203,15 @@ struct MediaPlayerView: View {
                         p.seek(to: CMTime(seconds: resume, preferredTimescale: 600))
                     }
                 }
-                endObserver = NotificationCenter.default.addObserver(
-                    forName: .AVPlayerItemDidPlayToEndTime,
-                    object: p.currentItem,
-                    queue: .main
-                ) { _ in
-                    PlaybackProgressStore.clear(remote: remote, path: path)
-                    onEnded?()
+                if let item = p.currentItem {
+                    endObserver = NotificationCenter.default.addObserver(
+                        forName: .AVPlayerItemDidPlayToEndTime,
+                        object: item,
+                        queue: .main
+                    ) { _ in
+                        PlaybackProgressStore.clear(remote: remote, path: path)
+                        onEnded?()
+                    }
                 }
                 p.play()
             }
@@ -319,6 +331,10 @@ struct MediaPlayerHost: View {
         preparing = true
         error = nil
         engine = MediaFormat.engine(for: entry.name)
+        // Purge les handlers de commandes distantes du lecteur précédent avant
+        // de changer éventuellement de moteur (évite des handlers VLC périmés
+        // qui survivraient à une bascule VLC → AVPlayer en playlist).
+        NowPlayingService.shared.resetRemoteCommands()
         NowPlayingService.shared.beginPlaybackSession()
         do {
             let s = try await RcloneStreamingService.shared.session(

--- a/Rclone GUI/Views/Player/VLCPlayerView.swift
+++ b/Rclone GUI/Views/Player/VLCPlayerView.swift
@@ -13,6 +13,7 @@
 //
 
 import SwiftUI
+import Combine
 
 #if canImport(VLCKitSPM)
 import VLCKitSPM
@@ -58,13 +59,13 @@ final class VLCPlayerModel: NSObject, ObservableObject {
         player.media = media
         player.play()
         if let start = startAtSeconds, start > 1 {
-            // Le seek doit attendre que le média soit prêt : on le tente après
-            // le passage en lecture (cf. mediaPlayerStateChanged → .playing).
-            pendingSeekSeconds = start
+            // Appliqué quand la durée devient connue (= demuxer prêt), dans
+            // refreshTime — un seek trop tôt sur un flux live est ignoré par VLC.
+            resumeTargetSeconds = start
         }
     }
 
-    private var pendingSeekSeconds: Double?
+    private var resumeTargetSeconds: Double?
 
     func togglePlayPause() {
         if player.isPlaying { player.pause() } else { player.play() }
@@ -123,14 +124,26 @@ final class VLCPlayerModel: NSObject, ObservableObject {
     private func refreshTime() {
         let ms = player.time?.intValue ?? 0
         positionSeconds = Double(ms) / 1000.0
-        // `player.media` est optionnel ; `length` peut être importé optionnel
-        // ou IUO → passer par une variable pour rester robuste à la nullabilité.
-        let lengthTime = player.media?.length
-        if let lengthMs = lengthTime?.intValue, lengthMs > 0 {
+        // `media` et `length` sont importés non-optionnels (annotations nonnull
+        // du header VLCKit) → accès direct sans optional-chaining. VLCKit
+        // renvoie toujours un VLCTime (intValue = 0 tant que la durée est
+        // indéterminée). `media` est garanti non-nil pendant la lecture.
+        let lengthMs = player.media.length.intValue
+        if lengthMs > 0 {
             durationSeconds = Double(lengthMs) / 1000.0
         } else if player.position > 0.0001 {
             // Estimation si la durée n'est pas encore connue.
             durationSeconds = positionSeconds / Double(player.position)
+        }
+
+        // Reprise différée : on seek une fois la durée réelle connue et que la
+        // cible est bien avant la fin.
+        if let target = resumeTargetSeconds, durationSeconds > 0, target < durationSeconds - 15 {
+            resumeTargetSeconds = nil
+            seek(toSeconds: target)
+        } else if resumeTargetSeconds != nil, durationSeconds > 0 {
+            // Durée connue mais cible hors plage → on abandonne la reprise.
+            resumeTargetSeconds = nil
         }
     }
 }
@@ -148,10 +161,8 @@ extension VLCPlayerModel: VLCMediaPlayerDelegate {
             isPlaying = true
             failed = false
             refreshTracks()
-            if let pending = pendingSeekSeconds {
-                pendingSeekSeconds = nil
-                seek(toSeconds: pending)
-            }
+            // La reprise est appliquée dans refreshTime() une fois la durée
+            // connue (le demuxer est alors prêt à seek).
         case .paused:
             isPlaying = false
         case .stopped:

--- a/Rclone GUI/Views/Settings/AboutView.swift
+++ b/Rclone GUI/Views/Settings/AboutView.swift
@@ -37,10 +37,16 @@ struct AboutView: View {
                 Link(destination: URL(string: "https://github.com/rclone/rclone")!) {
                     Label("Code source rclone", systemImage: "chevron.left.forwardslash.chevron.right")
                 }
+                Link(destination: URL(string: "https://code.videolan.org/videolan/VLCKit")!) {
+                    Label("Code source VLCKit (libVLC)", systemImage: "chevron.left.forwardslash.chevron.right")
+                }
             }
 
             Section("Crédits") {
                 Text("Construit avec rclone et SwiftUI.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("Lecture multi-format propulsée par VLCKit / libVLC (VideoLAN), sous licence LGPL v2.1. Le code source de VLCKit est disponible via le lien ci-dessus.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
Débloque la compilation du lecteur vidéo embarqué (build #42 échouait sur VLCPlayerView).

**Correctifs de compilation**
- `import Combine` (sinon `VLCPlayerModel` ne conforme pas à `ObservableObject` et les `@Published` n'ont pas d'`init(wrappedValue:)`).
- `player.media.length` sans optional-chaining (header VLCKit `nonnull`).

**Correctifs de la revue de code (deliver)**
- Purge des commandes distantes à chaque bascule de moteur (playlist mixte MP4↔MKV).
- Référence forte au player dans le Coordinator AVPlayer (`removeTimeObserver` garanti).
- Reprise VLC appliquée quand la durée est connue.
- Observer de fin lié à l'item précis (évite un `onEnded` global).

**Conformité** : attribution VLCKit/libVLC LGPL v2.1 + lien source dans `AboutView`.