### PR TITLE
feat(intents): Phase E2 — deep-link OpenRemote + UploadFileIntent

### DIFF
--- a/Rclone GUI/AppIntents/RcloneGUIIntents.swift
+++ b/Rclone GUI/AppIntents/RcloneGUIIntents.swift
@@ -7,12 +7,18 @@
 //    - DownloadFileIntent   : "Télécharger <path> depuis <remote>"
 //    - ListRemotesIntent    : "Liste mes remotes rclone"
 //
-//  Phase E2 will add UploadFileIntent + parameter resolvers (interactive
-//  remote/path picker via AppEntity).
+//  Phase E2 : OpenRemoteIntent deep-links directly into the remote's folder,
+//  and UploadFileIntent uploads a file from Shortcuts/Share Sheet.
 //
 
 import AppIntents
 import Foundation
+
+extension Notification.Name {
+    /// Posté par OpenRemoteIntent ; observé par MainTabView pour naviguer
+    /// directement vers le dossier racine du remote demandé.
+    static let rgOpenRemote = Notification.Name("com.rougetet.rclone-gui.openRemote")
+}
 
 @available(iOS 17.0, *)
 public struct RcloneGUIShortcuts: AppShortcutsProvider {
@@ -76,10 +82,15 @@ public struct OpenRemoteIntent: AppIntent {
 
     @MainActor
     public func perform() async throws -> some IntentResult & ProvidesDialog {
-        // Phase E1 minimum : the app is foregrounded and the user is told
-        // which remote to navigate to. Phase E2 will deep-link directly
-        // to FolderView via NavigationStack programmatic push.
-        return .result(dialog: "Ouvre l'onglet Remotes pour aller dans \(remoteName).")
+        // Phase E2 : deep-link réel — on poste une notification que MainTabView
+        // intercepte pour basculer sur l'onglet Fichiers et pousser le dossier
+        // racine du remote dans la pile de navigation.
+        NotificationCenter.default.post(
+            name: .rgOpenRemote,
+            object: nil,
+            userInfo: ["remote": remoteName]
+        )
+        return .result(dialog: "Ouverture de \(remoteName)…")
     }
 }
 
@@ -123,5 +134,48 @@ public struct DownloadFileIntent: AppIntent {
             to: dst
         )
         return .result(dialog: "Téléchargement de \(basename) lancé.")
+    }
+}
+
+// MARK: - Upload file
+
+@available(iOS 17.0, *)
+public struct UploadFileIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Téléverser un fichier"
+    public static let description = IntentDescription(
+        "Téléverse un fichier vers un remote rclone (depuis Raccourcis ou la feuille de partage)."
+    )
+
+    @Parameter(title: "Fichier")
+    public var file: IntentFile
+
+    @Parameter(title: "Remote")
+    public var remoteName: String
+
+    @Parameter(title: "Dossier de destination", default: "")
+    public var destinationFolder: String
+
+    public init() {}
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        // Matérialise le fichier fourni par Raccourcis dans un emplacement
+        // local temporaire avant de l'enquêter pour upload.
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appending(path: "intent-uploads", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        let filename = file.filename
+        let localURL = tmpDir.appending(path: filename)
+        try? FileManager.default.removeItem(at: localURL)
+        try file.data.write(to: localURL)
+
+        let folder = destinationFolder.trimmingCharacters(in: CharacterSet(charactersIn: "/ "))
+        let destPath = folder.isEmpty ? filename : "\(folder)/\(filename)"
+        try await TransferQueue.shared.enqueueUpload(
+            local: localURL,
+            remote: remoteName,
+            path: destPath
+        )
+        return .result(dialog: "Téléversement de \(filename) vers \(remoteName) lancé.")
     }
 }

--- a/Rclone GUI/Localizable.xcstrings
+++ b/Rclone GUI/Localizable.xcstrings
@@ -1,6 +1,170 @@
 {
   "sourceLanguage" : "fr",
   "strings" : {
+    "Téléverser un fichier" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datei hochladen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upload a file"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subir un archivo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléverser un fichier"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carica un file"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルをアップロード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파일 업로드"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestand uploaden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prześlij plik"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar um arquivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузить файл"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上传文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上傳檔案"
+          }
+        }
+      }
+    },
+    "Téléverse un fichier vers un remote rclone (depuis Raccourcis ou la feuille de partage)." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lädt eine Datei auf ein rclone-Remote hoch (über Kurzbefehle oder das Teilen-Menü)."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uploads a file to an rclone remote (from Shortcuts or the share sheet)."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sube un archivo a un remoto rclone (desde Atajos o la hoja de compartir)."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléverse un fichier vers un remote rclone (depuis Raccourcis ou la feuille de partage)."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carica un file su un remote rclone (da Comandi rapidi o dal foglio di condivisione)."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "rclone リモートにファイルをアップロードします（ショートカットや共有シートから）。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "rclone 리모트에 파일을 업로드합니다(단축어 또는 공유 시트에서)."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uploadt een bestand naar een rclone-remote (vanuit Opdrachten of het deelmenu)."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przesyła plik do zdalnego rclone (ze Skrótów lub arkusza udostępniania)."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envia um arquivo para um remote rclone (a partir dos Atalhos ou da folha de compartilhamento)."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загружает файл в удалённое хранилище rclone (из Быстрых команд или меню «Поделиться»)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将文件上传到 rclone 远端（从“快捷指令”或共享表单）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將檔案上傳到 rclone 遠端（從「捷徑」或分享工作表）。"
+          }
+        }
+      }
+    },
     "Quand le cache dépasse cette taille, les fichiers les moins récemment lus sont effacés automatiquement en premier (LRU)." : {
       "localizations" : {
         "de" : {

--- a/Rclone GUI/Views/MainTabView.swift
+++ b/Rclone GUI/Views/MainTabView.swift
@@ -97,6 +97,7 @@ struct MainTabView: View {
             // pushed under Files doesn't bleed into Home/Transfers/Settings.
             .id(selection)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .rgOpenRemote)) { handleOpenRemote($0) }
         #else
         TabView(selection: $selection) {
             ForEach(Tab.allCases) { tab in
@@ -107,6 +108,7 @@ struct MainTabView: View {
                     .tag(tab)
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .rgOpenRemote)) { handleOpenRemote($0) }
         #if DEBUG
         // Debug-only deep link used by the App Store screenshot pipeline to land
         // directly on a given surface. Inert unless launched with `--demo-screen`.
@@ -148,6 +150,16 @@ struct MainTabView: View {
         case .folder(let remote, let path):
             FolderView(remote: remote, path: path)
         }
+    }
+
+    /// Deep-link déclenché par OpenRemoteIntent (App Intents / Raccourcis) :
+    /// bascule sur l'onglet Fichiers et pousse le dossier racine du remote.
+    private func handleOpenRemote(_ note: Notification) {
+        guard let remote = note.userInfo?["remote"] as? String, !remote.isEmpty else { return }
+        selection = .files
+        #if !os(macOS)
+        filesPath = [.folder(remote: remote, path: "")]
+        #endif
     }
 }
 


### PR DESCRIPTION
## App Intents — Phase E2

- **`OpenRemoteIntent`** : **deep-link réel**. Au lieu d'un simple message, il poste une notification `rgOpenRemote` que `MainTabView` intercepte pour **basculer sur l'onglet Fichiers et pousser le dossier racine** du remote (via `filesPath` / `NavigationDestination.folder`).
- **`UploadFileIntent`** (nouveau) : téléverse un fichier vers un remote depuis **Raccourcis / la feuille de partage**. Matérialise l'`IntentFile` en local puis `enqueueUpload`.
- **i18n** : titre + description traduits en 12 langues (additif) ; les dialogues interpolés ("Ouverture de …", "Téléversement de …") restent en source FR (substitutions de format, secondaires côté Raccourcis).
- ✅ Builds iOS + macOS via le MCP Xcode.