### PR TITLE
chore(review): note 2.5.4 (background audio retiré)

### DIFF
--- a/fastlane/metadata/review_information/notes.txt
+++ b/fastlane/metadata/review_information/notes.txt
@@ -8,6 +8,7 @@ HOW TO TEST
 5. From the iOS Files app, the same remotes appear under "Rclone GUI" — open a file directly from there.
 
 NOTES FOR APP REVIEW
+- Guideline 2.5.4 (background audio): This build does NOT declare the "audio" UIBackgroundMode. The app's UIBackgroundModes contains only "remote-notification", "fetch" and "processing" — there is no "audio" entry. The app does not require persistent background audio; the previous build that included "audio" has been corrected in this build. Please verify the Info.plist UIBackgroundModes key.
 - The localhost HTTP server (127.0.0.1) declared in NSLocalNetworkUsageDescription is used solely to feed AVPlayer with decrypted bytes from rclone crypt streams. No traffic leaves the device.
 - The app uses only open-source standard cryptography (rclone crypt = NaCl secretbox / XSalsa20-Poly1305, AES-256-GCM in TLS). ITSAppUsesNonExemptEncryption is therefore set to false under the standard-encryption exemption.
 - No content is hosted by the developer; the app browses cloud accounts that the user owns.


### PR DESCRIPTION
Note App Review : le build ne déclare plus le mode `audio` (UIBackgroundModes = remote-notification, fetch, processing). Déjà poussée sur ASC via fastlane ; commit pour cohérence du dépôt.