### PR TITLE
feat(logs): Phase E2 — capture live des logs internes rclone (bridge slog)

### DIFF
--- a/Rclone GUI/Core/LibrcloneEngine.swift
+++ b/Rclone GUI/Core/LibrcloneEngine.swift
@@ -41,6 +41,9 @@ public struct LibrcloneEngine: RcloneEngine {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             DispatchQueue.global(qos: .userInitiated).async {
                 RclonebridgeInitialize()
+                // Phase E2 — démarre la capture des logs internes rclone (slog)
+                // pour que Réglages → Logs montre l'activité réelle du moteur.
+                RclonebridgeStartLogCapture()
                 continuation.resume()
             }
         }

--- a/Rclone GUI/Services/LogService.swift
+++ b/Rclone GUI/Services/LogService.swift
@@ -8,6 +8,9 @@
 //
 
 import Foundation
+#if canImport(RcloneKit)
+import RcloneKit
+#endif
 
 public enum LogLevel: String, Sendable, Codable {
     case info = "INFO"
@@ -108,6 +111,52 @@ public actor LogService {
         }
         print("\(icon) [\(category)] \(message)")
         #endif
+    }
+
+    private static let bridgeDateParser: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    /// Phase E2 — récupère les lignes de log internes de rclone capturées par
+    /// le bridge Go (slog) et les fond dans le ring sous la catégorie « rclone ».
+    /// Polled par LogsView tant que l'écran est visible. No-op si le moteur réel
+    /// (RcloneKit) n'est pas embarqué.
+    public func ingestBridgeLogs() {
+        #if canImport(RcloneKit)
+        let raw = RclonebridgeDrainLogs()
+        guard let data = raw.data(using: .utf8),
+              let lines = try? JSONDecoder().decode([String].self, from: data),
+              !lines.isEmpty else { return }
+        for line in lines {
+            let parts = line.split(separator: "\t", maxSplits: 2, omittingEmptySubsequences: false)
+            let timestamp = parts.count > 0 ? (Self.bridgeDateParser.date(from: String(parts[0])) ?? .now) : .now
+            let levelStr = parts.count > 1 ? String(parts[1]) : "INFO"
+            let message = parts.count > 2 ? String(parts[2]) : line
+            let level: LogLevel
+            switch levelStr {
+            case "ERROR":  level = .error
+            case "DEBUG":  level = .debug
+            default:       level = .info   // INFO / NOTICE / WARNING
+            }
+            appendEntry(LogEntry(timestamp: timestamp, level: level, category: "rclone", message: message))
+        }
+        #endif
+    }
+
+    /// Append sans miroir console (utilisé pour l'ingestion bridge — rclone a
+    /// déjà écrit ces lignes sur stderr via son handler d'origine).
+    private func appendEntry(_ entry: LogEntry) {
+        if !didReserveCapacity {
+            ring.reserveCapacity(maxEntries)
+            didReserveCapacity = true
+        }
+        ring.append(entry)
+        if ring.count > maxEntries {
+            let overflow = ring.count - maxEntries
+            ring.removeFirst(max(overflow, 100))
+        }
     }
 
     public func entries(filter: LogLevel? = nil, category: String? = nil) -> [LogEntry] {

--- a/Rclone GUI/Views/Settings/LogsView.swift
+++ b/Rclone GUI/Views/Settings/LogsView.swift
@@ -115,6 +115,12 @@ struct LogsView: View {
             await reload()
             crashReport = CrashReporter.pendingReportText()
             crashReportURL = CrashReporter.pendingReportFileURL()
+            // Logs live : tant que l'écran est ouvert, on draine périodiquement
+            // les logs internes rclone capturés par le bridge.
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(3))
+                await reload()
+            }
         }
         #if canImport(UIKit)
         .sheet(isPresented: $showCrashReport) {
@@ -236,6 +242,8 @@ struct LogsView: View {
     }
 
     private func reload() async {
+        // Fond les logs internes rclone (capturés par le bridge) avant lecture.
+        await LogService.shared.ingestBridgeLogs()
         let appEntries = await LogService.shared.entries(filter: levelFilter)
         let providerEntries = await MainActor.run {
             FileProviderManager.shared.diagnosticEntries()

--- a/scripts/rclone-bridge/bridge.go
+++ b/scripts/rclone-bridge/bridge.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net"
 	"net/http"
@@ -49,6 +50,89 @@ type RPCResult struct {
 }
 
 var streamSessions sync.Map // map[string]*http.Server
+
+// ─── Live log capture (Phase E2) ──────────────────────────────────────────
+// rclone logs through log/slog. We tee its default handler into a bounded
+// ring buffer that the host polls via DrainLogs, so Settings → Logs can show
+// the engine's real activity (notices, warnings, errors) — no backend server,
+// nothing leaves the device.
+
+var (
+	logMu     sync.Mutex
+	logRing   []string
+	logActive bool
+)
+
+const logRingCap = 2000
+
+type captureHandler struct{ inner slog.Handler }
+
+func (h *captureHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.inner.Enabled(ctx, l)
+}
+
+func (h *captureHandler) Handle(ctx context.Context, r slog.Record) error {
+	line := r.Time.UTC().Format(time.RFC3339) + "\t" + slogLevelLabel(r.Level) + "\t" + r.Message
+	logMu.Lock()
+	logRing = append(logRing, line)
+	if len(logRing) > logRingCap {
+		logRing = logRing[len(logRing)-logRingCap:]
+	}
+	logMu.Unlock()
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *captureHandler) WithAttrs(a []slog.Attr) slog.Handler {
+	return &captureHandler{inner: h.inner.WithAttrs(a)}
+}
+
+func (h *captureHandler) WithGroup(name string) slog.Handler {
+	return &captureHandler{inner: h.inner.WithGroup(name)}
+}
+
+func slogLevelLabel(l slog.Level) string {
+	switch {
+	case l < slog.LevelInfo:
+		return "DEBUG"
+	case l < slog.Level(2): // rclone NOTICE = 2
+		return "INFO"
+	case l < slog.LevelWarn:
+		return "NOTICE"
+	case l < slog.LevelError:
+		return "WARNING"
+	default:
+		return "ERROR"
+	}
+}
+
+// StartLogCapture begins teeing rclone's slog output into the ring buffer.
+// Idempotent — call once at startup. Preserves the existing handler (stderr).
+func StartLogCapture() {
+	logMu.Lock()
+	defer logMu.Unlock()
+	if logActive {
+		return
+	}
+	slog.SetDefault(slog.New(&captureHandler{inner: slog.Default().Handler()}))
+	logActive = true
+}
+
+// DrainLogs returns the log lines captured since the last call as a JSON array
+// of "RFC3339\tLEVEL\tmessage" strings, then clears the buffer. Returns "[]"
+// when empty.
+func DrainLogs() string {
+	logMu.Lock()
+	defer logMu.Unlock()
+	if len(logRing) == 0 {
+		return "[]"
+	}
+	out, err := json.Marshal(logRing)
+	logRing = logRing[:0]
+	if err != nil {
+		return "[]"
+	}
+	return string(out)
+}
 
 // SetEnv updates a process environment variable. Must be used instead of
 // the host's setenv(3) when the host is Swift on iOS: gomobile boots the


### PR DESCRIPTION
## Logs live du moteur rclone

Avant : `LogService` ne contenait que les logs émis côté Swift. Maintenant le **bridge Go tee le handler `log/slog` de rclone** dans un ring buffer borné, exposé via `DrainLogs()` — Réglages → Logs montre l'**activité réelle du moteur** (notices, warnings, erreurs). Aucun serveur, rien ne quitte l'appareil.

### Changements
- **`bridge.go`** : `captureHandler` (slog) qui tee vers le handler d'origine + un ring buffer ; `StartLogCapture()` (idempotent) + `DrainLogs()` (JSON, vide le buffer).
- **`LibrcloneEngine`** : `RclonebridgeStartLogCapture()` juste après `Initialize()`.
- **`LogService.ingestBridgeLogs()`** : draine + parse (`ts\tLEVEL\tmsg`) + fond dans le ring (catégorie « rclone »).
- **`LogsView`** : polling live toutes les 3 s tant que l'écran est ouvert.

### Vérification
- ✅ **Rebuild local du xcframework** réussi (nouveaux symboles présents sur ios-arm64 + macos-arm64).
- ✅ **Build macOS de l'app** réussi contre ces symboles.
- Le xcframework est **gitignoré** → `ci_post_clone` le rebuilde depuis `bridge.go` (le build App Store device l'aura).
- ⚠️ `build-rclone.sh` ne génère que device + mac (pas la slice simulateur) — sans impact sur le build App Store.