### PR TITLE
feat(roadmap): feuille de route sur le site + écran « Feuille de route » dans l'app

### DIFF
--- a/Rclone GUI/Localizable.xcstrings
+++ b/Rclone GUI/Localizable.xcstrings
@@ -1,6 +1,1154 @@
 {
   "sourceLanguage" : "fr",
   "strings" : {
+    "Ce qui arrive dans Rclone GUI. Tout reste privacy-first, open source et sans serveur." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Was als Nächstes in Rclone GUI kommt. Alles bleibt privacy-first, Open Source und ohne Server."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What's coming to Rclone GUI. Everything stays privacy-first, open source and serverless."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo que viene en Rclone GUI. Todo sigue siendo privacy-first, open source y sin servidor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce qui arrive dans Rclone GUI. Tout reste privacy-first, open source et sans serveur."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cosa arriva in Rclone GUI. Tutto resta privacy-first, open source e senza server."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rclone GUI の今後の予定。すべてプライバシー優先・オープンソース・サーバーレスのままです。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rclone GUI에 추가될 기능. 모두 프라이버시 우선, 오픈 소스, 서버 없이 유지됩니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wat eraan komt in Rclone GUI. Alles blijft privacy-first, open source en serverloos."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Co pojawi się w Rclone GUI. Wszystko pozostaje privacy-first, open source i bez serwera."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O que vem por aí no Rclone GUI. Tudo continua privacy-first, open source e sem servidor."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Что появится в Rclone GUI. Всё остаётся privacy-first, с открытым кодом и без сервера."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rclone GUI 即将推出的功能。一切始终隐私优先、开源、无服务器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rclone GUI 即將推出的功能。一切始終隱私優先、開源、無伺服器。"
+          }
+        }
+      }
+    },
+    "Court terme" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurzfristig"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Short term"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corto plazo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Court terme"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Breve termine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "短期"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Korte termijn"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Krótkoterminowe"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Curto prazo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ближайшее время"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "短期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "短期"
+          }
+        }
+      }
+    },
+    "En préparation" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In Arbeit"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En preparación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En préparation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In preparazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "準備中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "준비 중"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In voorbereiding"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W przygotowaniu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Em preparação"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В работе"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "进行中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進行中"
+          }
+        }
+      }
+    },
+    "Moyen terme" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mittelfristig"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mid term"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medio plazo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moyen terme"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medio termine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中期"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Middellange termijn"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Średnioterminowe"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Médio prazo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Среднесрочно"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中期"
+          }
+        }
+      }
+    },
+    "Prévu" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geplant"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Planned"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previsto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prévu"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pianificato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "予定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예정"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gepland"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaplanowane"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Planejado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запланировано"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已计划"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已規劃"
+          }
+        }
+      }
+    },
+    "Long terme" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langfristig"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Long term"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Largo plazo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Long terme"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lungo termine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長期"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "장기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lange termijn"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Długoterminowe"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Longo prazo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Долгосрочно"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "长期"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "長期"
+          }
+        }
+      }
+    },
+    "Vision" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vision"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vision"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vision"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ビジョン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비전"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visie"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wizja"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visão"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "愿景"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "願景"
+          }
+        }
+      }
+    },
+    "Voir la feuille de route complète" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vollständige Roadmap ansehen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "See the full roadmap"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver la hoja de ruta completa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir la feuille de route complète"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedi la roadmap completa"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロードマップ全体を見る"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 로드맵 보기"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volledige roadmap bekijken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zobacz pełną mapę drogową"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver o roteiro completo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Посмотреть полную дорожную карту"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看完整路线图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看完整路線圖"
+          }
+        }
+      }
+    },
+    "Roadmap indicative, sans engagement de date — priorisée avec vos retours." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unverbindliche Roadmap ohne feste Termine – nach Ihrem Feedback priorisiert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicative roadmap, no committed dates — prioritized with your feedback."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoja de ruta indicativa, sin fechas comprometidas: priorizada con tus comentarios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roadmap indicative, sans engagement de date — priorisée avec vos retours."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roadmap indicativa, senza date garantite — prioritizzata con i tuoi feedback."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目安のロードマップです。日付の確約はなく、皆さまのフィードバックで優先順位を決めます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "참고용 로드맵이며 날짜를 약속하지 않습니다. 여러분의 의견으로 우선순위를 정합니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicatieve roadmap, geen vaste data — geprioriteerd met jouw feedback."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orientacyjna mapa drogowa, bez zobowiązań co do dat — priorytety ustalane na podstawie Waszych opinii."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roteiro indicativo, sem datas garantidas — priorizado com seu feedback."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ориентировочная дорожная карта без обязательств по срокам — приоритеты по вашим отзывам."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线图仅供参考，不承诺具体日期——根据你的反馈确定优先级。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線圖僅供參考，不承諾具體日期——依你的回饋決定優先順序。"
+          }
+        }
+      }
+    },
+    "Feuille de route" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roadmap"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roadmap"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoja de ruta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feuille de route"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roadmap"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロードマップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로드맵"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roadmap"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mapa drogowa"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roteiro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дорожная карта"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線圖"
+          }
+        }
+      }
+    },
+    "Les fonctionnalités à venir" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kommende Funktionen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upcoming features"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Próximas funciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les fonctionnalités à venir"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funzionalità in arrivo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今後の機能"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예정된 기능"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aankomende functies"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nadchodzące funkcje"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recursos futuros"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Будущие функции"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即将推出的功能"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即將推出的功能"
+          }
+        }
+      }
+    },
+    "Transferts Pro · Flows · Ghost Vault · Handoff P2P · Glass Engine" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro-Transfers · Flows · Ghost Vault · P2P-Handoff · Glass Engine"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro Transfers · Flows · Ghost Vault · P2P Handoff · Glass Engine"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias Pro · Flows · Ghost Vault · Handoff P2P · Glass Engine"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferts Pro · Flows · Ghost Vault · Handoff P2P · Glass Engine"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trasferimenti Pro · Flows · Ghost Vault · Handoff P2P · Glass Engine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro転送 · Flows · Ghost Vault · P2Pハンドオフ · Glass Engine"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro 전송 · Flows · Ghost Vault · P2P 핸드오프 · Glass Engine"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro-overdrachten · Flows · Ghost Vault · P2P-handoff · Glass Engine"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfery Pro · Flows · Ghost Vault · Handoff P2P · Glass Engine"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferências Pro · Flows · Ghost Vault · Handoff P2P · Glass Engine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro-передачи · Flows · Ghost Vault · P2P-передача · Glass Engine"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "专业传输 · Flows · Ghost Vault · P2P 交接 · Glass Engine"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專業傳輸 · Flows · Ghost Vault · P2P 交接 · Glass Engine"
+          }
+        }
+      }
+    },
+    "Remote Lens · Recherche sémantique on-device · Sealed Share · Règles de sync · Mode Voyage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · Semantische Suche on-device · Sealed Share · Sync-Regeln · Reisemodus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · On-device semantic search · Sealed Share · Sync rules · Travel Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · Búsqueda semántica en el dispositivo · Sealed Share · Reglas de sync · Modo Viaje"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · Recherche sémantique on-device · Sealed Share · Règles de sync · Mode Voyage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · Ricerca semantica on-device · Sealed Share · Regole di sync · Modalità Viaggio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · オンデバイス意味検索 · Sealed Share · 同期ルール · 旅行モード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · 온디바이스 의미 검색 · Sealed Share · 동기화 규칙 · 여행 모드"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · Semantisch zoeken op het apparaat · Sealed Share · Sync-regels · Reismodus"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · Wyszukiwanie semantyczne na urządzeniu · Sealed Share · Reguły synchronizacji · Tryb podróży"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · Busca semântica no dispositivo · Sealed Share · Regras de sync · Modo Viagem"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · Семантический поиск на устройстве · Sealed Share · Правила синхронизации · Режим путешествия"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · 设备端语义搜索 · Sealed Share · 同步规则 · 旅行模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote Lens · 裝置端語意搜尋 · Sealed Share · 同步規則 · 旅行模式"
+          }
+        }
+      }
+    },
+    "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Héritage numérique" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Digitales Erbe"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Digital legacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Legado digital"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Héritage numérique"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Eredità digitale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · デジタル遺産"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · 디지털 유산"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Digitale nalatenschap"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Cyfrowe dziedzictwo"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Legado digital"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Цифровое наследие"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · 数字遗产"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · 數位遺產"
+          }
+        }
+      }
+    },
     "Impossible de lire le fichier sélectionné." : {
       "localizations" : {
         "de" : {

--- a/Rclone GUI/Views/Settings/RoadmapView.swift
+++ b/Rclone GUI/Views/Settings/RoadmapView.swift
@@ -1,0 +1,87 @@
+//
+//  RoadmapView.swift
+//  Rclone GUI — Views/Settings
+//
+//  Compact "what's coming" screen. The full, continuously-evolving roadmap
+//  lives on the website (rclone.rougetet.com/#roadmap) so it can change
+//  without shipping an App Store update; here we surface the headline items
+//  per horizon and link out for the detail. Stays on-brand: privacy-first,
+//  open source, no backend.
+//
+
+import SwiftUI
+
+struct RoadmapView: View {
+    @Environment(\.openURL) private var openURL
+    private let fullURL = URL(string: "https://rclone.rougetet.com/#roadmap")!
+
+    var body: some View {
+        List {
+            Section {
+                Text("Ce qui arrive dans Rclone GUI. Tout reste privacy-first, open source et sans serveur.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            horizon(
+                label: "Court terme",
+                tag: "En préparation",
+                tint: .green,
+                items: "Transferts Pro · Flows · Ghost Vault · Handoff P2P · Glass Engine"
+            )
+            horizon(
+                label: "Moyen terme",
+                tag: "Prévu",
+                tint: .blue,
+                items: "Remote Lens · Recherche sémantique on-device · Sealed Share · Règles de sync · Mode Voyage"
+            )
+            horizon(
+                label: "Long terme",
+                tag: "Vision",
+                tint: .purple,
+                items: "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Héritage numérique"
+            )
+
+            Section {
+                Button {
+                    openURL(fullURL)
+                } label: {
+                    Label("Voir la feuille de route complète", systemImage: "safari")
+                }
+            } footer: {
+                Text("Roadmap indicative, sans engagement de date — priorisée avec vos retours.")
+            }
+        }
+        .navigationTitle("Feuille de route")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    @ViewBuilder
+    private func horizon(
+        label: LocalizedStringKey,
+        tag: LocalizedStringKey,
+        tint: Color,
+        items: LocalizedStringKey
+    ) -> some View {
+        Section {
+            Text(items).font(.callout)
+        } header: {
+            HStack {
+                Text(label)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .textCase(nil)
+                Spacer()
+                Text(tag)
+                    .font(.caption2.weight(.bold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(tint.opacity(0.18), in: Capsule())
+                    .foregroundStyle(tint)
+                    .textCase(nil)
+            }
+        }
+    }
+}

--- a/Rclone GUI/Views/Settings/SettingsView.swift
+++ b/Rclone GUI/Views/Settings/SettingsView.swift
@@ -168,6 +168,16 @@ struct SettingsView: View {
                         tint: .teal
                     )
                 }
+                NavigationLink {
+                    RoadmapView()
+                } label: {
+                    SettingsNavigationRow(
+                        icon: "sparkles",
+                        title: "Feuille de route",
+                        subtitle: "Les fonctionnalités à venir",
+                        tint: .purple
+                    )
+                }
             }
 
             Section("Support") {

--- a/docs/app.js
+++ b/docs/app.js
@@ -2953,6 +2953,9 @@ const Header = ({
     href: "#versions"
   }, t('Nouveautés', 'What\'s new')), /*#__PURE__*/React.createElement("a", {
     className: "ghost navlink",
+    href: "#roadmap"
+  }, "Roadmap"), /*#__PURE__*/React.createElement("a", {
+    className: "ghost navlink",
     href: "#faq"
   }, "FAQ"), /*#__PURE__*/React.createElement("a", {
     className: "ghost",
@@ -3613,6 +3616,214 @@ const Versions = () => {
     size: 18
   }), it[lang] || it.en))))))));
 };
+const ROADMAP = [{
+  key: 'short',
+  label: {
+    fr: 'Court terme',
+    en: 'Short term'
+  },
+  tag: {
+    fr: 'EN PRÉPARATION',
+    en: 'IN PROGRESS'
+  },
+  items: [{
+    n: {
+      fr: 'Transferts Pro',
+      en: 'Pro Transfers'
+    },
+    d: {
+      fr: 'File d\'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire, logs exportables.',
+      en: 'Queue, priorities, robust resume, Wi-Fi/cellular limits, exportable logs.'
+    }
+  }, {
+    n: {
+      fr: 'Flows',
+      en: 'Flows'
+    },
+    d: {
+      fr: 'Automatisations 100 % locales (Raccourcis + App Intents) et Live Activity « santé du backup ».',
+      en: '100% local automations (Shortcuts + App Intents) and a "backup health" Live Activity.'
+    }
+  }, {
+    n: {
+      fr: 'Ghost Vault',
+      en: 'Ghost Vault'
+    },
+    d: {
+      fr: 'Sauvegarde chiffrée de toute ta config dans ton propre remote, scellée par Face ID. Sans compte.',
+      en: 'Encrypted backup of your whole config into your own remote, sealed with Face ID. No account.'
+    }
+  }, {
+    n: {
+      fr: 'Handoff P2P',
+      en: 'P2P Handoff'
+    },
+    d: {
+      fr: 'Transférer une config chiffrée entre tes appareils via QR / AirDrop, sans serveur.',
+      en: 'Move an encrypted config between your devices via QR / AirDrop, with no server.'
+    }
+  }, {
+    n: {
+      fr: 'Glass Engine',
+      en: 'Glass Engine'
+    },
+    d: {
+      fr: 'Moniteur « 0 appel maison » + build reproductible : prouver le privacy, pas le promettre.',
+      en: 'A "zero phone-home" monitor + reproducible build: prove privacy, don\'t just promise it.'
+    }
+  }]
+}, {
+  key: 'mid',
+  label: {
+    fr: 'Moyen terme',
+    en: 'Mid term'
+  },
+  tag: {
+    fr: 'PRÉVU',
+    en: 'PLANNED'
+  },
+  items: [{
+    n: {
+      fr: 'Remote Lens',
+      en: 'Remote Lens'
+    },
+    d: {
+      fr: 'Aperçus (vignettes, EXIF, 1re page PDF) par range requests, sans tout télécharger ni déchiffrer.',
+      en: 'Previews (thumbnails, EXIF, first PDF page) via range requests, without downloading or fully decrypting.'
+    }
+  }, {
+    n: {
+      fr: 'Recherche sémantique on-device',
+      en: 'On-device semantic search'
+    },
+    d: {
+      fr: 'Médiathèque locale chiffrée + recherche en langage naturel (Apple Intelligence), jamais côté serveur.',
+      en: 'Local encrypted media library + natural-language search (Apple Intelligence), never server-side.'
+    }
+  }, {
+    n: {
+      fr: 'Sealed Share',
+      en: 'Sealed Share'
+    },
+    d: {
+      fr: 'Partage hors-bande : lien backend natif + capsule-clé via AirDrop/QR, déchiffrement on-device.',
+      en: 'Out-of-band sharing: native backend link + key capsule via AirDrop/QR, decrypted on-device.'
+    }
+  }, {
+    n: {
+      fr: 'Règles de sync',
+      en: 'Sync rules'
+    },
+    d: {
+      fr: 'Règles locales par type/dossier + « toujours disponible hors-ligne » depuis Fichiers.',
+      en: 'Local rules by type/folder + "always available offline" from Files.'
+    }
+  }, {
+    n: {
+      fr: 'Mode Voyage',
+      en: 'Travel Mode'
+    },
+    d: {
+      fr: 'Coffre éphémère (déchiffrement en RAM), auto-démontage et Face ID par remote.',
+      en: 'Ephemeral vault (in-RAM decryption), auto-unmount and per-remote Face ID.'
+    }
+  }]
+}, {
+  key: 'long',
+  label: {
+    fr: 'Long terme',
+    en: 'Long term'
+  },
+  tag: {
+    fr: 'VISION',
+    en: 'VISION'
+  },
+  items: [{
+    n: {
+      fr: 'ChronoDrive',
+      en: 'ChronoDrive'
+    },
+    d: {
+      fr: 'N\'importe quel backend comme destination de sauvegarde versionnée façon Time Machine (macOS), chiffrée.',
+      en: 'Any backend as a versioned, encrypted Time Machine-style backup destination (macOS).'
+    }
+  }, {
+    n: {
+      fr: 'Ghost Sync',
+      en: 'Ghost Sync'
+    },
+    d: {
+      fr: 'Mesh P2P : réconciliation de deltas chiffrés entre tes appareils en réseau local, offline-first.',
+      en: 'P2P mesh: encrypted delta reconciliation between your devices over the local network, offline-first.'
+    }
+  }, {
+    n: {
+      fr: 'Quantum Vault',
+      en: 'Quantum Vault'
+    },
+    d: {
+      fr: 'Chiffrement post-quantique hybride (Kyber + AES) pour des archives « 2035-proof ».',
+      en: 'Hybrid post-quantum encryption (Kyber + AES) for "2035-proof" archives.'
+    }
+  }, {
+    n: {
+      fr: 'CipherSpace',
+      en: 'CipherSpace'
+    },
+    d: {
+      fr: 'Explorer ses archives chiffrées dans l\'espace, sur visionOS.',
+      en: 'Explore your encrypted archives in space, on visionOS.'
+    }
+  }, {
+    n: {
+      fr: 'Héritage numérique',
+      en: 'Digital legacy'
+    },
+    d: {
+      fr: 'Récupération sociale (partage de secret de Shamir) entre contacts de confiance + preuve de vie.',
+      en: 'Social recovery (Shamir secret sharing) among trusted contacts + proof of life.'
+    }
+  }]
+}];
+const Roadmap = ({
+  lang
+}) => {
+  const t = useT();
+  return /*#__PURE__*/React.createElement("section", {
+    id: "roadmap"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "wrap"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "eyebrow"
+  }, "Roadmap"), /*#__PURE__*/React.createElement("h2", {
+    className: "sec"
+  }, t('Et après ?', 'What\'s next?')), /*#__PURE__*/React.createElement("p", {
+    className: "sec-sub"
+  }, t('Notre cap : ton cloud, sans intermédiaire. Tout reste privacy-first, open source et sans serveur backend.', 'Our heading: your cloud, no middleman. Everything stays privacy-first, open source and backend-free.')), /*#__PURE__*/React.createElement("div", {
+    className: "roadmap"
+  }, ROADMAP.map(col => /*#__PURE__*/React.createElement("div", {
+    key: col.key,
+    className: 'rm-col rm-' + col.key
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "rm-head"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "rm-label"
+  }, col.label[lang] || col.label.en), /*#__PURE__*/React.createElement("span", {
+    className: "rm-tag"
+  }, col.tag[lang] || col.tag.en)), /*#__PURE__*/React.createElement("div", {
+    className: "rm-items"
+  }, col.items.map(it => /*#__PURE__*/React.createElement("div", {
+    key: it.n.en,
+    className: "rm-item"
+  }, /*#__PURE__*/React.createElement("h5", null, it.n[lang] || it.n.en), /*#__PURE__*/React.createElement("p", null, it.d[lang] || it.d.en))))))), /*#__PURE__*/React.createElement("div", {
+    className: "rm-bet"
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "bolt.fill",
+    size: 16
+  }), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, t('Pari produit', 'Product bet'), " : "), t('« Capability, pas compte » — le partage et le multi-appareils deviennent des objets cryptographiques que tu possèdes et révoques, jamais une ligne dans une base (puisqu\'il n\'y en a pas).', '"Capability, not account" — sharing and multi-device become cryptographic objects you own and revoke, never a row in a database (because there isn\'t one).'))), /*#__PURE__*/React.createElement("p", {
+    className: "rm-note"
+  }, t('Roadmap indicative, sans engagement de date — priorisée avec vos retours. Open source : suivez ou contribuez sur GitHub.', 'Indicative roadmap, no committed dates — prioritized with your feedback. Open source: follow or contribute on GitHub.'))));
+};
 const FAQ = () => {
   const t = useT();
   const items = [{
@@ -3680,6 +3891,8 @@ const Footer = () => {
   }), /*#__PURE__*/React.createElement("a", {
     href: "#versions"
   }, t('Nouveautés', 'What\'s new')), /*#__PURE__*/React.createElement("a", {
+    href: "#roadmap"
+  }, "Roadmap"), /*#__PURE__*/React.createElement("a", {
     href: "#faq"
   }, "FAQ"), /*#__PURE__*/React.createElement("a", {
     href: APP_STORE_URL,
@@ -3708,6 +3921,8 @@ const App = () => {
     setLang: setLang
   }), /*#__PURE__*/React.createElement(Hero, null), /*#__PURE__*/React.createElement(Gallery, {
     lang: lang
-  }), /*#__PURE__*/React.createElement(Features, null), /*#__PURE__*/React.createElement(Versions, null), /*#__PURE__*/React.createElement(Pricing, null), /*#__PURE__*/React.createElement(FreeMonth, null), /*#__PURE__*/React.createElement(FAQ, null), /*#__PURE__*/React.createElement(Footer, null));
+  }), /*#__PURE__*/React.createElement(Features, null), /*#__PURE__*/React.createElement(Versions, null), /*#__PURE__*/React.createElement(Roadmap, {
+    lang: lang
+  }), /*#__PURE__*/React.createElement(Pricing, null), /*#__PURE__*/React.createElement(FreeMonth, null), /*#__PURE__*/React.createElement(FAQ, null), /*#__PURE__*/React.createElement(Footer, null));
 };
 ReactDOM.createRoot(document.getElementById('root')).render(/*#__PURE__*/React.createElement(App, null));

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -700,6 +700,7 @@ const Header = ({ lang, setLang }) => {
       <a className="brand" href="#top"><img src="icon.png" alt="Rclone GUI"/>Rclone GUI</a>
       <div className="nav-sp"/>
       <a className="ghost navlink" href="#versions">{t('Nouveautés','What\'s new')}</a>
+      <a className="ghost navlink" href="#roadmap">Roadmap</a>
       <a className="ghost navlink" href="#faq">FAQ</a>
       <a className="ghost" href={GITHUB_URL} target="_blank" rel="noopener" style={{ marginRight:6 }}>GitHub</a>
       <div className="lang">
@@ -1063,6 +1064,65 @@ const Versions = () => {
   );
 };
 
+const ROADMAP = [
+  { key:'short', label:{ fr:'Court terme', en:'Short term' }, tag:{ fr:'EN PRÉPARATION', en:'IN PROGRESS' }, items:[
+    { n:{ fr:'Transferts Pro', en:'Pro Transfers' }, d:{ fr:'File d\'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire, logs exportables.', en:'Queue, priorities, robust resume, Wi-Fi/cellular limits, exportable logs.' } },
+    { n:{ fr:'Flows', en:'Flows' }, d:{ fr:'Automatisations 100 % locales (Raccourcis + App Intents) et Live Activity « santé du backup ».', en:'100% local automations (Shortcuts + App Intents) and a "backup health" Live Activity.' } },
+    { n:{ fr:'Ghost Vault', en:'Ghost Vault' }, d:{ fr:'Sauvegarde chiffrée de toute ta config dans ton propre remote, scellée par Face ID. Sans compte.', en:'Encrypted backup of your whole config into your own remote, sealed with Face ID. No account.' } },
+    { n:{ fr:'Handoff P2P', en:'P2P Handoff' }, d:{ fr:'Transférer une config chiffrée entre tes appareils via QR / AirDrop, sans serveur.', en:'Move an encrypted config between your devices via QR / AirDrop, with no server.' } },
+    { n:{ fr:'Glass Engine', en:'Glass Engine' }, d:{ fr:'Moniteur « 0 appel maison » + build reproductible : prouver le privacy, pas le promettre.', en:'A "zero phone-home" monitor + reproducible build: prove privacy, don\'t just promise it.' } },
+  ] },
+  { key:'mid', label:{ fr:'Moyen terme', en:'Mid term' }, tag:{ fr:'PRÉVU', en:'PLANNED' }, items:[
+    { n:{ fr:'Remote Lens', en:'Remote Lens' }, d:{ fr:'Aperçus (vignettes, EXIF, 1re page PDF) par range requests, sans tout télécharger ni déchiffrer.', en:'Previews (thumbnails, EXIF, first PDF page) via range requests, without downloading or fully decrypting.' } },
+    { n:{ fr:'Recherche sémantique on-device', en:'On-device semantic search' }, d:{ fr:'Médiathèque locale chiffrée + recherche en langage naturel (Apple Intelligence), jamais côté serveur.', en:'Local encrypted media library + natural-language search (Apple Intelligence), never server-side.' } },
+    { n:{ fr:'Sealed Share', en:'Sealed Share' }, d:{ fr:'Partage hors-bande : lien backend natif + capsule-clé via AirDrop/QR, déchiffrement on-device.', en:'Out-of-band sharing: native backend link + key capsule via AirDrop/QR, decrypted on-device.' } },
+    { n:{ fr:'Règles de sync', en:'Sync rules' }, d:{ fr:'Règles locales par type/dossier + « toujours disponible hors-ligne » depuis Fichiers.', en:'Local rules by type/folder + "always available offline" from Files.' } },
+    { n:{ fr:'Mode Voyage', en:'Travel Mode' }, d:{ fr:'Coffre éphémère (déchiffrement en RAM), auto-démontage et Face ID par remote.', en:'Ephemeral vault (in-RAM decryption), auto-unmount and per-remote Face ID.' } },
+  ] },
+  { key:'long', label:{ fr:'Long terme', en:'Long term' }, tag:{ fr:'VISION', en:'VISION' }, items:[
+    { n:{ fr:'ChronoDrive', en:'ChronoDrive' }, d:{ fr:'N\'importe quel backend comme destination de sauvegarde versionnée façon Time Machine (macOS), chiffrée.', en:'Any backend as a versioned, encrypted Time Machine-style backup destination (macOS).' } },
+    { n:{ fr:'Ghost Sync', en:'Ghost Sync' }, d:{ fr:'Mesh P2P : réconciliation de deltas chiffrés entre tes appareils en réseau local, offline-first.', en:'P2P mesh: encrypted delta reconciliation between your devices over the local network, offline-first.' } },
+    { n:{ fr:'Quantum Vault', en:'Quantum Vault' }, d:{ fr:'Chiffrement post-quantique hybride (Kyber + AES) pour des archives « 2035-proof ».', en:'Hybrid post-quantum encryption (Kyber + AES) for "2035-proof" archives.' } },
+    { n:{ fr:'CipherSpace', en:'CipherSpace' }, d:{ fr:'Explorer ses archives chiffrées dans l\'espace, sur visionOS.', en:'Explore your encrypted archives in space, on visionOS.' } },
+    { n:{ fr:'Héritage numérique', en:'Digital legacy' }, d:{ fr:'Récupération sociale (partage de secret de Shamir) entre contacts de confiance + preuve de vie.', en:'Social recovery (Shamir secret sharing) among trusted contacts + proof of life.' } },
+  ] },
+];
+const Roadmap = ({ lang }) => {
+  const t = useT();
+  return (
+    <section id="roadmap">
+      <div className="wrap">
+        <div className="eyebrow">Roadmap</div>
+        <h2 className="sec">{t('Et après ?','What\'s next?')}</h2>
+        <p className="sec-sub">{t('Notre cap : ton cloud, sans intermédiaire. Tout reste privacy-first, open source et sans serveur backend.','Our heading: your cloud, no middleman. Everything stays privacy-first, open source and backend-free.')}</p>
+        <div className="roadmap">
+          {ROADMAP.map(col => (
+            <div key={col.key} className={'rm-col rm-' + col.key}>
+              <div className="rm-head">
+                <span className="rm-label">{col.label[lang] || col.label.en}</span>
+                <span className="rm-tag">{col.tag[lang] || col.tag.en}</span>
+              </div>
+              <div className="rm-items">
+                {col.items.map(it => (
+                  <div key={it.n.en} className="rm-item">
+                    <h5>{it.n[lang] || it.n.en}</h5>
+                    <p>{it.d[lang] || it.d.en}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="rm-bet">
+          <Icon name="bolt.fill" size={16}/>
+          <span><b>{t('Pari produit','Product bet')} : </b>{t('« Capability, pas compte » — le partage et le multi-appareils deviennent des objets cryptographiques que tu possèdes et révoques, jamais une ligne dans une base (puisqu\'il n\'y en a pas).','"Capability, not account" — sharing and multi-device become cryptographic objects you own and revoke, never a row in a database (because there isn\'t one).')}</span>
+        </div>
+        <p className="rm-note">{t('Roadmap indicative, sans engagement de date — priorisée avec vos retours. Open source : suivez ou contribuez sur GitHub.','Indicative roadmap, no committed dates — prioritized with your feedback. Open source: follow or contribute on GitHub.')}</p>
+      </div>
+    </section>
+  );
+};
+
 const FAQ = () => {
   const t = useT();
   const items = [
@@ -1111,6 +1171,7 @@ const Footer = () => {
           <a className="brand" href="#top"><img src="icon.png" alt="" style={{ width:26, height:26, borderRadius:7 }}/>Rclone GUI</a>
           <div className="nav-sp"/>
           <a href="#versions">{t('Nouveautés','What\'s new')}</a>
+          <a href="#roadmap">Roadmap</a>
           <a href="#faq">FAQ</a>
           <a href={APP_STORE_URL} target="_blank" rel="noopener">App Store</a>
           <a href={GITHUB_URL} target="_blank" rel="noopener">GitHub</a>
@@ -1132,6 +1193,7 @@ const App = () => {
       <Gallery lang={lang}/>
       <Features/>
       <Versions/>
+      <Roadmap lang={lang}/>
       <Pricing/>
       <FreeMonth/>
       <FAQ/>

--- a/docs/index.html
+++ b/docs/index.html
@@ -289,6 +289,30 @@
   .faq-item[open] summary::after{content:"\2212"}
   .faq-item p{margin:0 0 18px;color:var(--muted);font-size:15px;font-weight:500;line-height:1.55}
   .faq-item p a{color:var(--accent);font-weight:700}
+  /* roadmap */
+  .roadmap{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:38px;align-items:start}
+  .rm-col{background:#fff;border:1px solid var(--line);border-radius:20px;padding:22px 22px 8px;
+    box-shadow:0 8px 26px rgba(11,8,32,.05);border-top:4px solid var(--accent)}
+  .rm-short{border-top-color:#34C759}
+  .rm-mid{border-top-color:#1A73E8}
+  .rm-long{border-top-color:var(--accent)}
+  .rm-head{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:6px}
+  .rm-label{font-size:18px;font-weight:800;letter-spacing:-.3px}
+  .rm-tag{font-size:10px;font-weight:800;letter-spacing:.5px;padding:4px 9px;border-radius:999px;
+    background:var(--accent-soft);color:var(--accent-deep);white-space:nowrap}
+  .rm-short .rm-tag{background:rgba(52,199,89,.16);color:#1f8f4a}
+  .rm-mid .rm-tag{background:rgba(26,115,232,.14);color:#0e5fae}
+  .rm-items{display:flex;flex-direction:column}
+  .rm-item{padding:12px 0;border-bottom:1px solid var(--line)}
+  .rm-item:last-child{border-bottom:none}
+  .rm-item h5{margin:0;font-size:15px;font-weight:700;letter-spacing:-.2px}
+  .rm-item p{margin:4px 0 0;font-size:13.5px;color:var(--muted);font-weight:500;line-height:1.45}
+  .rm-bet{display:flex;gap:12px;align-items:flex-start;margin:26px auto 0;max-width:820px;
+    background:linear-gradient(135deg,var(--accent),var(--accent-deep));color:#fff;border-radius:18px;
+    padding:18px 22px;font-size:15px;line-height:1.5;box-shadow:0 16px 40px rgba(124,58,237,.30)}
+  .rm-bet svg{flex:0 0 auto;margin-top:2px}
+  .rm-note{text-align:center;color:var(--muted);font-size:13px;font-weight:500;margin:18px auto 0;max-width:620px}
+  @media(max-width:760px){.roadmap{grid-template-columns:1fr}}
   /* new badge on gallery panels */
   .panel .newtag{position:absolute;top:16px;right:16px;background:var(--accent);color:#fff;font-size:10px;
     font-weight:800;letter-spacing:.5px;padding:4px 9px;border-radius:999px;z-index:3;


### PR DESCRIPTION
## Roadmap produit (site + app)

Roadmap ambitieuse issue d'un **brainstorm multi-IA** (Claude + Codex + OpenCode Go), **validée**, organisée en 3 horizons : **Court / Moyen / Long terme**.

### Site — rclone.rougetet.com
- Nouvelle section **« Roadmap »** (`#roadmap`) : 3 colonnes color-codées (En préparation / Prévu / Vision), **15 fonctionnalités** avec descriptions + le **pari produit « Capability, pas compte »**.
- Liens de navigation (header + footer), CSS dédié, FR/EN, `app.js` recompilé (runtime classique).
- Rendu vérifié (Chrome) : 3 colonnes, 15 items, 0 erreur JS.

### App
- Nouvel écran **`RoadmapView`** (compact) : 3 horizons + fonctionnalités phares + bouton **« Voir la feuille de route complète »** vers le détail du site. Le détail évolutif vit sur le web → pas besoin d'une release App Store pour le mettre à jour.
- Accessible via **Réglages → « Feuille de route »**.
- **i18n** : 14 chaînes traduites en 12 langues — insertion **purement additive** du String Catalog (1148 insertions, 0 suppression).
- Builds **iOS (simulateur) + macOS** validés via le MCP Xcode.

### Notes
- ADN préservé : privacy-first, open source, **aucun serveur backend**, chiffrement on-device.
- `MARKETING_VERSION` inchangé (1.6 en revue) — l'écran app partira dans la **prochaine version**. Le site, lui, est live dès le merge.