### PR TITLE
feat(gallery): vue grille + galerie médias (vignettes images/vidéos)

### DIFF
--- a/Rclone GUI/Core/MediaFormat.swift
+++ b/Rclone GUI/Core/MediaFormat.swift
@@ -78,6 +78,28 @@ public enum MediaFormat {
         isVideo(name) || isAudio(name)
     }
 
+    // Formats image reconnus (vignettes de la galerie).
+    static let imageExtensions: Set<String> = [
+        "jpg", "jpeg", "png", "heic", "heif", "gif", "webp", "bmp",
+        "tiff", "tif", "jp2", "avif", "ico",
+        // RAW courants (ImageIO sait en extraire une vignette)
+        "dng", "cr2", "cr3", "nef", "arw", "orf", "rw2", "raf", "srw"
+    ]
+
+    public static func isImage(_ name: String) -> Bool {
+        let e = ext(name)
+        if imageExtensions.contains(e) { return true }
+        if let type = UTType(filenameExtension: e), type.conforms(to: .image) {
+            return true
+        }
+        return false
+    }
+
+    /// Médias visuels = ce qui mérite une vignette dans la galerie.
+    public static func isVisualMedia(_ name: String) -> Bool {
+        isImage(name) || isVideo(name)
+    }
+
     /// Extensions de sous-titres « sidecar » qu'on cherche à côté du média.
     static let subtitleExtensions: Set<String> = [
         "srt", "ass", "ssa", "vtt", "sub", "idx"

--- a/Rclone GUI/Rclone_GUIApp.swift
+++ b/Rclone GUI/Rclone_GUIApp.swift
@@ -198,6 +198,8 @@ private func prepareRuntime() {
         // activée (no-op sinon). Après prepareSharedContainerLayout pour que
         // le conteneur et ses sous-dossiers existent.
         BackupExclusionManager.applyPersistedState()
+        // Démarre le monitoring réseau tôt (politique de vignettes Wi-Fi/cellulaire).
+        NetworkReachability.shared.activate()
         let workingDirectory = AppGroup.runtimeWorkingDirectoryURL
         _ = workingDirectory.path.withCString { chdir($0) }
         setenv("PWD", workingDirectory.path, 1)

--- a/Rclone GUI/Services/NetworkReachability.swift
+++ b/Rclone GUI/Services/NetworkReachability.swift
@@ -1,0 +1,56 @@
+//
+//  NetworkReachability.swift
+//  Rclone GUI — Services
+//
+//  Observe le type de connexion via NWPathMonitor pour alimenter la politique
+//  de génération des vignettes (« Wi-Fi seulement » évite de consommer des
+//  données cellulaires en téléchargeant des images depuis les remotes).
+//
+
+import Foundation
+import Network
+
+final class NetworkReachability: @unchecked Sendable {
+    static let shared = NetworkReachability()
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.rougetet.rclone-gui.reachability")
+    private let lock = NSLock()
+    private var _isExpensive = false
+    private var _isConstrained = false
+    private var _isSatisfied = true
+
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            self.lock.lock()
+            self._isExpensive = path.isExpensive          // cellulaire, partage de connexion…
+            self._isConstrained = path.isConstrained      // mode données réduites
+            self._isSatisfied = (path.status == .satisfied)
+            self.lock.unlock()
+        }
+        monitor.start(queue: queue)
+    }
+
+    /// Démarre le monitoring tôt (appelé au lancement) pour que l'état soit
+    /// frais avant la première vignette. L'accès à `.shared` suffit (init).
+    func activate() {}
+
+    var isExpensive: Bool {
+        lock.lock(); defer { lock.unlock() }; return _isExpensive
+    }
+
+    var isConstrained: Bool {
+        lock.lock(); defer { lock.unlock() }; return _isConstrained
+    }
+
+    var isOnline: Bool {
+        lock.lock(); defer { lock.unlock() }; return _isSatisfied
+    }
+
+    /// Connexion « non facturée » : en ligne, ni coûteuse (cellulaire) ni bridée.
+    var isUnmetered: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isSatisfied && !_isExpensive && !_isConstrained
+    }
+}

--- a/Rclone GUI/Services/RcloneStreamingService.swift
+++ b/Rclone GUI/Services/RcloneStreamingService.swift
@@ -23,6 +23,23 @@ public actor RcloneStreamingService {
     private init() {}
 
     public func session(remote: String, path: String, sizeHint: Int64?) async throws -> StreamingSession {
+        if let live = await liveSession(remote: remote, path: path) {
+            return live
+        }
+        let localURL = try await MediaCacheService.shared.localPlayableURL(
+            remote: remote,
+            path: path,
+            sizeHint: sizeHint,
+            policy: .reuseIfCached
+        )
+        return StreamingSession(id: UUID().uuidString, url: localURL, isLiveStream: false)
+    }
+
+    /// Session de streaming « live » via le bridge loopback **uniquement**
+    /// (pas de fallback téléchargement). Renvoie nil si le bridge est
+    /// indisponible. Utilisé par les vignettes pour ne jamais déclencher le
+    /// download complet d'un fichier juste pour une miniature.
+    public func liveSession(remote: String, path: String) async -> StreamingSession? {
         #if canImport(RcloneKit)
         do {
             _ = try await RcloneCore.shared.version()
@@ -33,25 +50,20 @@ public actor RcloneStreamingService {
                   let urlString = object?["url"] as? String,
                   let url = URL(string: urlString),
                   !id.isEmpty else {
-                throw RcloneError.invalidJSON(method: "StartFileHTTP", raw: raw, underlying: URLError(.badURL))
+                return nil
             }
             return StreamingSession(id: id, url: url, isLiveStream: true)
         } catch {
             await LogService.shared.log(
                 .info,
                 category: "streaming",
-                message: "Bridge streaming indisponible pour \(remote):\(path), fallback cache : \(error.localizedDescription)"
+                message: "Bridge streaming indisponible pour \(remote):\(path) : \(error.localizedDescription)"
             )
+            return nil
         }
+        #else
+        return nil
         #endif
-
-        let localURL = try await MediaCacheService.shared.localPlayableURL(
-            remote: remote,
-            path: path,
-            sizeHint: sizeHint,
-            policy: .reuseIfCached
-        )
-        return StreamingSession(id: UUID().uuidString, url: localURL, isLiveStream: false)
     }
 
     public func stop(_ session: StreamingSession) async {

--- a/Rclone GUI/Services/ThumbnailService.swift
+++ b/Rclone GUI/Services/ThumbnailService.swift
@@ -1,0 +1,241 @@
+//
+//  ThumbnailService.swift
+//  Rclone GUI — Services
+//
+//  Génère et met en cache les vignettes des médias distants pour la galerie.
+//
+//  Stratégie (économe) :
+//    - Images : bridge loopback live → URLSession → downsampling ImageIO
+//      (CGImageSourceCreateThumbnailAtIndex). Plafond de taille pour éviter de
+//      télécharger un fichier énorme juste pour une miniature.
+//    - Vidéos : bridge loopback live → AVAssetImageGenerator (1re seconde),
+//      qui ne lit que les plages nécessaires (pas de téléchargement complet).
+//    - Cache : mémoire (LRU) + disque (JPEG dans thumbnailCacheURL), clé =
+//      SHA-256 de remote:chemin|modTime|taille.
+//    - Concurrence bornée (sémaphore) + politique données (Wi-Fi seulement /
+//      toujours / jamais). On NE déclenche jamais le download complet d'un
+//      fichier (liveSession uniquement) pour une vignette.
+//
+
+import Foundation
+import CoreGraphics
+import ImageIO
+import AVFoundation
+import CryptoKit
+import UniformTypeIdentifiers
+
+public enum ThumbnailPolicy: String, CaseIterable, Sendable {
+    case always
+    case wifiOnly
+    case never
+
+    public static let defaultsKey = "thumbnails.policy"
+
+    public var label: String {
+        switch self {
+        case .always:   return String(localized: "Toujours")
+        case .wifiOnly: return String(localized: "Wi-Fi seulement")
+        case .never:    return String(localized: "Jamais")
+        }
+    }
+}
+
+/// Boîte Sendable autour d'un CGImage (immuable) pour le passer entre acteurs
+/// sans avertissement de concurrence.
+public struct CGImageBox: @unchecked Sendable {
+    public let image: CGImage
+}
+
+/// Sémaphore asynchrone pour borner le nombre de générations simultanées.
+actor AsyncSemaphore {
+    private var value: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(value: Int) { self.value = value }
+
+    func wait() async {
+        if value > 0 { value -= 1; return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func signal() {
+        if waiters.isEmpty {
+            value += 1
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
+public actor ThumbnailService {
+    public static let shared = ThumbnailService()
+    private init() {}
+
+    // Taille max d'un côté de la vignette (px). Uniforme pour un cache stable.
+    static let maxPixel: Int = 400
+    // Au-delà, on ne télécharge pas l'image pour une vignette (icône à la place).
+    static let imageSizeCap: Int64 = 80 * 1024 * 1024
+    // Générations réseau simultanées.
+    private let limiter = AsyncSemaphore(value: 3)
+
+    // Cache mémoire LRU (par nombre).
+    private var memCache: [String: CGImageBox] = [:]
+    private var memOrder: [String] = []
+    private let memLimit = 300
+
+    /// Vignette pour une entrée média. nil ⇒ afficher l'icône de repli.
+    public func thumbnail(for entry: RemoteEntryDTO, remote: String) async -> CGImageBox? {
+        guard MediaFormat.isVisualMedia(entry.name) else { return nil }
+        let key = Self.cacheKey(remote: remote, entry: entry)
+
+        if let cached = memCache[key] { return cached }
+        if let disk = Self.loadFromDisk(key: key) {
+            store(disk, key: key)
+            return disk
+        }
+
+        // Politique données : on ne GÉNÈRE pas si interdit (le cache reste servi).
+        switch Self.policy {
+        case .never:
+            return nil
+        case .wifiOnly where NetworkReachability.shared.isExpensive:
+            return nil
+        default:
+            break
+        }
+
+        await limiter.wait()
+        defer { Task { await limiter.signal() } }
+
+        // Re-vérifie après l'attente (réentrance : une autre tâche a pu générer).
+        if let cached = memCache[key] { return cached }
+
+        guard let box = await Self.generate(entry: entry, remote: remote) else { return nil }
+        Self.writeToDisk(box.image, key: key)
+        store(box, key: key)
+        return box
+    }
+
+    private func store(_ box: CGImageBox, key: String) {
+        if memCache[key] == nil { memOrder.append(key) }
+        memCache[key] = box
+        if memOrder.count > memLimit {
+            let evicted = memOrder.removeFirst()
+            memCache.removeValue(forKey: evicted)
+        }
+    }
+
+    public func clearCache() {
+        memCache.removeAll()
+        memOrder.removeAll()
+        let fm = FileManager.default
+        try? fm.removeItem(at: AppGroup.thumbnailCacheURL)
+        try? fm.createDirectory(at: AppGroup.thumbnailCacheURL, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Génération (hors acteur → s'exécute en parallèle)
+
+    nonisolated static var policy: ThumbnailPolicy {
+        ThumbnailPolicy(rawValue: UserDefaults.standard.string(forKey: ThumbnailPolicy.defaultsKey) ?? "") ?? .wifiOnly
+    }
+
+    nonisolated static func generate(entry: RemoteEntryDTO, remote: String) async -> CGImageBox? {
+        if MediaFormat.isImage(entry.name) {
+            return await generateImageThumbnail(remote: remote, entry: entry)
+        }
+        if MediaFormat.isVideo(entry.name) {
+            return await generateVideoThumbnail(remote: remote, entry: entry)
+        }
+        return nil
+    }
+
+    nonisolated static func generateImageThumbnail(remote: String, entry: RemoteEntryDTO) async -> CGImageBox? {
+        if entry.size > 0, entry.size > imageSizeCap { return nil }
+        guard let session = await RcloneStreamingService.shared.liveSession(
+            remote: remote, path: entry.pathInRemote
+        ) else { return nil }
+        defer { Task { await RcloneStreamingService.shared.stop(session) } }
+
+        guard let (data, _) = try? await URLSession.shared.data(from: session.url),
+              let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return nil
+        }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+        ]
+        guard let cg = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+        return CGImageBox(image: cg)
+    }
+
+    nonisolated static func generateVideoThumbnail(remote: String, entry: RemoteEntryDTO) async -> CGImageBox? {
+        guard let session = await RcloneStreamingService.shared.liveSession(
+            remote: remote, path: entry.pathInRemote
+        ) else { return nil }
+        defer { Task { await RcloneStreamingService.shared.stop(session) } }
+
+        let asset = AVURLAsset(url: session.url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: maxPixel, height: maxPixel)
+        generator.requestedTimeToleranceBefore = CMTime(seconds: 2, preferredTimescale: 600)
+        generator.requestedTimeToleranceAfter = CMTime(seconds: 3, preferredTimescale: 600)
+
+        let time = CMTime(seconds: 1, preferredTimescale: 600)
+        guard let result = try? await generator.image(at: time) else { return nil }
+        return CGImageBox(image: result.image)
+    }
+
+    // MARK: - Cache disque
+
+    nonisolated static func cacheKey(remote: String, entry: RemoteEntryDTO) -> String {
+        let raw = "\(remote):\(entry.pathInRemote)|\(Int(entry.modTime.timeIntervalSince1970))|\(entry.size)|\(maxPixel)"
+        let digest = SHA256.hash(data: Data(raw.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    nonisolated static func cacheFileURL(key: String) -> URL {
+        AppGroup.thumbnailCacheURL.appending(path: key).appendingPathExtension("jpg")
+    }
+
+    nonisolated static func loadFromDisk(key: String) -> CGImageBox? {
+        let url = cacheFileURL(key: key)
+        guard FileManager.default.fileExists(atPath: url.path),
+              let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let cg = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return nil
+        }
+        return CGImageBox(image: cg)
+    }
+
+    nonisolated static func writeToDisk(_ image: CGImage, key: String) {
+        let url = cacheFileURL(key: key)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        guard let dest = CGImageDestinationCreateWithURL(
+            url as CFURL, UTType.jpeg.identifier as CFString, 1, nil
+        ) else { return }
+        let props: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: 0.8]
+        CGImageDestinationAddImage(dest, image, props as CFDictionary)
+        CGImageDestinationFinalize(dest)
+    }
+
+    nonisolated public static func cacheSizeBytes() -> Int64 {
+        let root = AppGroup.thumbnailCacheURL
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: root.path),
+              let enumerator = fm.enumerator(at: root, includingPropertiesForKeys: [.fileSizeKey]) else {
+            return 0
+        }
+        var total: Int64 = 0
+        for case let url as URL in enumerator {
+            let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            total += Int64(size)
+        }
+        return total
+    }
+}

--- a/Rclone GUI/Views/Folders/FolderView.swift
+++ b/Rclone GUI/Views/Folders/FolderView.swift
@@ -73,6 +73,12 @@ struct FolderView: View {
     /// via .onChange(of: runningTransfers).
     @State private var activeTransferByPath: [String: Transfer] = [:]
 
+    // Mode d'affichage du navigateur : liste (défaut) ou grille. En grille,
+    // « médias uniquement » filtre dossiers/autres fichiers (mode galerie).
+    @AppStorage("browser.viewMode") private var viewModeRaw = "list"
+    @AppStorage("browser.gridMediaOnly") private var gridMediaOnly = false
+    private var viewMode: BrowserViewMode { BrowserViewMode(rawValue: viewModeRaw) ?? .list }
+
     private func computeActiveTransferByPath() -> [String: Transfer] {
         var dict: [String: Transfer] = [:]
         for t in runningTransfers {
@@ -190,6 +196,23 @@ struct FolderView: View {
                             hapticImpactTrigger &+= 1
                         }
                     }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Picker("Affichage", selection: $viewModeRaw) {
+                            Label("Liste", systemImage: "list.bullet").tag("list")
+                            Label("Grille", systemImage: "square.grid.2x2").tag("grid")
+                        }
+                        if viewMode == .grid {
+                            Divider()
+                            Toggle(isOn: $gridMediaOnly) {
+                                Label("Médias uniquement", systemImage: "photo.on.rectangle.angled")
+                            }
+                        }
+                    } label: {
+                        Image(systemName: viewMode == .grid ? "square.grid.2x2" : "list.bullet")
+                    }
+                    .accessibilityLabel("Mode d'affichage")
                 }
                 ToolbarItem(placement: .primaryAction) {
                     Button {
@@ -448,7 +471,10 @@ struct FolderView: View {
             ContentUnavailableView.search(text: query)
 
         case .loading, .loaded:
-            let list = List {
+            if viewMode == .grid {
+                gridContent
+            } else {
+              let list = List {
                 Section {
                     FolderOverviewCard(
                         remote: remote,
@@ -469,11 +495,78 @@ struct FolderView: View {
                     Text(displayedSectionTitle)
                 }
             }
-            #if os(iOS)
-            list.rgInsetGroupedList()
-            #else
-            list
-            #endif
+              #if os(iOS)
+              list.rgInsetGroupedList()
+              #else
+              list
+              #endif
+            }
+        }
+    }
+
+    private var gridRows: [DisplayedEntry] {
+        if gridMediaOnly {
+            return displayedRows.filter {
+                !$0.entry.isDirectory && MediaFormat.isVisualMedia($0.entry.name)
+            }
+        }
+        return displayedRows
+    }
+
+    @ViewBuilder
+    private var gridContent: some View {
+        if gridRows.isEmpty {
+            ContentUnavailableView(
+                "Aucun média",
+                systemImage: "photo.on.rectangle.angled",
+                description: Text("Ce dossier ne contient pas d'images ni de vidéos.")
+            )
+        } else {
+            ScrollView {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 100, maximum: 160), spacing: 10)],
+                    spacing: 12
+                ) {
+                    ForEach(gridRows) { row in
+                        gridCell(for: row)
+                    }
+                }
+                .padding(12)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func gridCell(for row: DisplayedEntry) -> some View {
+        let entry = row.entry
+        if entry.isDirectory {
+            NavigationLink(value: NavigationDestination.folder(
+                remote: remote,
+                path: entry.pathInRemote
+            )) {
+                MediaGridCell(entry: entry, remote: remote)
+            }
+            .buttonStyle(.plain)
+        } else {
+            Button {
+                handleTap(on: row)
+            } label: {
+                MediaGridCell(entry: entry, remote: remote)
+            }
+            .buttonStyle(.plain)
+            .contextMenu {
+                EntryActionsMenu(
+                    entry: entry,
+                    remote: remote,
+                    renameTarget: $renameTarget,
+                    deleteTarget: $deleteTarget,
+                    playTarget: $playTarget,
+                    previewTarget: $previewTarget,
+                    moveTarget: $moveTarget,
+                    downloadTarget: $downloadTarget,
+                    externalOpenTarget: $externalOpenTarget
+                )
+            }
         }
     }
 
@@ -1033,6 +1126,12 @@ private struct RemoteBatchTransferRequest: Identifiable {
 private struct DisplayedEntry: Identifiable {
     let id: String
     let entry: RemoteEntryDTO
+}
+
+/// Mode d'affichage du navigateur de dossiers.
+enum BrowserViewMode: String {
+    case list
+    case grid
 }
 
 /// Header card displayed at the top of each folder. Mirrors the walkthrough

--- a/Rclone GUI/Views/Folders/MediaGridCell.swift
+++ b/Rclone GUI/Views/Folders/MediaGridCell.swift
@@ -1,0 +1,91 @@
+//
+//  MediaGridCell.swift
+//  Rclone GUI — Views/Folders
+//
+//  Cellule de la vue grille / galerie. Charge sa vignette de façon paresseuse
+//  via ThumbnailService (cellule visible uniquement), avec placeholder icône,
+//  badge de lecture pour les vidéos, et libellé tronqué.
+//
+
+import SwiftUI
+
+struct MediaGridCell: View {
+    let entry: RemoteEntryDTO
+    let remote: String
+
+    @State private var thumb: CGImageBox?
+    @State private var loading = false
+
+    private var isVisual: Bool { MediaFormat.isVisualMedia(entry.name) }
+    private var isVideo: Bool { MediaFormat.isVideo(entry.name) }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.secondary.opacity(0.12))
+
+                if let thumb {
+                    Image(decorative: thumb.image, scale: 1)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    Image(systemName: placeholderIcon)
+                        .font(.system(size: 28))
+                        .foregroundStyle(placeholderColor)
+                    if loading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .padding(6)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                    }
+                }
+
+                if isVideo {
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 22))
+                        .foregroundStyle(.white)
+                        .shadow(radius: 3)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                        .padding(6)
+                }
+            }
+            .aspectRatio(1, contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(.quaternary, lineWidth: 0.5)
+            }
+
+            Text(entry.name)
+                .font(.caption2)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity)
+        }
+        .contentShape(Rectangle())
+        .task(id: entry.id) {
+            guard isVisual, thumb == nil else { return }
+            loading = true
+            defer { loading = false }
+            thumb = await ThumbnailService.shared.thumbnail(for: entry, remote: remote)
+        }
+    }
+
+    private var placeholderIcon: String {
+        if entry.isDirectory { return "folder.fill" }
+        if MediaFormat.isImage(entry.name) { return "photo" }
+        if MediaFormat.isVideo(entry.name) { return "film" }
+        if MediaFormat.isAudio(entry.name) { return "music.note" }
+        return "doc"
+    }
+
+    private var placeholderColor: Color {
+        if entry.isDirectory { return .blue }
+        if MediaFormat.isImage(entry.name) { return .green }
+        if MediaFormat.isVideo(entry.name) { return .purple }
+        if MediaFormat.isAudio(entry.name) { return .pink }
+        return .gray
+    }
+}

--- a/Rclone GUI/Views/Settings/SettingsView.swift
+++ b/Rclone GUI/Views/Settings/SettingsView.swift
@@ -92,6 +92,17 @@ struct SettingsView: View {
                 }
 
                 NavigationLink {
+                    ThumbnailSettingsView()
+                } label: {
+                    SettingsNavigationRow(
+                        icon: "rectangle.grid.3x2",
+                        title: "Vignettes",
+                        subtitle: "Galerie : politique de génération et cache",
+                        tint: .teal
+                    )
+                }
+
+                NavigationLink {
                     BackupSettingsView()
                 } label: {
                     SettingsNavigationRow(

--- a/Rclone GUI/Views/Settings/ThumbnailSettingsView.swift
+++ b/Rclone GUI/Views/Settings/ThumbnailSettingsView.swift
@@ -1,0 +1,99 @@
+//
+//  ThumbnailSettingsView.swift
+//  Rclone GUI — Views/Settings
+//
+//  Politique de génération des vignettes de la galerie (impact données) +
+//  gestion du cache disque. Voir ThumbnailService.
+//
+
+import SwiftUI
+
+struct ThumbnailSettingsView: View {
+    @AppStorage(ThumbnailPolicy.defaultsKey) private var policyRaw = ThumbnailPolicy.wifiOnly.rawValue
+    @State private var cacheBytes: Int64 = 0
+    @State private var isClearing = false
+
+    var body: some View {
+        Form {
+            Section {
+                headerCard
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    .listRowBackground(Color.clear)
+            }
+
+            Section {
+                Picker("Génération", selection: $policyRaw) {
+                    ForEach(ThumbnailPolicy.allCases, id: \.rawValue) { policy in
+                        Text(policy.label).tag(policy.rawValue)
+                    }
+                }
+                #if os(iOS)
+                .pickerStyle(.menu)
+                #endif
+            } header: {
+                Text("Vignettes")
+            } footer: {
+                Text("Générer une vignette télécharge des octets depuis le remote (rclone n'a pas de vignettes côté serveur). « Wi-Fi seulement » évite la consommation de données cellulaires ; les vignettes déjà en cache restent affichées dans tous les cas. Les vidéos n'extraient qu'une image (pas de téléchargement complet).")
+            }
+
+            Section("Cache des vignettes") {
+                LabeledContent("Taille") {
+                    Text(ByteCountFormatter.string(fromByteCount: cacheBytes, countStyle: .file))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+                Button(role: .destructive) {
+                    Task { await clearCache() }
+                } label: {
+                    HStack {
+                        Label("Vider le cache des vignettes", systemImage: "trash")
+                        if isClearing {
+                            Spacer()
+                            ProgressView().controlSize(.small)
+                        }
+                    }
+                }
+                .disabled(isClearing || cacheBytes == 0)
+            }
+        }
+        .navigationTitle("Vignettes")
+        #if os(iOS)
+        .rgInlineNavTitle()
+        #endif
+        .task { refreshSize() }
+    }
+
+    @ViewBuilder
+    private var headerCard: some View {
+        HStack(spacing: 14) {
+            AppIconTile(systemImage: "rectangle.grid.3x2.fill", tint: .teal, size: 54, iconSize: .title2)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Vignettes de la galerie")
+                    .font(.headline)
+                Text("Contrôle quand les miniatures images/vidéos sont générées et la taille du cache.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+            Spacer(minLength: 8)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background, in: .rect(cornerRadius: 16, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(.quaternary)
+        }
+    }
+
+    private func refreshSize() {
+        cacheBytes = ThumbnailService.cacheSizeBytes()
+    }
+
+    private func clearCache() async {
+        isClearing = true
+        defer { isClearing = false }
+        await ThumbnailService.shared.clearCache()
+        refreshSize()
+    }
+}


### PR DESCRIPTION
Transforme le navigateur en vrai navigateur média.

**UI**
- Toggle **Liste / Grille** dans chaque dossier (toolbar, préférence mémorisée) + filtre **Médias uniquement** (mode galerie type Photos).
- `MediaGridCell` : vignette paresseuse (cellules visibles), placeholder icône, badge lecture vidéo.

**Vignettes** (`ThumbnailService`)
- Images : downsampling ImageIO. Vidéos : `AVAssetImageGenerator` sur le bridge **loopback live** (1 image, pas de download complet).
- Cache mémoire LRU + disque (JPEG, clé SHA-256). Concurrence bornée, plafond de taille images.
- `RcloneStreamingService.liveSession()` : bridge-only (jamais de téléchargement complet pour une vignette).

**Données** (Réglages → Stockage → **Vignettes**)
- Politique **Wi-Fi seulement** (défaut) / Toujours / Jamais via `NetworkReachability` (NWPathMonitor). Cache servi en toutes circonstances.

API système validées par **typecheck local** (0 erreur/0 warning). Reste à valider par Xcode Cloud (intégration module app).