### PR TITLE
chore(fastlane): lanes metadata ciblent 1.5

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :ios do
   lane :upload_metadata do
     deliver(
       api_key: asc_key,
-      app_version: "1.4",    # cible explicitement la version 1.4 (ne touche pas la 1.3 en ligne)
+      app_version: "1.5",    # cible explicitement la version 1.5 (ne touche pas la 1.4 en revue)
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: false,
@@ -181,7 +181,7 @@ platform :mac do
     deliver(
       api_key: asc_key,
       platform: "osx",
-      app_version: "1.4",
+      app_version: "1.5",
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: false,
@@ -197,7 +197,7 @@ platform :mac do
       api_key: asc_key,
       platform: "osx",
       screenshots_path: "./fastlane/screenshots-mac",
-      app_version: "1.4",
+      app_version: "1.5",
       skip_binary_upload: true,
       skip_metadata: true,
       skip_screenshots: false,
@@ -212,7 +212,7 @@ platform :mac do
     deliver(
       api_key: asc_key,
       platform: "osx",
-      app_version: "1.4",
+      app_version: "1.5",
       submit_for_review: true,
       automatic_release: false,
       skip_binary_upload: true,


### PR DESCRIPTION
Bascule app_version 1.4 → 1.5 dans upload_metadata / upload_mac_metadata / upload_mac_screenshots / submit_mac. Versions 1.5 iOS + macOS déjà créées sur ASC + métadonnées poussées.