### PR TITLE
fix(player): await sur AVPlayer.seek async (macOS)

### DIFF
--- a/Rclone GUI/Views/Player/MediaPlayerView.swift
+++ b/Rclone GUI/Views/Player/MediaPlayerView.swift
@@ -200,7 +200,9 @@ struct MediaPlayerView: View {
                             if p.currentItem?.status == .readyToPlay { break }
                             try? await Task.sleep(for: .milliseconds(100))
                         }
-                        p.seek(to: CMTime(seconds: resume, preferredTimescale: 600))
+                        // En contexte async (Task), seek(to:) résout vers la
+                        // surcharge asynchrone → await requis.
+                        _ = await p.seek(to: CMTime(seconds: resume, preferredTimescale: 600))
                     }
                 }
                 if let item = p.currentItem {


### PR DESCRIPTION
Build #44 : **archive iOS SUCCEEDED** ✅, macOS échouait sur `MediaPlayerView.swift:203: expression is 'async' but is not marked with 'await'`. Le `seek(to:)` dans le `Task` de reprise macOS résout vers la surcharge asynchrone → `await` ajouté. Dernière erreur connue.