### PR TITLE
feat(site): version 1.5 — historique des versions, FAQ, écrans lecteur vidéo + galerie

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,4 +1,3 @@
-function _extends() { return _extends = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends.apply(null, arguments); }
 /* ════════════════════════════════════════════════════════════════════
    Config
    ════════════════════════════════════════════════════════════════════ */
@@ -84,10 +83,11 @@ const Icon = ({
         d: "M7.5 10.5V7a4.5 4.5 0 1 1 9 0v3.5"
       }));
     case 'lock.fill':
-      return /*#__PURE__*/React.createElement("svg", _extends({}, common, {
+      return /*#__PURE__*/React.createElement("svg", {
+        ...common,
         fill: "currentColor",
         stroke: "none"
-      }), /*#__PURE__*/React.createElement("path", {
+      }, /*#__PURE__*/React.createElement("path", {
         d: "M7.5 7a4.5 4.5 0 1 1 9 0v3.5h-2V7a2.5 2.5 0 0 0-5 0v3.5h-2V7Z"
       }), /*#__PURE__*/React.createElement("rect", {
         x: "4.5",
@@ -101,10 +101,11 @@ const Icon = ({
         d: "M7 18a4 4 0 0 1-.6-7.95 5.5 5.5 0 0 1 10.7-.7A4 4 0 0 1 17 18H7Z"
       }));
     case 'cloud.fill':
-      return /*#__PURE__*/React.createElement("svg", _extends({}, common, {
+      return /*#__PURE__*/React.createElement("svg", {
+        ...common,
         fill: "currentColor",
         stroke: "none"
-      }), /*#__PURE__*/React.createElement("path", {
+      }, /*#__PURE__*/React.createElement("path", {
         d: "M7 18a4 4 0 0 1-.6-7.95 5.5 5.5 0 0 1 10.7-.7A4 4 0 0 1 17 18H7Z"
       }));
     case 'folder':
@@ -112,10 +113,11 @@ const Icon = ({
         d: "M3.5 7.5A1.5 1.5 0 0 1 5 6h4l2 2h8a1.5 1.5 0 0 1 1.5 1.5v8A1.5 1.5 0 0 1 19 19H5a1.5 1.5 0 0 1-1.5-1.5v-10Z"
       }));
     case 'folder.fill':
-      return /*#__PURE__*/React.createElement("svg", _extends({}, common, {
+      return /*#__PURE__*/React.createElement("svg", {
+        ...common,
         fill: "currentColor",
         stroke: "currentColor"
-      }), /*#__PURE__*/React.createElement("path", {
+      }, /*#__PURE__*/React.createElement("path", {
         d: "M3.5 7.5A1.5 1.5 0 0 1 5 6h4l2 2h8a1.5 1.5 0 0 1 1.5 1.5v8A1.5 1.5 0 0 1 19 19H5a1.5 1.5 0 0 1-1.5-1.5v-10Z"
       }));
     case 'externaldrive':
@@ -180,10 +182,11 @@ const Icon = ({
         d: "M5 12.5l4.5 4.5L19 7.5"
       }));
     case 'check.circle':
-      return /*#__PURE__*/React.createElement("svg", _extends({}, common, {
+      return /*#__PURE__*/React.createElement("svg", {
+        ...common,
         fill: "currentColor",
         stroke: "none"
-      }), /*#__PURE__*/React.createElement("path", {
+      }, /*#__PURE__*/React.createElement("path", {
         d: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm-1.2 14L6.5 11.7l1.4-1.4 2.9 2.9 5.3-5.3 1.4 1.4-6.7 6.7Z"
       }));
     case 'plus':
@@ -215,10 +218,11 @@ const Icon = ({
         d: "M12 7v5l3 2"
       }));
     case 'bolt.fill':
-      return /*#__PURE__*/React.createElement("svg", _extends({}, common, {
+      return /*#__PURE__*/React.createElement("svg", {
+        ...common,
         fill: "currentColor",
         stroke: "none"
-      }), /*#__PURE__*/React.createElement("path", {
+      }, /*#__PURE__*/React.createElement("path", {
         d: "M14 2 5 13h6l-1 9 9-11h-6l1-9Z"
       }));
     case 'photo':
@@ -252,10 +256,11 @@ const Icon = ({
         d: "m7 18 4-4 3 3 2-2 5 5"
       }));
     case 'shield.fill':
-      return /*#__PURE__*/React.createElement("svg", _extends({}, common, {
+      return /*#__PURE__*/React.createElement("svg", {
+        ...common,
         fill: "currentColor",
         stroke: "none"
-      }), /*#__PURE__*/React.createElement("path", {
+      }, /*#__PURE__*/React.createElement("path", {
         d: "M12 3 4 6v6c0 5 3.5 8.5 8 9 4.5-.5 8-4 8-9V6l-8-3Zm-1.2 13L6.5 11.7 7.9 10.3 10.8 13.2 16.1 7.9 17.5 9.3 10.8 16Z"
       }));
     case 'faceid':
@@ -275,10 +280,11 @@ const Icon = ({
         d: "M14 3v5h5"
       }));
     case 'play.fill':
-      return /*#__PURE__*/React.createElement("svg", _extends({}, common, {
+      return /*#__PURE__*/React.createElement("svg", {
+        ...common,
         fill: "currentColor",
         stroke: "none"
-      }), /*#__PURE__*/React.createElement("path", {
+      }, /*#__PURE__*/React.createElement("path", {
         d: "M7 4.5v15l13-7.5L7 4.5Z"
       }));
     case 'download':
@@ -292,10 +298,11 @@ const Icon = ({
         d: "M5 12v7a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-7"
       }));
     case 'star.fill':
-      return /*#__PURE__*/React.createElement("svg", _extends({}, common, {
+      return /*#__PURE__*/React.createElement("svg", {
+        ...common,
         fill: "currentColor",
         stroke: "none"
-      }), /*#__PURE__*/React.createElement("path", {
+      }, /*#__PURE__*/React.createElement("path", {
         d: "m12 3 2.7 5.7 6.3.9-4.6 4.4 1.1 6.2L12 17.3l-5.5 2.9 1.1-6.2-4.6-4.4 6.3-.9L12 3Z"
       }));
     case 'wifi':
@@ -1364,7 +1371,7 @@ const ScreenFileDetail = () => {
       fontWeight: 700,
       letterSpacing: 0.4
     }
-  }, "4032 \xD7 3024"))), /*#__PURE__*/React.createElement("div", {
+  }, "4032 × 3024"))), /*#__PURE__*/React.createElement("div", {
     style: {
       padding: '14px 20px 4px'
     }
@@ -2311,6 +2318,428 @@ const ScreenSecurity = () => {
   }));
 };
 
+/* ─── v1.5 : Galerie en grille ─────────────────────────────────────── */
+const GALLERY_TILES = [{
+  v: false,
+  g: 'linear-gradient(135deg,#FFB088,#C44569)'
+}, {
+  v: true,
+  g: 'linear-gradient(135deg,#6C7BFF,#241452)',
+  d: '1:24'
+}, {
+  v: false,
+  g: 'linear-gradient(135deg,#34C759,#0E7A3A)'
+}, {
+  v: false,
+  g: 'linear-gradient(135deg,#0E5FAE,#093E70)'
+}, {
+  v: true,
+  g: 'linear-gradient(135deg,#FF2D55,#7A0E2A)',
+  d: '0:42'
+}, {
+  v: false,
+  g: 'linear-gradient(135deg,#FF9500,#A85E00)'
+}, {
+  v: false,
+  g: 'linear-gradient(135deg,#AF52DE,#5B21B6)'
+}, {
+  v: true,
+  g: 'linear-gradient(135deg,#16A085,#0B5345)',
+  d: '3:08'
+}, {
+  v: false,
+  g: 'linear-gradient(135deg,#FFD16B,#C98A00)'
+}, {
+  v: false,
+  g: 'linear-gradient(135deg,#FF6B6B,#8A2842)'
+}, {
+  v: true,
+  g: 'linear-gradient(135deg,#5AC8FA,#0E5FAE)',
+  d: '0:18'
+}, {
+  v: false,
+  g: 'linear-gradient(135deg,#BF5AF2,#6B1FB0)'
+}];
+const Segmented = ({
+  active
+}) => {
+  const items = [{
+    id: 'list',
+    icon: 'tray'
+  }, {
+    id: 'grid',
+    icon: 'photo.stack'
+  }];
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: 'inline-flex',
+      background: 'rgba(118,118,128,0.16)',
+      borderRadius: 9,
+      padding: 2
+    }
+  }, items.map(it => /*#__PURE__*/React.createElement("div", {
+    key: it.id,
+    style: {
+      width: 38,
+      height: 30,
+      borderRadius: 7,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: it.id === active ? '#fff' : 'transparent',
+      color: it.id === active ? ACCENT : '#8E8E93',
+      boxShadow: it.id === active ? '0 1px 3px rgba(0,0,0,0.18)' : 'none'
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: it.icon,
+    size: 17,
+    weight: "semibold"
+  }))));
+};
+const ScreenGallery = () => {
+  const t = useT();
+  return /*#__PURE__*/React.createElement(ScreenFrame, {
+    bg: "#F2F2F7"
+  }, /*#__PURE__*/React.createElement(StatusBar, null), /*#__PURE__*/React.createElement("div", {
+    style: {
+      padding: '6px 16px 8px',
+      display: 'flex',
+      alignItems: 'center',
+      gap: 6,
+      color: ACCENT,
+      fontSize: 16,
+      fontWeight: 500
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "chevron.right",
+    size: 16,
+    weight: "semibold",
+    style: {
+      transform: 'rotate(180deg)'
+    }
+  }), /*#__PURE__*/React.createElement("span", null, "Remotes")), /*#__PURE__*/React.createElement("div", {
+    style: {
+      padding: '2px 20px 0',
+      display: 'flex',
+      alignItems: 'flex-end',
+      justifyContent: 'space-between'
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8
+    }
+  }, /*#__PURE__*/React.createElement(BackendChip, {
+    kind: "b2",
+    cryptOverlay: true,
+    size: 34
+  }), /*#__PURE__*/React.createElement("h1", {
+    style: {
+      fontSize: 26,
+      fontWeight: 700,
+      letterSpacing: -0.5,
+      margin: 0
+    }
+  }, t('Galerie', 'Gallery'))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      paddingBottom: 4
+    }
+  }, /*#__PURE__*/React.createElement(Segmented, {
+    active: "grid"
+  }))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      padding: '10px 16px 0',
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 6,
+      background: ACCENT,
+      color: '#fff',
+      padding: '6px 12px',
+      borderRadius: 999,
+      fontSize: 13,
+      fontWeight: 700
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "photo.stack",
+    size: 14,
+    weight: "bold"
+  }), t('Médias uniquement', 'Media only')), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 13,
+      color: '#8E8E93',
+      fontWeight: 500
+    }
+  }, t('86 photos · 12 vidéos', '86 photos · 12 videos'))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      padding: '12px 16px 0',
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, 1fr)',
+      gap: 6
+    }
+  }, GALLERY_TILES.map((tile, i) => /*#__PURE__*/React.createElement("div", {
+    key: i,
+    style: {
+      position: 'relative',
+      aspectRatio: '1/1',
+      borderRadius: 10,
+      overflow: 'hidden',
+      background: tile.g
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      inset: 0,
+      background: 'radial-gradient(ellipse at 30% 20%, rgba(255,255,255,0.25), transparent 55%)'
+    }
+  }), tile.v && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      top: 6,
+      left: 6,
+      width: 22,
+      height: 22,
+      borderRadius: '50%',
+      background: 'rgba(0,0,0,0.42)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: '#fff'
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "play.fill",
+    size: 10
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      bottom: 5,
+      right: 6,
+      fontSize: 10,
+      fontWeight: 700,
+      color: '#fff',
+      textShadow: '0 1px 3px rgba(0,0,0,0.5)'
+    }
+  }, tile.d))))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      flex: 1
+    }
+  }), /*#__PURE__*/React.createElement(TabBar, {
+    active: "remotes"
+  }));
+};
+
+/* ─── v1.5 : Lecteur vidéo intégré ─────────────────────────────────── */
+const ScreenPlayer = () => {
+  const t = useT();
+  return /*#__PURE__*/React.createElement(ScreenFrame, {
+    bg: "#0A0A0F"
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      inset: 0,
+      background: 'linear-gradient(160deg, #3A2A6E 0%, #1A1030 52%, #0A0A0F 100%)'
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      inset: 0,
+      background: 'radial-gradient(ellipse at 50% 36%, rgba(124,58,237,0.5), transparent 62%)'
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'relative',
+      padding: '56px 22px 0',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      color: '#fff'
+    }
+  }, /*#__PURE__*/React.createElement("span", {
+    style: {
+      fontSize: 16,
+      fontWeight: 600
+    }
+  }, t('OK', 'Done')), /*#__PURE__*/React.createElement("div", {
+    style: {
+      textAlign: 'center',
+      minWidth: 0,
+      flex: 1,
+      padding: '0 12px'
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 15,
+      fontWeight: 600,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap'
+    }
+  }, "sunset-timelapse.mkv"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      opacity: 0.7,
+      marginTop: 2
+    }
+  }, t('media · Crypt sur B2', 'media · Crypt on B2'))), /*#__PURE__*/React.createElement("span", {
+    style: {
+      fontSize: 11,
+      fontWeight: 800,
+      letterSpacing: 0.6,
+      padding: '4px 8px',
+      borderRadius: 6,
+      background: 'rgba(255,255,255,0.18)'
+    }
+  }, "VLC")), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'relative',
+      flex: 1,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 34,
+      color: '#fff'
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      opacity: 0.85
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "rotate",
+    size: 26,
+    weight: "semibold",
+    style: {
+      transform: 'scaleX(-1)'
+    }
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      width: 84,
+      height: 84,
+      borderRadius: '50%',
+      background: 'rgba(255,255,255,0.16)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      border: '1px solid rgba(255,255,255,0.25)'
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "play.fill",
+    size: 36
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      opacity: 0.85
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "rotate",
+    size: 26,
+    weight: "semibold"
+  }))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'relative',
+      display: 'flex',
+      justifyContent: 'center',
+      paddingBottom: 14
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 7,
+      background: 'rgba(255,255,255,0.16)',
+      color: '#fff',
+      padding: '8px 14px',
+      borderRadius: 999,
+      fontSize: 13,
+      fontWeight: 600
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "clock",
+    size: 14
+  }), t('Reprendre à 12:34', 'Resume at 12:34'))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'relative',
+      padding: '0 22px 40px',
+      color: '#fff'
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      height: 5,
+      borderRadius: 3,
+      background: 'rgba(255,255,255,0.25)',
+      position: 'relative'
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      width: '42%',
+      height: '100%',
+      borderRadius: 3,
+      background: '#fff'
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: 'absolute',
+      left: '42%',
+      top: '50%',
+      transform: 'translate(-50%,-50%)',
+      width: 13,
+      height: 13,
+      borderRadius: '50%',
+      background: '#fff',
+      boxShadow: '0 2px 6px rgba(0,0,0,0.4)'
+    }
+  })), /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      fontSize: 12,
+      opacity: 0.85,
+      marginTop: 7
+    }
+  }, /*#__PURE__*/React.createElement("span", null, "12:34"), /*#__PURE__*/React.createElement("span", null, "-27:46")), /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginTop: 18
+    }
+  }, [{
+    icon: 'doc',
+    label: t('Sous-titres', 'Subtitles')
+  }, {
+    icon: 'music',
+    label: t('Audio', 'Audio')
+  }, {
+    icon: 'speedometer',
+    label: '1.0×'
+  }, {
+    icon: 'share',
+    label: t('Externe', 'External')
+  }].map(b => /*#__PURE__*/React.createElement("div", {
+    key: b.label,
+    style: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: 5,
+      opacity: 0.92
+    }
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: b.icon,
+    size: 20,
+    weight: "semibold"
+  }), /*#__PURE__*/React.createElement("span", {
+    style: {
+      fontSize: 10,
+      fontWeight: 600
+    }
+  }, b.label))))));
+};
+
 /* ════════════════════════════════════════════════════════════════════
    Shots (palettes + headlines repris de app.jsx)
    ════════════════════════════════════════════════════════════════════ */
@@ -2402,6 +2831,32 @@ const SHOTS = [{
     s: 'Photos, video, PDF — opened straight from Files.'
   }
 }, {
+  id: 'player',
+  Screen: ScreenPlayer,
+  palette: 'midnight',
+  isNew: true,
+  fr: {
+    h: 'Lecteur vidéo\nintégré.',
+    s: 'MKV, AVI, WebM, TS… Sous-titres, pistes audio, reprise. Dans l\'app ou en externe.'
+  },
+  en: {
+    h: 'Built-in\nvideo player.',
+    s: 'MKV, AVI, WebM, TS… Subtitles, audio tracks, resume. In-app or external.'
+  }
+}, {
+  id: 'gallery',
+  Screen: ScreenGallery,
+  palette: 'forest',
+  isNew: true,
+  fr: {
+    h: 'Une vraie\ngalerie médias.',
+    s: 'Vue grille avec vignettes images & vidéos. Liste ou grille, mode « Médias ».'
+  },
+  en: {
+    h: 'A real media\ngallery.',
+    s: 'Grid view with photo & video thumbnails. List or grid, "Media only" mode.'
+  }
+}, {
   id: 'home',
   Screen: ScreenHome,
   palette: 'cream',
@@ -2479,35 +2934,44 @@ const AppStoreBadge = () => {
 const Header = ({
   lang,
   setLang
-}) => /*#__PURE__*/React.createElement("header", {
-  className: "nav"
-}, /*#__PURE__*/React.createElement("div", {
-  className: "wrap nav-in"
-}, /*#__PURE__*/React.createElement("a", {
-  className: "brand",
-  href: "#top"
-}, /*#__PURE__*/React.createElement("img", {
-  src: "icon.png",
-  alt: "Rclone GUI"
-}), "Rclone GUI"), /*#__PURE__*/React.createElement("div", {
-  className: "nav-sp"
-}), /*#__PURE__*/React.createElement("a", {
-  className: "ghost",
-  href: GITHUB_URL,
-  target: "_blank",
-  rel: "noopener",
-  style: {
-    marginRight: 6
-  }
-}, "GitHub"), /*#__PURE__*/React.createElement("div", {
-  className: "lang"
-}, /*#__PURE__*/React.createElement("button", {
-  className: lang === 'en' ? 'on' : '',
-  onClick: () => setLang('en')
-}, "EN"), /*#__PURE__*/React.createElement("button", {
-  className: lang === 'fr' ? 'on' : '',
-  onClick: () => setLang('fr')
-}, "FR"))));
+}) => {
+  const t = useT();
+  return /*#__PURE__*/React.createElement("header", {
+    className: "nav"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "wrap nav-in"
+  }, /*#__PURE__*/React.createElement("a", {
+    className: "brand",
+    href: "#top"
+  }, /*#__PURE__*/React.createElement("img", {
+    src: "icon.png",
+    alt: "Rclone GUI"
+  }), "Rclone GUI"), /*#__PURE__*/React.createElement("div", {
+    className: "nav-sp"
+  }), /*#__PURE__*/React.createElement("a", {
+    className: "ghost navlink",
+    href: "#versions"
+  }, t('Nouveautés', 'What\'s new')), /*#__PURE__*/React.createElement("a", {
+    className: "ghost navlink",
+    href: "#faq"
+  }, "FAQ"), /*#__PURE__*/React.createElement("a", {
+    className: "ghost",
+    href: GITHUB_URL,
+    target: "_blank",
+    rel: "noopener",
+    style: {
+      marginRight: 6
+    }
+  }, "GitHub"), /*#__PURE__*/React.createElement("div", {
+    className: "lang"
+  }, /*#__PURE__*/React.createElement("button", {
+    className: lang === 'en' ? 'on' : '',
+    onClick: () => setLang('en')
+  }, "EN"), /*#__PURE__*/React.createElement("button", {
+    className: lang === 'fr' ? 'on' : '',
+    onClick: () => setLang('fr')
+  }, "FR"))));
+};
 const Hero = () => {
   const t = useT();
   return /*#__PURE__*/React.createElement("section", {
@@ -2524,7 +2988,7 @@ const Hero = () => {
   }, /*#__PURE__*/React.createElement(Icon, {
     name: "bolt.fill",
     size: 14
-  }), t('v1.4 · ESSAI GRATUIT', 'v1.4 · FREE TRIAL'))), /*#__PURE__*/React.createElement("h1", {
+  }), t('v1.5 · ESSAI GRATUIT', 'v1.5 · FREE TRIAL'))), /*#__PURE__*/React.createElement("h1", {
     className: "title"
   }, ML(t('Tous vos clouds.\nChiffrés.', 'Every cloud.\nEncrypted.'))), /*#__PURE__*/React.createElement("p", {
     className: "sub"
@@ -2624,12 +3088,14 @@ const Gallery = ({
         background: `linear-gradient(180deg, ${p.from} 0%, ${p.to} 100%)`,
         color: ink
       }
-    }, /*#__PURE__*/React.createElement("div", {
+    }, s.isNew && /*#__PURE__*/React.createElement("span", {
+      className: "newtag"
+    }, t('NOUVEAU · v1.5', 'NEW · v1.5')), /*#__PURE__*/React.createElement("div", {
       className: "kick",
       style: {
         color: p.accent
       }
-    }, "RCLONE GUI \xB7 iOS"), /*#__PURE__*/React.createElement("h3", null, ML(copy.h)), /*#__PURE__*/React.createElement("p", {
+    }, "RCLONE GUI · iOS"), /*#__PURE__*/React.createElement("h3", null, ML(copy.h)), /*#__PURE__*/React.createElement("p", {
       className: "psub"
     }, copy.s), /*#__PURE__*/React.createElement("div", {
       className: "stage"
@@ -2839,7 +3305,7 @@ const FreeMonth = () => {
     className: "free"
   }, /*#__PURE__*/React.createElement("div", {
     className: "gift"
-  }, "\uD83C\uDF81"), /*#__PURE__*/React.createElement("h2", null, t('Un mois offert', 'One month free')), /*#__PURE__*/React.createElement("p", {
+  }, "🎁"), /*#__PURE__*/React.createElement("h2", null, t('Un mois offert', 'One month free')), /*#__PURE__*/React.createElement("p", {
     className: "lede"
   }, t('Un code App Store personnel, valable une fois, pour démarrer votre essai sans frais. Un par personne.', 'A personal, single-use App Store code to start your trial at no cost. One per person.')), /*#__PURE__*/React.createElement("div", {
     className: "claimbox"
@@ -2917,7 +3383,7 @@ const FreeMonth = () => {
       fontSize: 40,
       lineHeight: 1
     }
-  }, "\uD83D\uDCEC"), /*#__PURE__*/React.createElement("div", {
+  }, "📬"), /*#__PURE__*/React.createElement("div", {
     style: {
       fontSize: 20,
       fontWeight: 800,
@@ -2992,6 +3458,187 @@ const FreeMonth = () => {
     className: "n"
   }, s.n), /*#__PURE__*/React.createElement("h5", null, s.h), /*#__PURE__*/React.createElement("p", null, s.p)))))));
 };
+const VERSIONS = [{
+  v: '1.5',
+  current: true,
+  date: {
+    fr: 'Juin 2026',
+    en: 'June 2026'
+  },
+  items: [{
+    fr: 'Lecteur vidéo intégré multi-format (MKV, AVI, WebM, TS…) : sous-titres intégrés et fichiers externes, pistes audio, reprise là où vous étiez.',
+    en: 'Built-in multi-format video player (MKV, AVI, WebM, TS…): embedded and sidecar subtitles, audio tracks, resume where you left off.'
+  }, {
+    fr: 'Au choix : lecture dans l\'app ou dans une app externe (Infuse, VLC).',
+    en: 'Your choice: play in-app or in an external app (Infuse, VLC).'
+  }, {
+    fr: 'Galerie en grille avec vignettes pour photos et vidéos : bascule liste/grille, mode « Médias uniquement », génération des vignettes en Wi-Fi par défaut.',
+    en: 'Grid gallery with thumbnails for photos and videos: list/grid toggle, "Media only" mode, Wi-Fi-only thumbnail generation by default.'
+  }, {
+    fr: 'Nouvelle option pour exclure les données de l\'app des sauvegardes iCloud.',
+    en: 'New option to exclude the app\'s data from iCloud backups.'
+  }, {
+    fr: 'Stabilité et performances.',
+    en: 'Stability and performance improvements.'
+  }]
+}, {
+  v: '1.4',
+  date: {
+    fr: 'Juin 2026',
+    en: 'June 2026'
+  },
+  items: [{
+    fr: 'Nouveaux clouds : Drime, Internxt et Filen (Internxt et Filen chiffrés de bout en bout).',
+    en: 'New clouds: Drime, Internxt and Filen (Internxt and Filen are end-to-end encrypted).'
+  }, {
+    fr: 'Panneau « où trouver vos identifiants » pour Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage…',
+    en: '"Where to get your credentials" panel for Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage…'
+  }, {
+    fr: 'Sélecteur de stockage pour les remotes composites (alias, union, combine) — fini la saisie manuelle de « remote:chemin ».',
+    en: 'Storage picker for composite remotes (alias, union, combine) — no more typing "remote:path" by hand.'
+  }, {
+    fr: 'Correction de la connexion aux remotes protégés par mot de passe (SFTP, FTP, WebDAV, SMB…).',
+    en: 'Fixed connecting to password-protected remotes (SFTP, FTP, WebDAV, SMB…).'
+  }, {
+    fr: 'Remotes verrouillés masqués des Récents et Favoris.',
+    en: 'Locked remotes hidden from Recents and Favorites.'
+  }]
+}, {
+  v: '1.3',
+  date: {
+    fr: 'Juin 2026',
+    en: 'June 2026'
+  },
+  items: [{
+    fr: 'Correctif important : l\'import d\'une configuration rclone chiffrée par mot de passe ne plante plus.',
+    en: 'Important fix: importing a password-encrypted rclone configuration no longer crashes the app.'
+  }, {
+    fr: 'Bouton « J\'ai un code » pour utiliser des codes promo.',
+    en: '"I have a code" button to redeem promo codes.'
+  }, {
+    fr: 'Page « Contacter le développeur » dans Réglages → Support.',
+    en: '"Contact the Developer" page in Settings → Support.'
+  }, {
+    fr: 'Traduction anglaise complète de l\'app + code source désormais public sur GitHub.',
+    en: 'Completed English translation across the whole app + source code now public on GitHub.'
+  }]
+}, {
+  v: '1.2',
+  date: {
+    fr: 'Juin 2026',
+    en: 'June 2026'
+  },
+  items: [{
+    fr: 'App macOS native (Mac Apple Silicon) : barre latérale et intégration Finder.',
+    en: 'Native macOS app (Apple Silicon Macs): sidebar layout and Finder integration.'
+  }, {
+    fr: 'Assistant guidé pour les remotes chiffrés (crypt) : choix du stockage, navigation jusqu\'au dossier, mot de passe — sans saisie de chemin.',
+    en: 'Guided wizard for encrypted (crypt) remotes: pick storage, browse to the folder, set a password — no manual path typing.'
+  }, {
+    fr: 'Assistant d\'ajout amélioré : bouton Retour et sélecteur de fichier natif pour importer rclone.conf.',
+    en: 'Improved add-remote wizard: Back button and native file picker to import rclone.conf.'
+  }]
+}, {
+  v: '1.1',
+  date: {
+    fr: 'Mai 2026',
+    en: 'May 2026'
+  },
+  items: [{
+    fr: 'Localisation anglaise complète : l\'interface suit la langue de l\'appareil.',
+    en: 'Full English localization: the interface follows your device language.'
+  }, {
+    fr: 'Première ouverture plus fluide, stabilité et finitions.',
+    en: 'Smoother first-launch, stability and polish.'
+  }]
+}, {
+  v: '1.0',
+  date: {
+    fr: 'Mai 2026',
+    en: 'May 2026'
+  },
+  items: [{
+    fr: 'Première version publique : client rclone natif, 70+ backends, intégration Fichiers (File Provider), chiffrement crypt de bout en bout, sync photo, Face ID, zéro tracking.',
+    en: 'First public release: native rclone client, 70+ backends, Files integration (File Provider), end-to-end crypt encryption, photo sync, Face ID, zero tracking.'
+  }]
+}];
+const Versions = () => {
+  const t = useT();
+  const lang = React.useContext(LangContext);
+  return /*#__PURE__*/React.createElement("section", {
+    id: "versions"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "wrap"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "eyebrow"
+  }, t('Nouveautés', 'What\'s new')), /*#__PURE__*/React.createElement("h2", {
+    className: "sec"
+  }, t('Chaque version, en mieux', 'Every release, better')), /*#__PURE__*/React.createElement("p", {
+    className: "sec-sub"
+  }, t('L\'historique complet des mises à jour et ce qu\'elles apportent.', 'The full update history and what each one adds.')), /*#__PURE__*/React.createElement("div", {
+    className: "versions"
+  }, VERSIONS.map(rel => /*#__PURE__*/React.createElement("div", {
+    key: rel.v,
+    className: rel.current ? 'ver current' : 'ver'
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "ver-head"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "ver-num"
+  }, t('Version ', 'Version '), rel.v), /*#__PURE__*/React.createElement("span", {
+    className: "ver-date"
+  }, rel.date[lang] || rel.date.en), rel.current && /*#__PURE__*/React.createElement("span", {
+    className: "ver-tag"
+  }, t('ACTUELLE', 'CURRENT'))), /*#__PURE__*/React.createElement("ul", {
+    className: "ver-list"
+  }, rel.items.map((it, i) => /*#__PURE__*/React.createElement("li", {
+    key: i
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "check.circle",
+    size: 18
+  }), it[lang] || it.en))))))));
+};
+const FAQ = () => {
+  const t = useT();
+  const items = [{
+    q: t('Rclone GUI est-il gratuit ?', 'Is Rclone GUI free?'),
+    a: t('Il y a un essai gratuit (1 mois via un code personnel sur ce site). Ensuite, un achat unique à vie de 29,99 € (iPhone + iPad + Mac) ou un abonnement dès 2,99 €/mois (11,99 €/an). L\'app est aussi open source : vous pouvez la compiler vous-même gratuitement.', 'There is a free trial (1 month via a personal code on this site). After that, a one-time lifetime purchase of €29.99 (iPhone + iPad + Mac) or a subscription from €2.99/month (€11.99/year). It is also open source, so you can build it yourself for free.')
+  }, {
+    q: t('Quels services cloud sont pris en charge ?', 'Which cloud services are supported?'),
+    a: t('Plus de 80 backends via le moteur rclone : Amazon S3, Cloudflare R2, Google Drive, Dropbox, OneDrive, Backblaze B2, SFTP, WebDAV, Storj, Wasabi, Drime, Internxt, Filen, et bien d\'autres.', '80+ backends through the rclone engine: Amazon S3, Cloudflare R2, Google Drive, Dropbox, OneDrive, Backblaze B2, SFTP, WebDAV, Storj, Wasabi, Drime, Internxt, Filen and many more.')
+  }, {
+    q: t('Quels formats vidéo puis-je lire ? (v1.5)', 'Which video formats can I play? (v1.5)'),
+    a: t('Le lecteur intégré est multi-format : MP4, MOV, M4V, mais aussi MKV, AVI, WebM, TS et plus, grâce à un moteur hybride. Sous-titres (intégrés et fichiers externes) et pistes audio inclus. Vous pouvez aussi ouvrir la vidéo dans une app externe (Infuse, VLC).', 'The built-in player is multi-format: MP4, MOV, M4V, plus MKV, AVI, WebM, TS and more, thanks to a hybrid engine. Subtitles (embedded and sidecar files) and audio tracks included. You can also open videos in an external app (Infuse, VLC).')
+  }, {
+    q: t('Mes données sont-elles privées et chiffrées ?', 'Is my data private and encrypted?'),
+    a: t('Oui. Le chiffrement rclone « crypt » est natif, avec déchiffrement des noms à la volée ; vos clés ne quittent jamais l\'appareil. Aucun tracker, aucun serveur backend. Vous pouvez aussi exclure les données de l\'app des sauvegardes iCloud (v1.5).', 'Yes. rclone "crypt" encryption is native, with on-the-fly filename decryption; your keys never leave the device. No trackers, no backend server. You can also exclude the app\'s data from iCloud backups (v1.5).')
+  }, {
+    q: t('Fonctionne-t-il sur Mac et iPad ?', 'Does it work on Mac and iPad?'),
+    a: t('Oui : iPhone, iPad et Mac (Apple Silicon, app native depuis la v1.2). L\'achat à vie couvre les trois plateformes.', 'Yes: iPhone, iPad and Mac (Apple Silicon, native app since v1.2). The lifetime purchase covers all three platforms.')
+  }, {
+    q: t('Comment obtenir une réduction ?', 'How can I get a discount?'),
+    a: t('Étudiant·e, emploi précaire, chômage ou budget serré ? Écrivez au développeur pour un code adapté à vos moyens — sans justificatif.', 'Student, precarious job, unemployed or on a tight budget? Email the developer for a code based on what you can afford — no proof required.')
+  }, {
+    q: t('Est-ce open source ?', 'Is it open source?'),
+    a: t('Oui, sous licence MPL-2.0 et auditable sur GitHub. Aucun serveur backend, aucune analytics.', 'Yes, under the MPL-2.0 license and auditable on GitHub. No backend server, no analytics.')
+  }];
+  return /*#__PURE__*/React.createElement("section", {
+    id: "faq"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "wrap"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "eyebrow"
+  }, t('Questions', 'Questions')), /*#__PURE__*/React.createElement("h2", {
+    className: "sec"
+  }, t('Vos questions', 'Your questions')), /*#__PURE__*/React.createElement("p", {
+    className: "sec-sub"
+  }, t('Tout ce qu\'il faut savoir avant de vous lancer.', 'Everything you need to know before you start.')), /*#__PURE__*/React.createElement("div", {
+    className: "faq"
+  }, items.map((it, i) => /*#__PURE__*/React.createElement("details", {
+    className: "faq-item",
+    key: i,
+    open: i === 0
+  }, /*#__PURE__*/React.createElement("summary", null, it.q), /*#__PURE__*/React.createElement("p", null, it.a))))));
+};
 const Footer = () => {
   const t = useT();
   return /*#__PURE__*/React.createElement("footer", null, /*#__PURE__*/React.createElement("div", {
@@ -3012,6 +3659,10 @@ const Footer = () => {
   }), "Rclone GUI"), /*#__PURE__*/React.createElement("div", {
     className: "nav-sp"
   }), /*#__PURE__*/React.createElement("a", {
+    href: "#versions"
+  }, t('Nouveautés', 'What\'s new')), /*#__PURE__*/React.createElement("a", {
+    href: "#faq"
+  }, "FAQ"), /*#__PURE__*/React.createElement("a", {
     href: APP_STORE_URL,
     target: "_blank",
     rel: "noopener"
@@ -3038,6 +3689,6 @@ const App = () => {
     setLang: setLang
   }), /*#__PURE__*/React.createElement(Hero, null), /*#__PURE__*/React.createElement(Gallery, {
     lang: lang
-  }), /*#__PURE__*/React.createElement(Features, null), /*#__PURE__*/React.createElement(Pricing, null), /*#__PURE__*/React.createElement(FreeMonth, null), /*#__PURE__*/React.createElement(Footer, null));
+  }), /*#__PURE__*/React.createElement(Features, null), /*#__PURE__*/React.createElement(Versions, null), /*#__PURE__*/React.createElement(Pricing, null), /*#__PURE__*/React.createElement(FreeMonth, null), /*#__PURE__*/React.createElement(FAQ, null), /*#__PURE__*/React.createElement(Footer, null));
 };
 ReactDOM.createRoot(document.getElementById('root')).render(/*#__PURE__*/React.createElement(App, null));

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -542,6 +542,113 @@ const ScreenSecurity = () => {
   </ScreenFrame>);
 };
 
+/* ─── v1.5 : Galerie en grille ─────────────────────────────────────── */
+const GALLERY_TILES = [
+  { v:false, g:'linear-gradient(135deg,#FFB088,#C44569)' },
+  { v:true,  g:'linear-gradient(135deg,#6C7BFF,#241452)', d:'1:24' },
+  { v:false, g:'linear-gradient(135deg,#34C759,#0E7A3A)' },
+  { v:false, g:'linear-gradient(135deg,#0E5FAE,#093E70)' },
+  { v:true,  g:'linear-gradient(135deg,#FF2D55,#7A0E2A)', d:'0:42' },
+  { v:false, g:'linear-gradient(135deg,#FF9500,#A85E00)' },
+  { v:false, g:'linear-gradient(135deg,#AF52DE,#5B21B6)' },
+  { v:true,  g:'linear-gradient(135deg,#16A085,#0B5345)', d:'3:08' },
+  { v:false, g:'linear-gradient(135deg,#FFD16B,#C98A00)' },
+  { v:false, g:'linear-gradient(135deg,#FF6B6B,#8A2842)' },
+  { v:true,  g:'linear-gradient(135deg,#5AC8FA,#0E5FAE)', d:'0:18' },
+  { v:false, g:'linear-gradient(135deg,#BF5AF2,#6B1FB0)' },
+];
+const Segmented = ({ active }) => {
+  const items = [{ id:'list', icon:'tray' }, { id:'grid', icon:'photo.stack' }];
+  return (
+    <div style={{ display:'inline-flex', background:'rgba(118,118,128,0.16)', borderRadius:9, padding:2 }}>
+      {items.map(it => (
+        <div key={it.id} style={{ width:38, height:30, borderRadius:7, display:'flex', alignItems:'center', justifyContent:'center',
+          background:it.id===active ? '#fff' : 'transparent', color:it.id===active ? ACCENT : '#8E8E93',
+          boxShadow:it.id===active ? '0 1px 3px rgba(0,0,0,0.18)' : 'none' }}>
+          <Icon name={it.icon} size={17} weight="semibold"/>
+        </div>
+      ))}
+    </div>
+  );
+};
+const ScreenGallery = () => {
+  const t = useT();
+  return (
+  <ScreenFrame bg="#F2F2F7">
+    <StatusBar/>
+    <div style={{ padding:'6px 16px 8px', display:'flex', alignItems:'center', gap:6, color:ACCENT, fontSize:16, fontWeight:500 }}><Icon name="chevron.right" size={16} weight="semibold" style={{ transform:'rotate(180deg)' }}/><span>Remotes</span></div>
+    <div style={{ padding:'2px 20px 0', display:'flex', alignItems:'flex-end', justifyContent:'space-between' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:8 }}><BackendChip kind="b2" cryptOverlay={true} size={34}/><h1 style={{ fontSize:26, fontWeight:700, letterSpacing:-0.5, margin:0 }}>{t('Galerie','Gallery')}</h1></div>
+      <div style={{ paddingBottom:4 }}><Segmented active="grid"/></div>
+    </div>
+    <div style={{ padding:'10px 16px 0', display:'flex', alignItems:'center', gap:8 }}>
+      <div style={{ display:'inline-flex', alignItems:'center', gap:6, background:ACCENT, color:'#fff', padding:'6px 12px', borderRadius:999, fontSize:13, fontWeight:700 }}><Icon name="photo.stack" size={14} weight="bold"/>{t('Médias uniquement','Media only')}</div>
+      <div style={{ fontSize:13, color:'#8E8E93', fontWeight:500 }}>{t('86 photos · 12 vidéos','86 photos · 12 videos')}</div>
+    </div>
+    <div style={{ padding:'12px 16px 0', display:'grid', gridTemplateColumns:'repeat(3, 1fr)', gap:6 }}>
+      {GALLERY_TILES.map((tile, i) => (
+        <div key={i} style={{ position:'relative', aspectRatio:'1/1', borderRadius:10, overflow:'hidden', background:tile.g }}>
+          <div style={{ position:'absolute', inset:0, background:'radial-gradient(ellipse at 30% 20%, rgba(255,255,255,0.25), transparent 55%)' }}/>
+          {tile.v && (
+            <>
+              <div style={{ position:'absolute', top:6, left:6, width:22, height:22, borderRadius:'50%', background:'rgba(0,0,0,0.42)', display:'flex', alignItems:'center', justifyContent:'center', color:'#fff' }}><Icon name="play.fill" size={10}/></div>
+              <div style={{ position:'absolute', bottom:5, right:6, fontSize:10, fontWeight:700, color:'#fff', textShadow:'0 1px 3px rgba(0,0,0,0.5)' }}>{tile.d}</div>
+            </>
+          )}
+        </div>
+      ))}
+    </div>
+    <div style={{ flex:1 }}/>
+    <TabBar active="remotes"/>
+  </ScreenFrame>);
+};
+
+/* ─── v1.5 : Lecteur vidéo intégré ─────────────────────────────────── */
+const ScreenPlayer = () => {
+  const t = useT();
+  return (
+  <ScreenFrame bg="#0A0A0F">
+    <div style={{ position:'absolute', inset:0, background:'linear-gradient(160deg, #3A2A6E 0%, #1A1030 52%, #0A0A0F 100%)' }}/>
+    <div style={{ position:'absolute', inset:0, background:'radial-gradient(ellipse at 50% 36%, rgba(124,58,237,0.5), transparent 62%)' }}/>
+    <div style={{ position:'relative', padding:'56px 22px 0', display:'flex', alignItems:'center', justifyContent:'space-between', color:'#fff' }}>
+      <span style={{ fontSize:16, fontWeight:600 }}>{t('OK','Done')}</span>
+      <div style={{ textAlign:'center', minWidth:0, flex:1, padding:'0 12px' }}>
+        <div style={{ fontSize:15, fontWeight:600, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>sunset-timelapse.mkv</div>
+        <div style={{ fontSize:11, opacity:0.7, marginTop:2 }}>{t('media · Crypt sur B2','media · Crypt on B2')}</div>
+      </div>
+      <span style={{ fontSize:11, fontWeight:800, letterSpacing:0.6, padding:'4px 8px', borderRadius:6, background:'rgba(255,255,255,0.18)' }}>VLC</span>
+    </div>
+    <div style={{ position:'relative', flex:1, display:'flex', alignItems:'center', justifyContent:'center', gap:34, color:'#fff' }}>
+      <div style={{ opacity:0.85 }}><Icon name="rotate" size={26} weight="semibold" style={{ transform:'scaleX(-1)' }}/></div>
+      <div style={{ width:84, height:84, borderRadius:'50%', background:'rgba(255,255,255,0.16)', display:'flex', alignItems:'center', justifyContent:'center', border:'1px solid rgba(255,255,255,0.25)' }}><Icon name="play.fill" size={36}/></div>
+      <div style={{ opacity:0.85 }}><Icon name="rotate" size={26} weight="semibold"/></div>
+    </div>
+    <div style={{ position:'relative', display:'flex', justifyContent:'center', paddingBottom:14 }}>
+      <div style={{ display:'inline-flex', alignItems:'center', gap:7, background:'rgba(255,255,255,0.16)', color:'#fff', padding:'8px 14px', borderRadius:999, fontSize:13, fontWeight:600 }}><Icon name="clock" size={14}/>{t('Reprendre à 12:34','Resume at 12:34')}</div>
+    </div>
+    <div style={{ position:'relative', padding:'0 22px 40px', color:'#fff' }}>
+      <div style={{ height:5, borderRadius:3, background:'rgba(255,255,255,0.25)', position:'relative' }}>
+        <div style={{ width:'42%', height:'100%', borderRadius:3, background:'#fff' }}/>
+        <div style={{ position:'absolute', left:'42%', top:'50%', transform:'translate(-50%,-50%)', width:13, height:13, borderRadius:'50%', background:'#fff', boxShadow:'0 2px 6px rgba(0,0,0,0.4)' }}/>
+      </div>
+      <div style={{ display:'flex', justifyContent:'space-between', fontSize:12, opacity:0.85, marginTop:7 }}><span>12:34</span><span>-27:46</span></div>
+      <div style={{ display:'flex', justifyContent:'space-between', alignItems:'center', marginTop:18 }}>
+        {[
+          { icon:'doc', label:t('Sous-titres','Subtitles') },
+          { icon:'music', label:t('Audio','Audio') },
+          { icon:'speedometer', label:'1.0×' },
+          { icon:'share', label:t('Externe','External') },
+        ].map(b => (
+          <div key={b.label} style={{ display:'flex', flexDirection:'column', alignItems:'center', gap:5, opacity:0.92 }}>
+            <Icon name={b.icon} size={20} weight="semibold"/>
+            <span style={{ fontSize:10, fontWeight:600 }}>{b.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </ScreenFrame>);
+};
+
 /* ════════════════════════════════════════════════════════════════════
    Shots (palettes + headlines repris de app.jsx)
    ════════════════════════════════════════════════════════════════════ */
@@ -558,6 +665,8 @@ const SHOTS = [
   { id:'backends', Screen:ScreenRemotes, palette:'ocean', fr:{h:'80+ services.\nUn seul endroit.', s:'S3, R2, Drive, Dropbox, B2, SFTP, WebDAV, Storj, Wasabi…'}, en:{h:'80+ services.\nOne home.', s:'S3, R2, Drive, Dropbox, B2, SFTP, WebDAV, Storj, Wasabi…'} },
   { id:'crypt-paths', Screen:ScreenFolder, palette:'violet', fr:{h:'Noms déchiffrés\nà la volée.', s:'Aucun transit en clair. AES-256 + NaCl secretbox.'}, en:{h:'Filenames decrypted\non the fly.', s:'No cleartext in transit. AES-256 + NaCl secretbox.'} },
   { id:'stream', Screen:ScreenFileDetail, palette:'rose', fr:{h:'Stream direct.\nZéro téléchargement.', s:'Photos, vidéos, PDF — ouverts depuis Fichiers iOS.'}, en:{h:'Stream direct.\nNo full download.', s:'Photos, video, PDF — opened straight from Files.'} },
+  { id:'player', Screen:ScreenPlayer, palette:'midnight', isNew:true, fr:{h:'Lecteur vidéo\nintégré.', s:'MKV, AVI, WebM, TS… Sous-titres, pistes audio, reprise. Dans l\'app ou en externe.'}, en:{h:'Built-in\nvideo player.', s:'MKV, AVI, WebM, TS… Subtitles, audio tracks, resume. In-app or external.'} },
+  { id:'gallery', Screen:ScreenGallery, palette:'forest', isNew:true, fr:{h:'Une vraie\ngalerie médias.', s:'Vue grille avec vignettes images & vidéos. Liste ou grille, mode « Médias ».'}, en:{h:'A real media\ngallery.', s:'Grid view with photo & video thumbnails. List or grid, "Media only" mode.'} },
   { id:'home', Screen:ScreenHome, palette:'cream', fr:{h:'Votre centre\nde contrôle.', s:'Transferts, favoris, sync photo, débit. En un coup d\'œil.'}, en:{h:'Your control\ncenter.', s:'Transfers, pins, photo sync, throughput. At a glance.'} },
   { id:'wizard', Screen:ScreenWizard, palette:'forest', fr:{h:'Assistant\nguidé.', s:'OAuth en deux tapotements. Import rclone.conf en un geste.'}, en:{h:'Guided\nsetup.', s:'OAuth in two taps. rclone.conf import in one gesture.'} },
   { id:'photos', Screen:ScreenPhotoSync, palette:'rose', fr:{h:'Backup photo,\nintelligent.', s:'Throttle adaptatif, reprise réseau, exécution en arrière-plan.'}, en:{h:'Smart photo\nbackup.', s:'Adaptive throttle, network resume, background tasks.'} },
@@ -583,11 +692,15 @@ const AppStoreBadge = () => {
   );
 };
 
-const Header = ({ lang, setLang }) => (
+const Header = ({ lang, setLang }) => {
+  const t = useT();
+  return (
   <header className="nav">
     <div className="wrap nav-in">
       <a className="brand" href="#top"><img src="icon.png" alt="Rclone GUI"/>Rclone GUI</a>
       <div className="nav-sp"/>
+      <a className="ghost navlink" href="#versions">{t('Nouveautés','What\'s new')}</a>
+      <a className="ghost navlink" href="#faq">FAQ</a>
       <a className="ghost" href={GITHUB_URL} target="_blank" rel="noopener" style={{ marginRight:6 }}>GitHub</a>
       <div className="lang">
         <button className={lang==='en'?'on':''} onClick={() => setLang('en')}>EN</button>
@@ -595,7 +708,8 @@ const Header = ({ lang, setLang }) => (
       </div>
     </div>
   </header>
-);
+  );
+};
 
 const Hero = () => {
   const t = useT();
@@ -603,7 +717,7 @@ const Hero = () => {
     <section className="hero" id="top">
       <div className="wrap">
         <img className="icon" src="icon.png" alt="Rclone GUI"/>
-        <div><span className="pill"><Icon name="bolt.fill" size={14}/>{t('v1.4 · ESSAI GRATUIT','v1.4 · FREE TRIAL')}</span></div>
+        <div><span className="pill"><Icon name="bolt.fill" size={14}/>{t('v1.5 · ESSAI GRATUIT','v1.5 · FREE TRIAL')}</span></div>
         <h1 className="title">{ML(t('Tous vos clouds.\nChiffrés.','Every cloud.\nEncrypted.'))}</h1>
         <p className="sub">{t('Parcourez 80+ services cloud — y compris vos remotes rclone chiffrés — directement dans Fichiers. iPhone, iPad & Mac.','Browse 80+ cloud services — including your encrypted rclone crypt remotes — right inside Files. iPhone, iPad & Mac.')}</p>
         <div className="cta-row">
@@ -651,6 +765,7 @@ const Gallery = ({ lang }) => {
           const ink = p.dark ? '#fff' : '#0B0820';
           return (
             <div key={s.id} className="panel" style={{ background:`linear-gradient(180deg, ${p.from} 0%, ${p.to} 100%)`, color:ink }}>
+              {s.isNew && <span className="newtag">{t('NOUVEAU · v1.5','NEW · v1.5')}</span>}
               <div className="kick" style={{ color:p.accent }}>RCLONE GUI · iOS</div>
               <h3>{ML(copy.h)}</h3>
               <p className="psub">{copy.s}</p>
@@ -879,6 +994,107 @@ const FreeMonth = () => {
   );
 };
 
+const VERSIONS = [
+  { v:'1.5', current:true, date:{ fr:'Juin 2026', en:'June 2026' }, items:[
+    { fr:'Lecteur vidéo intégré multi-format (MKV, AVI, WebM, TS…) : sous-titres intégrés et fichiers externes, pistes audio, reprise là où vous étiez.', en:'Built-in multi-format video player (MKV, AVI, WebM, TS…): embedded and sidecar subtitles, audio tracks, resume where you left off.' },
+    { fr:'Au choix : lecture dans l\'app ou dans une app externe (Infuse, VLC).', en:'Your choice: play in-app or in an external app (Infuse, VLC).' },
+    { fr:'Galerie en grille avec vignettes pour photos et vidéos : bascule liste/grille, mode « Médias uniquement », génération des vignettes en Wi-Fi par défaut.', en:'Grid gallery with thumbnails for photos and videos: list/grid toggle, "Media only" mode, Wi-Fi-only thumbnail generation by default.' },
+    { fr:'Nouvelle option pour exclure les données de l\'app des sauvegardes iCloud.', en:'New option to exclude the app\'s data from iCloud backups.' },
+    { fr:'Stabilité et performances.', en:'Stability and performance improvements.' },
+  ] },
+  { v:'1.4', date:{ fr:'Juin 2026', en:'June 2026' }, items:[
+    { fr:'Nouveaux clouds : Drime, Internxt et Filen (Internxt et Filen chiffrés de bout en bout).', en:'New clouds: Drime, Internxt and Filen (Internxt and Filen are end-to-end encrypted).' },
+    { fr:'Panneau « où trouver vos identifiants » pour Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage…', en:'"Where to get your credentials" panel for Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage…' },
+    { fr:'Sélecteur de stockage pour les remotes composites (alias, union, combine) — fini la saisie manuelle de « remote:chemin ».', en:'Storage picker for composite remotes (alias, union, combine) — no more typing "remote:path" by hand.' },
+    { fr:'Correction de la connexion aux remotes protégés par mot de passe (SFTP, FTP, WebDAV, SMB…).', en:'Fixed connecting to password-protected remotes (SFTP, FTP, WebDAV, SMB…).' },
+    { fr:'Remotes verrouillés masqués des Récents et Favoris.', en:'Locked remotes hidden from Recents and Favorites.' },
+  ] },
+  { v:'1.3', date:{ fr:'Juin 2026', en:'June 2026' }, items:[
+    { fr:'Correctif important : l\'import d\'une configuration rclone chiffrée par mot de passe ne plante plus.', en:'Important fix: importing a password-encrypted rclone configuration no longer crashes the app.' },
+    { fr:'Bouton « J\'ai un code » pour utiliser des codes promo.', en:'"I have a code" button to redeem promo codes.' },
+    { fr:'Page « Contacter le développeur » dans Réglages → Support.', en:'"Contact the Developer" page in Settings → Support.' },
+    { fr:'Traduction anglaise complète de l\'app + code source désormais public sur GitHub.', en:'Completed English translation across the whole app + source code now public on GitHub.' },
+  ] },
+  { v:'1.2', date:{ fr:'Juin 2026', en:'June 2026' }, items:[
+    { fr:'App macOS native (Mac Apple Silicon) : barre latérale et intégration Finder.', en:'Native macOS app (Apple Silicon Macs): sidebar layout and Finder integration.' },
+    { fr:'Assistant guidé pour les remotes chiffrés (crypt) : choix du stockage, navigation jusqu\'au dossier, mot de passe — sans saisie de chemin.', en:'Guided wizard for encrypted (crypt) remotes: pick storage, browse to the folder, set a password — no manual path typing.' },
+    { fr:'Assistant d\'ajout amélioré : bouton Retour et sélecteur de fichier natif pour importer rclone.conf.', en:'Improved add-remote wizard: Back button and native file picker to import rclone.conf.' },
+  ] },
+  { v:'1.1', date:{ fr:'Mai 2026', en:'May 2026' }, items:[
+    { fr:'Localisation anglaise complète : l\'interface suit la langue de l\'appareil.', en:'Full English localization: the interface follows your device language.' },
+    { fr:'Première ouverture plus fluide, stabilité et finitions.', en:'Smoother first-launch, stability and polish.' },
+  ] },
+  { v:'1.0', date:{ fr:'Mai 2026', en:'May 2026' }, items:[
+    { fr:'Première version publique : client rclone natif, 70+ backends, intégration Fichiers (File Provider), chiffrement crypt de bout en bout, sync photo, Face ID, zéro tracking.', en:'First public release: native rclone client, 70+ backends, Files integration (File Provider), end-to-end crypt encryption, photo sync, Face ID, zero tracking.' },
+  ] },
+];
+const Versions = () => {
+  const t = useT();
+  const lang = React.useContext(LangContext);
+  return (
+    <section id="versions">
+      <div className="wrap">
+        <div className="eyebrow">{t('Nouveautés','What\'s new')}</div>
+        <h2 className="sec">{t('Chaque version, en mieux','Every release, better')}</h2>
+        <p className="sec-sub">{t('L\'historique complet des mises à jour et ce qu\'elles apportent.','The full update history and what each one adds.')}</p>
+        <div className="versions">
+          {VERSIONS.map(rel => (
+            <div key={rel.v} className={rel.current ? 'ver current' : 'ver'}>
+              <div className="ver-head">
+                <span className="ver-num">{t('Version ','Version ')}{rel.v}</span>
+                <span className="ver-date">{rel.date[lang] || rel.date.en}</span>
+                {rel.current && <span className="ver-tag">{t('ACTUELLE','CURRENT')}</span>}
+              </div>
+              <ul className="ver-list">
+                {rel.items.map((it, i) => (
+                  <li key={i}><Icon name="check.circle" size={18}/>{it[lang] || it.en}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const FAQ = () => {
+  const t = useT();
+  const items = [
+    { q:t('Rclone GUI est-il gratuit ?','Is Rclone GUI free?'),
+      a:t('Il y a un essai gratuit (1 mois via un code personnel sur ce site). Ensuite, un achat unique à vie de 29,99 € (iPhone + iPad + Mac) ou un abonnement dès 2,99 €/mois (11,99 €/an). L\'app est aussi open source : vous pouvez la compiler vous-même gratuitement.','There is a free trial (1 month via a personal code on this site). After that, a one-time lifetime purchase of €29.99 (iPhone + iPad + Mac) or a subscription from €2.99/month (€11.99/year). It is also open source, so you can build it yourself for free.') },
+    { q:t('Quels services cloud sont pris en charge ?','Which cloud services are supported?'),
+      a:t('Plus de 80 backends via le moteur rclone : Amazon S3, Cloudflare R2, Google Drive, Dropbox, OneDrive, Backblaze B2, SFTP, WebDAV, Storj, Wasabi, Drime, Internxt, Filen, et bien d\'autres.','80+ backends through the rclone engine: Amazon S3, Cloudflare R2, Google Drive, Dropbox, OneDrive, Backblaze B2, SFTP, WebDAV, Storj, Wasabi, Drime, Internxt, Filen and many more.') },
+    { q:t('Quels formats vidéo puis-je lire ? (v1.5)','Which video formats can I play? (v1.5)'),
+      a:t('Le lecteur intégré est multi-format : MP4, MOV, M4V, mais aussi MKV, AVI, WebM, TS et plus, grâce à un moteur hybride. Sous-titres (intégrés et fichiers externes) et pistes audio inclus. Vous pouvez aussi ouvrir la vidéo dans une app externe (Infuse, VLC).','The built-in player is multi-format: MP4, MOV, M4V, plus MKV, AVI, WebM, TS and more, thanks to a hybrid engine. Subtitles (embedded and sidecar files) and audio tracks included. You can also open videos in an external app (Infuse, VLC).') },
+    { q:t('Mes données sont-elles privées et chiffrées ?','Is my data private and encrypted?'),
+      a:t('Oui. Le chiffrement rclone « crypt » est natif, avec déchiffrement des noms à la volée ; vos clés ne quittent jamais l\'appareil. Aucun tracker, aucun serveur backend. Vous pouvez aussi exclure les données de l\'app des sauvegardes iCloud (v1.5).','Yes. rclone "crypt" encryption is native, with on-the-fly filename decryption; your keys never leave the device. No trackers, no backend server. You can also exclude the app\'s data from iCloud backups (v1.5).') },
+    { q:t('Fonctionne-t-il sur Mac et iPad ?','Does it work on Mac and iPad?'),
+      a:t('Oui : iPhone, iPad et Mac (Apple Silicon, app native depuis la v1.2). L\'achat à vie couvre les trois plateformes.','Yes: iPhone, iPad and Mac (Apple Silicon, native app since v1.2). The lifetime purchase covers all three platforms.') },
+    { q:t('Comment obtenir une réduction ?','How can I get a discount?'),
+      a:t('Étudiant·e, emploi précaire, chômage ou budget serré ? Écrivez au développeur pour un code adapté à vos moyens — sans justificatif.','Student, precarious job, unemployed or on a tight budget? Email the developer for a code based on what you can afford — no proof required.') },
+    { q:t('Est-ce open source ?','Is it open source?'),
+      a:t('Oui, sous licence MPL-2.0 et auditable sur GitHub. Aucun serveur backend, aucune analytics.','Yes, under the MPL-2.0 license and auditable on GitHub. No backend server, no analytics.') },
+  ];
+  return (
+    <section id="faq">
+      <div className="wrap">
+        <div className="eyebrow">{t('Questions','Questions')}</div>
+        <h2 className="sec">{t('Vos questions','Your questions')}</h2>
+        <p className="sec-sub">{t('Tout ce qu\'il faut savoir avant de vous lancer.','Everything you need to know before you start.')}</p>
+        <div className="faq">
+          {items.map((it, i) => (
+            <details className="faq-item" key={i} open={i===0}>
+              <summary>{it.q}</summary>
+              <p>{it.a}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
 const Footer = () => {
   const t = useT();
   return (
@@ -887,6 +1103,8 @@ const Footer = () => {
         <div className="foot">
           <a className="brand" href="#top"><img src="icon.png" alt="" style={{ width:26, height:26, borderRadius:7 }}/>Rclone GUI</a>
           <div className="nav-sp"/>
+          <a href="#versions">{t('Nouveautés','What\'s new')}</a>
+          <a href="#faq">FAQ</a>
           <a href={APP_STORE_URL} target="_blank" rel="noopener">App Store</a>
           <a href={GITHUB_URL} target="_blank" rel="noopener">GitHub</a>
           <a href="privacy.html">{t('Confidentialité','Privacy')}</a>
@@ -906,8 +1124,10 @@ const App = () => {
       <Hero/>
       <Gallery lang={lang}/>
       <Features/>
+      <Versions/>
       <Pricing/>
       <FreeMonth/>
+      <FAQ/>
       <Footer/>
     </LangContext.Provider>
   );

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
     ]
   },
   "downloadUrl": "https://apps.apple.com/app/id6770088773",
-  "softwareVersion": "1.4",
+  "softwareVersion": "1.5",
   "author": {
     "@type": "Person",
     "name": "Vitalys Rougetet"
@@ -56,6 +56,9 @@
     "Encrypted rclone config (ChaChaPoly, Keychain)",
     "Photo library backup (PhotoSync)",
     "Audio and video streaming from remote files",
+    "Built-in multi-format video player (MP4, MKV, AVI, WebM, TS) with subtitles and audio tracks",
+    "Media gallery with grid view and photo/video thumbnails",
+    "Option to exclude app data from iCloud backups",
     "No backend server, no data collection"
   ],
   "screenshot": "https://rclone.rougetet.com/icon.png"
@@ -90,6 +93,21 @@
       "@type": "Question",
       "name": "Does it support rclone crypt encryption?",
       "acceptedAnswer": { "@type": "Answer", "text": "Yes. rclone crypt is supported natively with on-the-fly filename decryption (AES-256 + NaCl secretbox). Your encryption keys never leave the device." }
+    },
+    {
+      "@type": "Question",
+      "name": "Which video formats can I play?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Since version 1.5 there is a built-in multi-format video player. It plays MP4, MOV and M4V plus MKV, AVI, WebM, TS and more through a hybrid engine, with embedded and sidecar subtitles and multiple audio tracks. You can also open videos in an external app such as Infuse or VLC." }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a media gallery for photos and videos?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yes. Version 1.5 adds a grid gallery with thumbnails for your photos and videos. You can switch between list and grid in any folder or turn on a media-only view, with Wi-Fi-only thumbnail generation by default." }
+    },
+    {
+      "@type": "Question",
+      "name": "Does it work on Mac and iPad?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yes. Rclone GUI runs on iPhone, iPad and Mac (native Apple Silicon app since version 1.2). The one-time lifetime purchase covers all three platforms." }
     }
   ]
 }
@@ -241,6 +259,37 @@
   .pricing-note{text-align:center;color:var(--muted);font-size:14px;margin:26px auto 0;font-weight:500;max-width:620px;line-height:1.5}
   .pricing-note a{color:var(--accent);font-weight:700}
   .pricing-note .solid{display:block;margin-top:10px}
+  /* versions / changelog */
+  .versions{max-width:760px;margin:38px auto 0;display:flex;flex-direction:column;gap:16px}
+  .ver{background:#fff;border:1px solid var(--line);border-radius:20px;padding:22px 24px;
+    box-shadow:0 8px 26px rgba(11,8,32,.05);position:relative}
+  .ver.current{border:2px solid var(--accent);box-shadow:0 18px 46px rgba(124,58,237,.18)}
+  .ver-head{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+  .ver-num{font-size:22px;font-weight:800;letter-spacing:-.5px}
+  .ver-date{font-size:13px;color:var(--muted);font-weight:600}
+  .ver-tag{margin-left:auto;background:var(--accent);color:#fff;font-size:11px;font-weight:800;
+    letter-spacing:.5px;padding:4px 10px;border-radius:999px}
+  .ver-list{list-style:none;padding:0;margin:14px 0 0;display:flex;flex-direction:column;gap:9px}
+  .ver-list li{display:flex;gap:10px;font-size:14.5px;font-weight:500;line-height:1.4;align-items:flex-start}
+  .ver-list li svg{flex:0 0 auto;margin-top:2px;color:var(--accent)}
+  /* faq */
+  .faq{max-width:760px;margin:38px auto 0;display:flex;flex-direction:column;gap:12px}
+  .faq-item{background:#fff;border:1px solid var(--line);border-radius:16px;padding:2px 20px;
+    box-shadow:0 8px 26px rgba(11,8,32,.05)}
+  .faq-item summary{cursor:pointer;list-style:none;padding:16px 0;font-size:16.5px;font-weight:700;
+    display:flex;align-items:center;justify-content:space-between;gap:12px}
+  .faq-item summary::-webkit-details-marker{display:none}
+  .faq-item summary::after{content:"+";font-size:24px;font-weight:300;color:var(--accent);line-height:1}
+  .faq-item[open] summary::after{content:"\2212"}
+  .faq-item p{margin:0 0 18px;color:var(--muted);font-size:15px;font-weight:500;line-height:1.55}
+  .faq-item p a{color:var(--accent);font-weight:700}
+  /* new badge on gallery panels */
+  .panel .newtag{position:absolute;top:16px;right:16px;background:var(--accent);color:#fff;font-size:10px;
+    font-weight:800;letter-spacing:.5px;padding:4px 9px;border-radius:999px;z-index:3;
+    box-shadow:0 6px 16px rgba(124,58,237,.4)}
+  /* nav links */
+  .navlink{margin-right:4px}
+  @media(max-width:680px){.navlink{display:none}}
   /* a11y */
   :focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:8px}
   @media(prefers-reduced-motion:reduce){

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,12 +15,15 @@ The app is privacy-first: no backend server, no analytics, no data transmitted. 
 - **Files.app integration**: every remote exposed as a FileProvider domain in the native iOS/macOS file browser
 - **PhotoSync**: automatic photo library backup to any configured remote
 - **Streaming**: audio and video playback from remote files via a local loopback HTTP server, including from crypt remotes
+- **Built-in video player (v1.5)**: multi-format playback (MP4, MOV, M4V, MKV, AVI, WebM, TS…) with embedded and sidecar subtitles, audio tracks and resume; play in-app or in an external app (Infuse, VLC)
+- **Media gallery (v1.5)**: grid view with photo and video thumbnails, list/grid toggle, "Media only" mode, Wi-Fi-only thumbnail generation
+- **iCloud backup control (v1.5)**: option to exclude the app's data from iCloud backups
 - **Encrypted config import**: import rclone.conf files encrypted with `rclone config encryption set`
 - **No backend**: credentials and files never leave the device
 
 ## Pricing
 
-Subscription (monthly or annual). A free 1-month trial code is available at https://rclone.rougetet.com — one per person, delivered by email.
+Free 1-month trial, then a one-time lifetime purchase (€29.99, covers iPhone + iPad + Mac) or a subscription from €2.99/month (€11.99/year). A personal trial code is available at https://rclone.rougetet.com — one per person, delivered by email. The app is also open source, so it can be built for free.
 
 ## Download
 


### PR DESCRIPTION
## Mise à jour du site vitrine pour la 1.5

### Ajouts
- **Hero** passé en `v1.5`.
- **Section « Nouveautés »** (`#versions`) : historique complet des versions **1.0 → 1.5** (FR/EN), chacune listant ce qu'elle apporte. La version actuelle est mise en avant (badge **ACTUELLE/CURRENT**).
- **Section « Questions » / FAQ** (`#faq`) : accordéon natif (`<details>`), 7 questions FR/EN (gratuité, clouds supportés, **formats vidéo**, confidentialité, Mac/iPad, réduction, open source).
- **Deux nouveaux écrans mockés** dans le carrousel, badgés **NEW · v1.5** :
  - **Lecteur vidéo intégré** (UI sombre, sous-titres/audio/externe, reprise).
  - **Galerie en grille** (bascule liste/grille, « Médias uniquement », vignettes photo/vidéo).
- **Navigation** : liens *Nouveautés* + *FAQ* dans le header et le footer.

### SEO / technique
- `index.html` : `softwareVersion` → **1.5**, `featureList` enrichie (lecteur vidéo, galerie, exclusion iCloud), **FAQPage** JSON-LD étendu, CSS des sections versions/FAQ/badges/nav.
- `llms.txt` : features v1.5 + tarif à vie.
- `app.js` recompilé depuis `app.src.jsx` (Babel, runtime classique).

### Vérifications
- ✅ `node --check docs/app.js` OK, 0 import ESM, React.createElement (runtime classique).
- ✅ Rendu testé en navigateur (Chrome headless) : aucune erreur JS, toutes les sections rendues (versions 1.0→1.5, FAQ, écrans lecteur + galerie).