### PR TITLE
feat(roadmap): dates cibles précises (site + app)

### DIFF
--- a/Rclone GUI/Localizable.xcstrings
+++ b/Rclone GUI/Localizable.xcstrings
@@ -1,6 +1,580 @@
 {
   "sourceLanguage" : "fr",
   "strings" : {
+    "Transferts Pro" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro-Transfers"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro Transfers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencias Pro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferts Pro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trasferimenti Pro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro転送"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro 전송"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro-overdrachten"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfery Pro"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferências Pro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pro-передачи"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "专业传输"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專業傳輸"
+          }
+        }
+      }
+    },
+    "Handoff P2P" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P-Handoff"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P Handoff"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff P2P"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff P2P"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff P2P"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2Pハンドオフ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P 핸드오프"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P-handoff"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff P2P"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff P2P"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P-передача"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P 交接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P2P 交接"
+          }
+        }
+      }
+    },
+    "Recherche sémantique on-device" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semantische Suche on-device"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "On-device semantic search"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Búsqueda semántica en el dispositivo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche sémantique on-device"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricerca semantica on-device"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンデバイス意味検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "온디바이스 의미 검색"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semantisch zoeken op het apparaat"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyszukiwanie semantyczne na urządzeniu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Busca semântica no dispositivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Семантический поиск на устройстве"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备端语义搜索"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "裝置端語意搜尋"
+          }
+        }
+      }
+    },
+    "Règles de sync" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync-Regeln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync rules"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reglas de sync"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Règles de sync"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regole di sync"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期ルール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동기화 규칙"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync-regels"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reguły synchronizacji"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regras de sync"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Правила синхронизации"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步规则"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步規則"
+          }
+        }
+      }
+    },
+    "Mode Voyage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reisemodus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Travel Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo Viaje"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode Voyage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalità Viaggio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旅行モード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여행 모드"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reismodus"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryb podróży"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo Viagem"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим путешествия"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旅行模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旅行模式"
+          }
+        }
+      }
+    },
+    "Héritage numérique" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digitales Erbe"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digital legacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legado digital"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Héritage numérique"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eredità digitale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デジタル遺産"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디지털 유산"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Digitale nalatenschap"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cyfrowe dziedzictwo"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Legado digital"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цифровое наследие"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数字遗产"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "數位遺產"
+          }
+        }
+      }
+    },
+    "Dates cibles, susceptibles d'évoluer." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zieltermine, Änderungen möglich."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Target dates, subject to change."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechas previstas, sujetas a cambios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dates cibles, susceptibles d'évoluer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date obiettivo, soggette a modifiche."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標日です。変更される場合があります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목표 날짜이며 변경될 수 있습니다."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streefdata, kunnen wijzigen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daty docelowe, mogą ulec zmianie."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datas previstas, sujeitas a alteração."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ориентировочные даты, могут измениться."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目标日期，可能会变。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目標日期，可能會變。"
+          }
+        }
+      }
+    },
     "Téléverser un fichier" : {
       "localizations" : {
         "de" : {

--- a/Rclone GUI/Views/Settings/RoadmapView.swift
+++ b/Rclone GUI/Views/Settings/RoadmapView.swift
@@ -2,11 +2,12 @@
 //  RoadmapView.swift
 //  Rclone GUI — Views/Settings
 //
-//  Compact "what's coming" screen. The full, continuously-evolving roadmap
-//  lives on the website (rclone.rougetet.com/#roadmap) so it can change
-//  without shipping an App Store update; here we surface the headline items
-//  per horizon and link out for the detail. Stays on-brand: privacy-first,
-//  open source, no backend.
+//  Compact "what's coming" screen with target dates. The full, continuously-
+//  evolving roadmap lives on the website (rclone.rougetet.com/#roadmap) so it
+//  can change without an App Store update; here we surface the headline items
+//  per horizon with their target date and link out. Dates are locale-neutral
+//  (numeric month/year, Qn) so they need no translation. Stays on-brand:
+//  privacy-first, open source, no backend.
 //
 
 import SwiftUI
@@ -14,6 +15,12 @@ import SwiftUI
 struct RoadmapView: View {
     @Environment(\.openURL) private var openURL
     private let fullURL = URL(string: "https://rclone.rougetet.com/#roadmap")!
+
+    private struct Item: Identifiable {
+        let id = UUID()
+        let name: LocalizedStringKey
+        let date: String   // locale-neutral, e.g. "07/2026", "Q1 2027"
+    }
 
     var body: some View {
         List {
@@ -23,24 +30,27 @@ struct RoadmapView: View {
                     .foregroundStyle(.secondary)
             }
 
-            horizon(
-                label: "Court terme",
-                tag: "En préparation",
-                tint: .green,
-                items: "Transferts Pro · Flows · Ghost Vault · Handoff P2P · Glass Engine"
-            )
-            horizon(
-                label: "Moyen terme",
-                tag: "Prévu",
-                tint: .blue,
-                items: "Remote Lens · Recherche sémantique on-device · Sealed Share · Règles de sync · Mode Voyage"
-            )
-            horizon(
-                label: "Long terme",
-                tag: "Vision",
-                tint: .purple,
-                items: "ChronoDrive · Ghost Sync · Quantum Vault · CipherSpace · Héritage numérique"
-            )
+            horizon(label: "Court terme", window: "07–09 / 2026", tint: .green, items: [
+                Item(name: "Transferts Pro", date: "07/2026"),
+                Item(name: "Flows", date: "07/2026"),
+                Item(name: "Ghost Vault", date: "08/2026"),
+                Item(name: "Handoff P2P", date: "08/2026"),
+                Item(name: "Glass Engine", date: "09/2026"),
+            ])
+            horizon(label: "Moyen terme", window: "10–12 / 2026", tint: .blue, items: [
+                Item(name: "Remote Lens", date: "10/2026"),
+                Item(name: "Sealed Share", date: "10/2026"),
+                Item(name: "Recherche sémantique on-device", date: "11/2026"),
+                Item(name: "Règles de sync", date: "11/2026"),
+                Item(name: "Mode Voyage", date: "12/2026"),
+            ])
+            horizon(label: "Long terme", window: "2027", tint: .purple, items: [
+                Item(name: "ChronoDrive", date: "Q1 2027"),
+                Item(name: "Ghost Sync", date: "Q1 2027"),
+                Item(name: "Quantum Vault", date: "Q2 2027"),
+                Item(name: "Héritage numérique", date: "Q2 2027"),
+                Item(name: "CipherSpace", date: "Q3 2027"),
+            ])
 
             Section {
                 Button {
@@ -49,7 +59,7 @@ struct RoadmapView: View {
                     Label("Voir la feuille de route complète", systemImage: "safari")
                 }
             } footer: {
-                Text("Roadmap indicative, sans engagement de date — priorisée avec vos retours.")
+                Text("Dates cibles, susceptibles d'évoluer.")
             }
         }
         .navigationTitle("Feuille de route")
@@ -59,14 +69,18 @@ struct RoadmapView: View {
     }
 
     @ViewBuilder
-    private func horizon(
-        label: LocalizedStringKey,
-        tag: LocalizedStringKey,
-        tint: Color,
-        items: LocalizedStringKey
-    ) -> some View {
+    private func horizon(label: LocalizedStringKey, window: String, tint: Color, items: [Item]) -> some View {
         Section {
-            Text(items).font(.callout)
+            ForEach(items) { it in
+                HStack(spacing: 10) {
+                    Text(it.name).font(.callout)
+                    Spacer(minLength: 8)
+                    Text(it.date)
+                        .font(.caption.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+            }
         } header: {
             HStack {
                 Text(label)
@@ -74,8 +88,9 @@ struct RoadmapView: View {
                     .foregroundStyle(.primary)
                     .textCase(nil)
                 Spacer()
-                Text(tag)
+                Text(window)
                     .font(.caption2.weight(.bold))
+                    .monospacedDigit()
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
                     .background(tint.opacity(0.18), in: Capsule())

--- a/docs/app.js
+++ b/docs/app.js
@@ -3623,13 +3623,17 @@ const ROADMAP = [{
     en: 'Short term'
   },
   tag: {
-    fr: 'EN PRÉPARATION',
-    en: 'IN PROGRESS'
+    fr: 'Juil.–sept. 2026',
+    en: 'Jul–Sep 2026'
   },
   items: [{
     n: {
       fr: 'Transferts Pro',
       en: 'Pro Transfers'
+    },
+    when: {
+      fr: 'Juil. 2026',
+      en: 'Jul 2026'
     },
     d: {
       fr: 'File d\'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire, logs exportables.',
@@ -3640,6 +3644,10 @@ const ROADMAP = [{
       fr: 'Flows',
       en: 'Flows'
     },
+    when: {
+      fr: 'Juil. 2026',
+      en: 'Jul 2026'
+    },
     d: {
       fr: 'Automatisations 100 % locales (Raccourcis + App Intents) et Live Activity « santé du backup ».',
       en: '100% local automations (Shortcuts + App Intents) and a "backup health" Live Activity.'
@@ -3648,6 +3656,10 @@ const ROADMAP = [{
     n: {
       fr: 'Ghost Vault',
       en: 'Ghost Vault'
+    },
+    when: {
+      fr: 'Août 2026',
+      en: 'Aug 2026'
     },
     d: {
       fr: 'Sauvegarde chiffrée de toute ta config dans ton propre remote, scellée par Face ID. Sans compte.',
@@ -3658,6 +3670,10 @@ const ROADMAP = [{
       fr: 'Handoff P2P',
       en: 'P2P Handoff'
     },
+    when: {
+      fr: 'Août 2026',
+      en: 'Aug 2026'
+    },
     d: {
       fr: 'Transférer une config chiffrée entre tes appareils via QR / AirDrop, sans serveur.',
       en: 'Move an encrypted config between your devices via QR / AirDrop, with no server.'
@@ -3666,6 +3682,10 @@ const ROADMAP = [{
     n: {
       fr: 'Glass Engine',
       en: 'Glass Engine'
+    },
+    when: {
+      fr: 'Sept. 2026',
+      en: 'Sep 2026'
     },
     d: {
       fr: 'Moniteur « 0 appel maison » + build reproductible : prouver le privacy, pas le promettre.',
@@ -3679,13 +3699,17 @@ const ROADMAP = [{
     en: 'Mid term'
   },
   tag: {
-    fr: 'PRÉVU',
-    en: 'PLANNED'
+    fr: 'Oct.–déc. 2026',
+    en: 'Oct–Dec 2026'
   },
   items: [{
     n: {
       fr: 'Remote Lens',
       en: 'Remote Lens'
+    },
+    when: {
+      fr: 'Oct. 2026',
+      en: 'Oct 2026'
     },
     d: {
       fr: 'Aperçus (vignettes, EXIF, 1re page PDF) par range requests, sans tout télécharger ni déchiffrer.',
@@ -3693,17 +3717,12 @@ const ROADMAP = [{
     }
   }, {
     n: {
-      fr: 'Recherche sémantique on-device',
-      en: 'On-device semantic search'
-    },
-    d: {
-      fr: 'Médiathèque locale chiffrée + recherche en langage naturel (Apple Intelligence), jamais côté serveur.',
-      en: 'Local encrypted media library + natural-language search (Apple Intelligence), never server-side.'
-    }
-  }, {
-    n: {
       fr: 'Sealed Share',
       en: 'Sealed Share'
+    },
+    when: {
+      fr: 'Oct. 2026',
+      en: 'Oct 2026'
     },
     d: {
       fr: 'Partage hors-bande : lien backend natif + capsule-clé via AirDrop/QR, déchiffrement on-device.',
@@ -3711,8 +3730,25 @@ const ROADMAP = [{
     }
   }, {
     n: {
+      fr: 'Recherche sémantique on-device',
+      en: 'On-device semantic search'
+    },
+    when: {
+      fr: 'Nov. 2026',
+      en: 'Nov 2026'
+    },
+    d: {
+      fr: 'Médiathèque locale chiffrée + recherche en langage naturel (Apple Intelligence), jamais côté serveur.',
+      en: 'Local encrypted media library + natural-language search (Apple Intelligence), never server-side.'
+    }
+  }, {
+    n: {
       fr: 'Règles de sync',
       en: 'Sync rules'
+    },
+    when: {
+      fr: 'Nov. 2026',
+      en: 'Nov 2026'
     },
     d: {
       fr: 'Règles locales par type/dossier + « toujours disponible hors-ligne » depuis Fichiers.',
@@ -3722,6 +3758,10 @@ const ROADMAP = [{
     n: {
       fr: 'Mode Voyage',
       en: 'Travel Mode'
+    },
+    when: {
+      fr: 'Déc. 2026',
+      en: 'Dec 2026'
     },
     d: {
       fr: 'Coffre éphémère (déchiffrement en RAM), auto-démontage et Face ID par remote.',
@@ -3735,13 +3775,17 @@ const ROADMAP = [{
     en: 'Long term'
   },
   tag: {
-    fr: 'VISION',
-    en: 'VISION'
+    fr: '2027',
+    en: '2027'
   },
   items: [{
     n: {
       fr: 'ChronoDrive',
       en: 'ChronoDrive'
+    },
+    when: {
+      fr: 'T1 2027',
+      en: 'Q1 2027'
     },
     d: {
       fr: 'N\'importe quel backend comme destination de sauvegarde versionnée façon Time Machine (macOS), chiffrée.',
@@ -3752,6 +3796,10 @@ const ROADMAP = [{
       fr: 'Ghost Sync',
       en: 'Ghost Sync'
     },
+    when: {
+      fr: 'T1 2027',
+      en: 'Q1 2027'
+    },
     d: {
       fr: 'Mesh P2P : réconciliation de deltas chiffrés entre tes appareils en réseau local, offline-first.',
       en: 'P2P mesh: encrypted delta reconciliation between your devices over the local network, offline-first.'
@@ -3761,27 +3809,39 @@ const ROADMAP = [{
       fr: 'Quantum Vault',
       en: 'Quantum Vault'
     },
+    when: {
+      fr: 'T2 2027',
+      en: 'Q2 2027'
+    },
     d: {
       fr: 'Chiffrement post-quantique hybride (Kyber + AES) pour des archives « 2035-proof ».',
       en: 'Hybrid post-quantum encryption (Kyber + AES) for "2035-proof" archives.'
     }
   }, {
     n: {
-      fr: 'CipherSpace',
-      en: 'CipherSpace'
-    },
-    d: {
-      fr: 'Explorer ses archives chiffrées dans l\'espace, sur visionOS.',
-      en: 'Explore your encrypted archives in space, on visionOS.'
-    }
-  }, {
-    n: {
       fr: 'Héritage numérique',
       en: 'Digital legacy'
+    },
+    when: {
+      fr: 'T2 2027',
+      en: 'Q2 2027'
     },
     d: {
       fr: 'Récupération sociale (partage de secret de Shamir) entre contacts de confiance + preuve de vie.',
       en: 'Social recovery (Shamir secret sharing) among trusted contacts + proof of life.'
+    }
+  }, {
+    n: {
+      fr: 'CipherSpace',
+      en: 'CipherSpace'
+    },
+    when: {
+      fr: 'T3 2027',
+      en: 'Q3 2027'
+    },
+    d: {
+      fr: 'Explorer ses archives chiffrées dans l\'espace, sur visionOS.',
+      en: 'Explore your encrypted archives in space, on visionOS.'
     }
   }]
 }];
@@ -3815,14 +3875,18 @@ const Roadmap = ({
   }, col.items.map(it => /*#__PURE__*/React.createElement("div", {
     key: it.n.en,
     className: "rm-item"
-  }, /*#__PURE__*/React.createElement("h5", null, it.n[lang] || it.n.en), /*#__PURE__*/React.createElement("p", null, it.d[lang] || it.d.en))))))), /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "rm-item-head"
+  }, /*#__PURE__*/React.createElement("h5", null, it.n[lang] || it.n.en), /*#__PURE__*/React.createElement("span", {
+    className: "rm-when"
+  }, it.when && (it.when[lang] || it.when.en) || '')), /*#__PURE__*/React.createElement("p", null, it.d[lang] || it.d.en))))))), /*#__PURE__*/React.createElement("div", {
     className: "rm-bet"
   }, /*#__PURE__*/React.createElement(Icon, {
     name: "bolt.fill",
     size: 16
   }), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, t('Pari produit', 'Product bet'), " : "), t('« Capability, pas compte » — le partage et le multi-appareils deviennent des objets cryptographiques que tu possèdes et révoques, jamais une ligne dans une base (puisqu\'il n\'y en a pas).', '"Capability, not account" — sharing and multi-device become cryptographic objects you own and revoke, never a row in a database (because there isn\'t one).'))), /*#__PURE__*/React.createElement("p", {
     className: "rm-note"
-  }, t('Roadmap indicative, sans engagement de date — priorisée avec vos retours. Open source : suivez ou contribuez sur GitHub.', 'Indicative roadmap, no committed dates — prioritized with your feedback. Open source: follow or contribute on GitHub.'))));
+  }, t('Dates cibles, susceptibles d\'évoluer — priorisées avec vos retours. Open source : suivez l\'avancement sur GitHub.', 'Target dates, subject to change — prioritized with your feedback. Open source: follow progress on GitHub.'))));
 };
 const FAQ = () => {
   const t = useT();

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -1065,26 +1065,26 @@ const Versions = () => {
 };
 
 const ROADMAP = [
-  { key:'short', label:{ fr:'Court terme', en:'Short term' }, tag:{ fr:'EN PRÉPARATION', en:'IN PROGRESS' }, items:[
-    { n:{ fr:'Transferts Pro', en:'Pro Transfers' }, d:{ fr:'File d\'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire, logs exportables.', en:'Queue, priorities, robust resume, Wi-Fi/cellular limits, exportable logs.' } },
-    { n:{ fr:'Flows', en:'Flows' }, d:{ fr:'Automatisations 100 % locales (Raccourcis + App Intents) et Live Activity « santé du backup ».', en:'100% local automations (Shortcuts + App Intents) and a "backup health" Live Activity.' } },
-    { n:{ fr:'Ghost Vault', en:'Ghost Vault' }, d:{ fr:'Sauvegarde chiffrée de toute ta config dans ton propre remote, scellée par Face ID. Sans compte.', en:'Encrypted backup of your whole config into your own remote, sealed with Face ID. No account.' } },
-    { n:{ fr:'Handoff P2P', en:'P2P Handoff' }, d:{ fr:'Transférer une config chiffrée entre tes appareils via QR / AirDrop, sans serveur.', en:'Move an encrypted config between your devices via QR / AirDrop, with no server.' } },
-    { n:{ fr:'Glass Engine', en:'Glass Engine' }, d:{ fr:'Moniteur « 0 appel maison » + build reproductible : prouver le privacy, pas le promettre.', en:'A "zero phone-home" monitor + reproducible build: prove privacy, don\'t just promise it.' } },
+  { key:'short', label:{ fr:'Court terme', en:'Short term' }, tag:{ fr:'Juil.–sept. 2026', en:'Jul–Sep 2026' }, items:[
+    { n:{ fr:'Transferts Pro', en:'Pro Transfers' }, when:{ fr:'Juil. 2026', en:'Jul 2026' }, d:{ fr:'File d\'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire, logs exportables.', en:'Queue, priorities, robust resume, Wi-Fi/cellular limits, exportable logs.' } },
+    { n:{ fr:'Flows', en:'Flows' }, when:{ fr:'Juil. 2026', en:'Jul 2026' }, d:{ fr:'Automatisations 100 % locales (Raccourcis + App Intents) et Live Activity « santé du backup ».', en:'100% local automations (Shortcuts + App Intents) and a "backup health" Live Activity.' } },
+    { n:{ fr:'Ghost Vault', en:'Ghost Vault' }, when:{ fr:'Août 2026', en:'Aug 2026' }, d:{ fr:'Sauvegarde chiffrée de toute ta config dans ton propre remote, scellée par Face ID. Sans compte.', en:'Encrypted backup of your whole config into your own remote, sealed with Face ID. No account.' } },
+    { n:{ fr:'Handoff P2P', en:'P2P Handoff' }, when:{ fr:'Août 2026', en:'Aug 2026' }, d:{ fr:'Transférer une config chiffrée entre tes appareils via QR / AirDrop, sans serveur.', en:'Move an encrypted config between your devices via QR / AirDrop, with no server.' } },
+    { n:{ fr:'Glass Engine', en:'Glass Engine' }, when:{ fr:'Sept. 2026', en:'Sep 2026' }, d:{ fr:'Moniteur « 0 appel maison » + build reproductible : prouver le privacy, pas le promettre.', en:'A "zero phone-home" monitor + reproducible build: prove privacy, don\'t just promise it.' } },
   ] },
-  { key:'mid', label:{ fr:'Moyen terme', en:'Mid term' }, tag:{ fr:'PRÉVU', en:'PLANNED' }, items:[
-    { n:{ fr:'Remote Lens', en:'Remote Lens' }, d:{ fr:'Aperçus (vignettes, EXIF, 1re page PDF) par range requests, sans tout télécharger ni déchiffrer.', en:'Previews (thumbnails, EXIF, first PDF page) via range requests, without downloading or fully decrypting.' } },
-    { n:{ fr:'Recherche sémantique on-device', en:'On-device semantic search' }, d:{ fr:'Médiathèque locale chiffrée + recherche en langage naturel (Apple Intelligence), jamais côté serveur.', en:'Local encrypted media library + natural-language search (Apple Intelligence), never server-side.' } },
-    { n:{ fr:'Sealed Share', en:'Sealed Share' }, d:{ fr:'Partage hors-bande : lien backend natif + capsule-clé via AirDrop/QR, déchiffrement on-device.', en:'Out-of-band sharing: native backend link + key capsule via AirDrop/QR, decrypted on-device.' } },
-    { n:{ fr:'Règles de sync', en:'Sync rules' }, d:{ fr:'Règles locales par type/dossier + « toujours disponible hors-ligne » depuis Fichiers.', en:'Local rules by type/folder + "always available offline" from Files.' } },
-    { n:{ fr:'Mode Voyage', en:'Travel Mode' }, d:{ fr:'Coffre éphémère (déchiffrement en RAM), auto-démontage et Face ID par remote.', en:'Ephemeral vault (in-RAM decryption), auto-unmount and per-remote Face ID.' } },
+  { key:'mid', label:{ fr:'Moyen terme', en:'Mid term' }, tag:{ fr:'Oct.–déc. 2026', en:'Oct–Dec 2026' }, items:[
+    { n:{ fr:'Remote Lens', en:'Remote Lens' }, when:{ fr:'Oct. 2026', en:'Oct 2026' }, d:{ fr:'Aperçus (vignettes, EXIF, 1re page PDF) par range requests, sans tout télécharger ni déchiffrer.', en:'Previews (thumbnails, EXIF, first PDF page) via range requests, without downloading or fully decrypting.' } },
+    { n:{ fr:'Sealed Share', en:'Sealed Share' }, when:{ fr:'Oct. 2026', en:'Oct 2026' }, d:{ fr:'Partage hors-bande : lien backend natif + capsule-clé via AirDrop/QR, déchiffrement on-device.', en:'Out-of-band sharing: native backend link + key capsule via AirDrop/QR, decrypted on-device.' } },
+    { n:{ fr:'Recherche sémantique on-device', en:'On-device semantic search' }, when:{ fr:'Nov. 2026', en:'Nov 2026' }, d:{ fr:'Médiathèque locale chiffrée + recherche en langage naturel (Apple Intelligence), jamais côté serveur.', en:'Local encrypted media library + natural-language search (Apple Intelligence), never server-side.' } },
+    { n:{ fr:'Règles de sync', en:'Sync rules' }, when:{ fr:'Nov. 2026', en:'Nov 2026' }, d:{ fr:'Règles locales par type/dossier + « toujours disponible hors-ligne » depuis Fichiers.', en:'Local rules by type/folder + "always available offline" from Files.' } },
+    { n:{ fr:'Mode Voyage', en:'Travel Mode' }, when:{ fr:'Déc. 2026', en:'Dec 2026' }, d:{ fr:'Coffre éphémère (déchiffrement en RAM), auto-démontage et Face ID par remote.', en:'Ephemeral vault (in-RAM decryption), auto-unmount and per-remote Face ID.' } },
   ] },
-  { key:'long', label:{ fr:'Long terme', en:'Long term' }, tag:{ fr:'VISION', en:'VISION' }, items:[
-    { n:{ fr:'ChronoDrive', en:'ChronoDrive' }, d:{ fr:'N\'importe quel backend comme destination de sauvegarde versionnée façon Time Machine (macOS), chiffrée.', en:'Any backend as a versioned, encrypted Time Machine-style backup destination (macOS).' } },
-    { n:{ fr:'Ghost Sync', en:'Ghost Sync' }, d:{ fr:'Mesh P2P : réconciliation de deltas chiffrés entre tes appareils en réseau local, offline-first.', en:'P2P mesh: encrypted delta reconciliation between your devices over the local network, offline-first.' } },
-    { n:{ fr:'Quantum Vault', en:'Quantum Vault' }, d:{ fr:'Chiffrement post-quantique hybride (Kyber + AES) pour des archives « 2035-proof ».', en:'Hybrid post-quantum encryption (Kyber + AES) for "2035-proof" archives.' } },
-    { n:{ fr:'CipherSpace', en:'CipherSpace' }, d:{ fr:'Explorer ses archives chiffrées dans l\'espace, sur visionOS.', en:'Explore your encrypted archives in space, on visionOS.' } },
-    { n:{ fr:'Héritage numérique', en:'Digital legacy' }, d:{ fr:'Récupération sociale (partage de secret de Shamir) entre contacts de confiance + preuve de vie.', en:'Social recovery (Shamir secret sharing) among trusted contacts + proof of life.' } },
+  { key:'long', label:{ fr:'Long terme', en:'Long term' }, tag:{ fr:'2027', en:'2027' }, items:[
+    { n:{ fr:'ChronoDrive', en:'ChronoDrive' }, when:{ fr:'T1 2027', en:'Q1 2027' }, d:{ fr:'N\'importe quel backend comme destination de sauvegarde versionnée façon Time Machine (macOS), chiffrée.', en:'Any backend as a versioned, encrypted Time Machine-style backup destination (macOS).' } },
+    { n:{ fr:'Ghost Sync', en:'Ghost Sync' }, when:{ fr:'T1 2027', en:'Q1 2027' }, d:{ fr:'Mesh P2P : réconciliation de deltas chiffrés entre tes appareils en réseau local, offline-first.', en:'P2P mesh: encrypted delta reconciliation between your devices over the local network, offline-first.' } },
+    { n:{ fr:'Quantum Vault', en:'Quantum Vault' }, when:{ fr:'T2 2027', en:'Q2 2027' }, d:{ fr:'Chiffrement post-quantique hybride (Kyber + AES) pour des archives « 2035-proof ».', en:'Hybrid post-quantum encryption (Kyber + AES) for "2035-proof" archives.' } },
+    { n:{ fr:'Héritage numérique', en:'Digital legacy' }, when:{ fr:'T2 2027', en:'Q2 2027' }, d:{ fr:'Récupération sociale (partage de secret de Shamir) entre contacts de confiance + preuve de vie.', en:'Social recovery (Shamir secret sharing) among trusted contacts + proof of life.' } },
+    { n:{ fr:'CipherSpace', en:'CipherSpace' }, when:{ fr:'T3 2027', en:'Q3 2027' }, d:{ fr:'Explorer ses archives chiffrées dans l\'espace, sur visionOS.', en:'Explore your encrypted archives in space, on visionOS.' } },
   ] },
 ];
 const Roadmap = ({ lang }) => {
@@ -1105,7 +1105,10 @@ const Roadmap = ({ lang }) => {
               <div className="rm-items">
                 {col.items.map(it => (
                   <div key={it.n.en} className="rm-item">
-                    <h5>{it.n[lang] || it.n.en}</h5>
+                    <div className="rm-item-head">
+                      <h5>{it.n[lang] || it.n.en}</h5>
+                      <span className="rm-when">{(it.when && (it.when[lang] || it.when.en)) || ''}</span>
+                    </div>
                     <p>{it.d[lang] || it.d.en}</p>
                   </div>
                 ))}
@@ -1117,7 +1120,7 @@ const Roadmap = ({ lang }) => {
           <Icon name="bolt.fill" size={16}/>
           <span><b>{t('Pari produit','Product bet')} : </b>{t('« Capability, pas compte » — le partage et le multi-appareils deviennent des objets cryptographiques que tu possèdes et révoques, jamais une ligne dans une base (puisqu\'il n\'y en a pas).','"Capability, not account" — sharing and multi-device become cryptographic objects you own and revoke, never a row in a database (because there isn\'t one).')}</span>
         </div>
-        <p className="rm-note">{t('Roadmap indicative, sans engagement de date — priorisée avec vos retours. Open source : suivez ou contribuez sur GitHub.','Indicative roadmap, no committed dates — prioritized with your feedback. Open source: follow or contribute on GitHub.')}</p>
+        <p className="rm-note">{t('Dates cibles, susceptibles d\'évoluer — priorisées avec vos retours. Open source : suivez l\'avancement sur GitHub.','Target dates, subject to change — prioritized with your feedback. Open source: follow progress on GitHub.')}</p>
       </div>
     </section>
   );

--- a/docs/index.html
+++ b/docs/index.html
@@ -305,7 +305,10 @@
   .rm-items{display:flex;flex-direction:column}
   .rm-item{padding:12px 0;border-bottom:1px solid var(--line)}
   .rm-item:last-child{border-bottom:none}
+  .rm-item-head{display:flex;align-items:baseline;justify-content:space-between;gap:8px}
   .rm-item h5{margin:0;font-size:15px;font-weight:700;letter-spacing:-.2px}
+  .rm-when{flex:0 0 auto;font-size:11px;font-weight:800;letter-spacing:.3px;color:var(--accent-deep);
+    background:var(--accent-soft);padding:2px 7px;border-radius:999px;white-space:nowrap}
   .rm-item p{margin:4px 0 0;font-size:13.5px;color:var(--muted);font-weight:500;line-height:1.45}
   .rm-bet{display:flex;gap:12px;align-items:flex-start;margin:26px auto 0;max-width:820px;
     background:linear-gradient(135deg,var(--accent),var(--accent-deep));color:#fff;border-radius:18px;


### PR DESCRIPTION
Ajoute des **dates cibles précises** à la roadmap, sur les deux surfaces.

**Site** (rclone.rougetet.com) : puce de date par item (mois/année), fenêtre de dates en en-tête de colonne (Juil.–sept. 2026 / Oct.–déc. 2026 / 2027), note « dates cibles, susceptibles d'évoluer ».

**App** (écran Feuille de route) : restructuré en **lignes par item avec date cible** ; format **locale-neutre** (07/2026 … Q3 2027) → aucune traduction de dates ; tag d'horizon = fenêtre de dates. 6 noms descriptifs + pied de page traduits en 12 langues (additif) ; noms propres en source FR.

Calendrier cible : Été 2026 (court terme), Automne 2026 (moyen), 2027 (long). `app.js` recompilé. ✅ Builds macOS. Dates volontairement présentées comme **cibles susceptibles d'évoluer**.