### PR TITLE
chore: gitignore clé API ASC (.p8) + captures jpg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ Pods/
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
+fastlane/screenshots/**/*.jpg
+fastlane/screenshots/**/*.jpeg
 fastlane/test_output
 
 # --- Rclone build artifacts ---------------------------------------------
@@ -54,3 +56,8 @@ Frameworks/RcloneKit.xcframework/
 .smoke-test-cache
 
 RcloneFileProviderUI/RcloneKit.xcframework/
+
+# App Store Connect API key (secret, never commit)
+fastlane/.appstore-key.p8
+fastlane/*.p8
+*.p8


### PR DESCRIPTION
Durcissement .gitignore : la clé App Store Connect `.p8` n'était pas couverte (le Fastfile la disait pourtant gitignorée), et les captures `.jpg/.jpeg` rejoignent les `.png` déjà ignorées.