### PR TITLE
feat(cache): Phase E2 — branche « Taille max » à l'éviction LRU

### DIFF
--- a/Rclone GUI/Localizable.xcstrings
+++ b/Rclone GUI/Localizable.xcstrings
@@ -1,6 +1,88 @@
 {
   "sourceLanguage" : "fr",
   "strings" : {
+    "Quand le cache dépasse cette taille, les fichiers les moins récemment lus sont effacés automatiquement en premier (LRU)." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wenn der Cache diese Größe überschreitet, werden zuerst die am längsten nicht abgespielten Dateien automatisch gelöscht (LRU)."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When the cache exceeds this size, the least recently played files are deleted automatically first (LRU)."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuando la caché supera este tamaño, los archivos reproducidos menos recientemente se eliminan automáticamente primero (LRU)."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quand le cache dépasse cette taille, les fichiers les moins récemment lus sont effacés automatiquement en premier (LRU)."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando la cache supera questa dimensione, i file riprodotti meno di recente vengono eliminati automaticamente per primi (LRU)."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュがこのサイズを超えると、最も長く再生されていないファイルから自動的に削除されます（LRU）。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시가 이 크기를 초과하면 가장 오래전에 재생한 파일부터 자동으로 삭제됩니다(LRU)."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wanneer de cache deze grootte overschrijdt, worden eerst de minst recent afgespeelde bestanden automatisch verwijderd (LRU)."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gdy pamięć podręczna przekroczy ten rozmiar, najdawniej odtwarzane pliki są usuwane automatycznie w pierwszej kolejności (LRU)."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando o cache excede este tamanho, os arquivos reproduzidos menos recentemente são apagados automaticamente primeiro (LRU)."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Когда кэш превышает этот размер, файлы, которые дольше всего не воспроизводились, удаляются автоматически в первую очередь (LRU)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当缓存超过此大小时，最久未播放的文件会被自动优先删除（LRU）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當快取超過此大小時，最久未播放的檔案會被自動優先刪除（LRU）。"
+          }
+        }
+      }
+    },
     "Effacer le cache au verrouillage" : {
       "localizations" : {
         "de" : {

--- a/Rclone GUI/Views/Settings/CacheSettingsView.swift
+++ b/Rclone GUI/Views/Settings/CacheSettingsView.swift
@@ -36,7 +36,7 @@ struct CacheSettingsView: View {
                     }
                 }
             } footer: {
-                Text("Quand le cache atteint cette taille, les fichiers les plus anciens sont effacés en premier (LRU — Phase E2).")
+                Text("Quand le cache dépasse cette taille, les fichiers les moins récemment lus sont effacés automatiquement en premier (LRU).")
             }
 
             Section {
@@ -62,7 +62,25 @@ struct CacheSettingsView: View {
         #if os(iOS)
         .rgInlineNavTitle()
         #endif
-        .task { await refreshSize() }
+        .task {
+            // Synchronise la limite LRU du service avec le réglage de l'UI
+            // (sources de vérité distinctes) puis affiche la taille courante.
+            await MediaCacheService.shared.setMaxSizeBytes(bytes(forGB: maxSizeGB))
+            await refreshSize()
+        }
+        .onChange(of: maxSizeGB) { _, newValue in
+            // L'utilisateur ajuste la limite : on l'applique au service et on
+            // évince immédiatement si le cache dépasse déjà la nouvelle taille.
+            Task {
+                await MediaCacheService.shared.setMaxSizeBytes(bytes(forGB: newValue))
+                try? await MediaCacheService.shared.evictIfNeeded()
+                await refreshSize()
+            }
+        }
+    }
+
+    private func bytes(forGB gb: Double) -> Int64 {
+        Int64(gb) * 1_073_741_824
     }
 
     private func refreshSize() async {


### PR DESCRIPTION
## Phase E2 (volet LRU) — éviction du cache pilotée par le réglage

L'algorithme **LRU existait déjà** (`MediaCacheService.evictIfNeeded()` : évince le moins récemment lu jusque sous la limite, appelé avant/après chaque download). Le **bug** : le slider « Taille max » écrivait `cache.maxSizeGB`, jamais lu par le service (qui lit `mediaCache.maxSizeBytes` → toujours 5 Go par défaut). Régler la taille n'avait donc **aucun effet**.

### Correctif
- **`CacheSettingsView`** : synchronise la limite vers `MediaCacheService.setMaxSizeBytes()` à l'ouverture **et** à chaque changement du slider, puis **évince immédiatement** (`evictIfNeeded()`) si le cache dépasse déjà la nouvelle taille.
- Footer réécrit (fin de la promesse « LRU — Phase E2 »).
- **i18n** : 1 chaîne × 12 langues (additif, 0 suppression).
- ✅ Builds iOS + macOS via le MCP Xcode.

Avec le wipe-au-verrouillage (#29), le volet **sécurité + LRU** de la Phase E2 est clos. `MARKETING_VERSION` inchangé (1.6 en revue).