### PR TITLE
feat(privacy): toggle « Exclure des sauvegardes iCloud »

### DIFF
--- a/Rclone GUI/Core/BackupExclusionManager.swift
+++ b/Rclone GUI/Core/BackupExclusionManager.swift
@@ -1,0 +1,79 @@
+//
+//  BackupExclusionManager.swift
+//  Rclone GUI — Core
+//
+//  Exclut (ou réintègre) les données de l'app des sauvegardes iCloud / Finder
+//  via l'attribut `isExcludedFromBackup` (NSURLIsExcludedFromBackupKey).
+//
+//  Cibles :
+//    - le conteneur App Group : configuration rclone chiffrée, cache de
+//      navigation SwiftData, miniatures, coffre-fort, état FileProvider… ;
+//    - le dossier Documents de l'app : fichiers téléchargés.
+//  Le cache média vit dans Caches, jamais inclus dans une sauvegarde → non
+//  concerné. Les identifiants vivent dans le Trousseau (sauvegardé à part).
+//
+//  Réglage opt-in (défaut : données sauvegardées, pour faciliter la
+//  restauration sur un nouvel appareil).
+//
+
+import Foundation
+
+public enum BackupExclusionManager {
+    /// Clé UserDefaults du toggle. Absente/false ⇒ données incluses au backup.
+    public static let defaultsKey = "privacy.excludeFromICloudBackup"
+
+    public static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: defaultsKey)
+    }
+
+    /// Données de l'app à marquer/démarquer.
+    static var targetURLs: [URL] {
+        var urls: [URL] = [AppGroup.containerURL]
+        if let documents = try? FileManager.default.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        ) {
+            urls.append(documents)
+        }
+        return urls
+    }
+
+    /// Applique (`excluded = true`) ou retire (`false`) l'exclusion de backup
+    /// sur chaque cible existante. Idempotent — sûr à rappeler à chaque
+    /// lancement. Renvoie `false` si au moins une cible a échoué.
+    @discardableResult
+    public static func apply(excluded: Bool) -> Bool {
+        let fileManager = FileManager.default
+        var allSucceeded = true
+
+        for url in targetURLs {
+            guard fileManager.fileExists(atPath: url.path) else { continue }
+            var mutableURL = url
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = excluded
+            do {
+                try mutableURL.setResourceValues(values)
+            } catch {
+                allSucceeded = false
+                Task {
+                    await LogService.shared.log(
+                        .error,
+                        category: "backup",
+                        message: "isExcludedFromBackup=\(excluded) a échoué pour \(url.lastPathComponent) : \(error.localizedDescription)"
+                    )
+                }
+            }
+        }
+        return allSucceeded
+    }
+
+    /// Ré-affirme l'état persisté au démarrage. N'agit que si l'exclusion est
+    /// activée : les nouveaux fichiers créés sous un dossier déjà exclu héritent
+    /// de l'exclusion, mais on ré-applique sur la racine par sûreté.
+    public static func applyPersistedState() {
+        guard isEnabled else { return }
+        apply(excluded: true)
+    }
+}

--- a/Rclone GUI/Rclone_GUIApp.swift
+++ b/Rclone GUI/Rclone_GUIApp.swift
@@ -188,6 +188,10 @@ struct Rclone_GUIApp: App {
 private func prepareRuntime() {
     do {
         try AppGroup.prepareSharedContainerLayout()
+        // Ré-affirme l'exclusion de sauvegarde iCloud si l'utilisateur l'a
+        // activée (no-op sinon). Après prepareSharedContainerLayout pour que
+        // le conteneur et ses sous-dossiers existent.
+        BackupExclusionManager.applyPersistedState()
         let workingDirectory = AppGroup.runtimeWorkingDirectoryURL
         _ = workingDirectory.path.withCString { chdir($0) }
         setenv("PWD", workingDirectory.path, 1)

--- a/Rclone GUI/Views/Settings/BackupSettingsView.swift
+++ b/Rclone GUI/Views/Settings/BackupSettingsView.swift
@@ -1,0 +1,86 @@
+//
+//  BackupSettingsView.swift
+//  Rclone GUI — Views/Settings
+//
+//  Toggle pour exclure les données de l'app des sauvegardes iCloud / Finder.
+//  Voir BackupExclusionManager pour la liste exacte des cibles.
+//
+
+import SwiftUI
+
+struct BackupSettingsView: View {
+    @AppStorage(BackupExclusionManager.defaultsKey) private var excludeFromBackup = false
+    @State private var transientMessage: String?
+
+    var body: some View {
+        Form {
+            Section {
+                headerCard
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .listRowBackground(Color.clear)
+            }
+
+            Section {
+                Toggle(isOn: Binding(
+                    get: { excludeFromBackup },
+                    set: { newValue in
+                        excludeFromBackup = newValue
+                        let ok = BackupExclusionManager.apply(excluded: newValue)
+                        if !ok {
+                            transientMessage = "Certaines données n'ont pas pu être marquées. Réessaie ; si ça persiste, c'est sans danger pour l'app."
+                        }
+                    }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Exclure des sauvegardes iCloud")
+                            .font(.body.weight(.medium))
+                        Text(excludeFromBackup
+                             ? "Les données de l'app ne seront pas incluses dans la sauvegarde iCloud de l'appareil."
+                             : "Les données de l'app sont incluses dans la sauvegarde iCloud de l'appareil.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } header: {
+                Text("Sauvegarde iCloud")
+            } footer: {
+                Text("Quand c'est activé, la configuration rclone (chiffrée), le cache de navigation, les miniatures, le coffre-fort et les fichiers téléchargés sont marqués « exclus de la sauvegarde » (NSURLIsExcludedFromBackupKey). Utile pour la confidentialité ou pour ne pas alourdir votre sauvegarde iCloud.\n\nVos identifiants restent dans le Trousseau (sauvegardé séparément). Après une restauration sur un nouvel appareil, il faudra réimporter votre configuration.")
+            }
+        }
+        .navigationTitle("Sauvegarde iCloud")
+        #if os(iOS)
+        .rgInlineNavTitle()
+        #endif
+        .alert("Sauvegarde", isPresented: Binding(
+            get: { transientMessage != nil },
+            set: { if !$0 { transientMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { transientMessage = nil }
+        } message: {
+            Text(transientMessage ?? "")
+        }
+    }
+
+    @ViewBuilder
+    private var headerCard: some View {
+        HStack(spacing: 14) {
+            AppIconTile(systemImage: "icloud.slash", tint: .blue, size: 54, iconSize: .title2)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(excludeFromBackup ? "Exclu de la sauvegarde" : "Inclus dans la sauvegarde")
+                    .font(.headline)
+                Text("Contrôle si les données de l'app figurent dans la sauvegarde iCloud de l'appareil.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background, in: .rect(cornerRadius: 16, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(.quaternary)
+        }
+    }
+}

--- a/Rclone GUI/Views/Settings/SettingsView.swift
+++ b/Rclone GUI/Views/Settings/SettingsView.swift
@@ -92,6 +92,17 @@ struct SettingsView: View {
                 }
 
                 NavigationLink {
+                    BackupSettingsView()
+                } label: {
+                    SettingsNavigationRow(
+                        icon: "icloud.slash",
+                        title: "Sauvegarde iCloud",
+                        subtitle: "Exclure les données de l'app de la sauvegarde iCloud",
+                        tint: .blue
+                    )
+                }
+
+                NavigationLink {
                     TrashView()
                 } label: {
                     SettingsNavigationRow(


### PR DESCRIPTION
Réglages → Stockage → **Sauvegarde iCloud** : un toggle qui pose `isExcludedFromBackup` sur les données de l'app.

**Cibles** : conteneur App Group (config rclone chiffrée, cache de navigation SwiftData, miniatures, coffre-fort, état FileProvider) + dossier Documents (téléchargements). Le cache média (Caches) n'est jamais sauvegardé ; les identifiants restent dans le Trousseau.

**Détails**
- `BackupExclusionManager.apply(excluded:)` idempotent + `applyPersistedState()` ré-affirmé au lancement (`prepareRuntime`).
- **Opt-in** (défaut : données sauvegardées, pour faciliter la restauration sur un nouvel appareil).
- `BackupSettingsView` calque le pattern de `PerformanceSettingsView` (Form/Section/Toggle/footer).