### PR TITLE
feat(ci): automatisation Jira → Trello (GitHub Actions planifié)

### DIFF
--- a/.github/workflows/jira-trello-sync.yml
+++ b/.github/workflows/jira-trello-sync.yml
@@ -1,0 +1,46 @@
+name: Jira → Trello sync
+
+# Synchronise les tickets Jira (source de vérité) vers un board Trello.
+# Tous les credentials sont des GitHub Secrets — rien en clair dans le dépôt.
+# Désactivé tant que les secrets ne sont pas configurés (le job sort en no-op).
+
+on:
+  schedule:
+    - cron: "17,47 * * * *"   # toutes les 30 min (minutes off-pic)
+  workflow_dispatch: {}        # déclenchement manuel depuis l'onglet Actions
+
+concurrency:
+  group: jira-trello-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Guard — skip if not configured
+        id: guard
+        env:
+          JIRA_SITE: ${{ secrets.JIRA_SITE }}
+        run: |
+          if [ -z "$JIRA_SITE" ]; then
+            echo "JIRA_SITE secret absent — sync non configurée, on saute."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run Jira → Trello sync
+        if: steps.guard.outputs.configured == 'true'
+        env:
+          JIRA_SITE: ${{ secrets.JIRA_SITE }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          JIRA_PROJECT: ${{ secrets.JIRA_PROJECT }}
+          JIRA_JQL: ${{ secrets.JIRA_JQL }}
+          TRELLO_KEY: ${{ secrets.TRELLO_KEY }}
+          TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
+          TRELLO_BOARD: ${{ secrets.TRELLO_BOARD }}
+        run: python3 scripts/jira-trello-sync/sync.py

--- a/scripts/jira-trello-sync/README.md
+++ b/scripts/jira-trello-sync/README.md
@@ -1,0 +1,61 @@
+# Jira → Trello sync
+
+Automatisation **Jira → Trello** (Jira = source de vérité) tournant en
+**GitHub Actions** (`.github/workflows/jira-trello-sync.yml`), toutes les 30 min
++ déclenchement manuel. Aucun credential dans le dépôt : tout passe par les
+**GitHub Secrets**.
+
+Chaque ticket Jira retenu par le JQL crée/met à jour une carte Trello :
+`summary → nom`, `description → desc` (ADF aplati + lien Jira), `status → liste`
+(créée automatiquement), `duedate → échéance`, `issuetype → étiquette`. Le sync
+est **idempotent** (marqueur `[jira:KEY]` dans la carte). Les cartes dont le
+ticket disparaît du JQL sont **archivées** (jamais supprimées).
+
+## 1. Créer un board Trello dédié
+
+⚠️ **N'utilise pas le board roadmap** (curé à la main) comme cible — le sync y
+créerait des listes de statut Jira. Crée un board vide « Jira mirror » et
+récupère son shortlink (l'identifiant dans l'URL `trello.com/b/XXXXXXXX`).
+
+## 2. Obtenir les credentials
+
+| Secret | Où l'obtenir |
+|---|---|
+| `JIRA_SITE` | `https://<ton-site>.atlassian.net` |
+| `JIRA_EMAIL` | ton email de compte Atlassian |
+| `JIRA_TOKEN` | https://id.atlassian.com/manage-profile/security/api-tokens → *Create API token* |
+| `JIRA_PROJECT` | clé du projet (ex. `RG`) — ou laisse vide et fournis `JIRA_JQL` |
+| `JIRA_JQL` | *(optionnel)* requête JQL personnalisée, ex. `project = RG AND statusCategory != Done` |
+| `TRELLO_KEY` | https://trello.com/power-ups/admin → ton Power-Up → *API key* |
+| `TRELLO_TOKEN` | token Trello (un token API Atlassian fonctionne aussi) |
+| `TRELLO_BOARD` | shortlink/id du board mirror (étape 1) |
+
+> Le **token API Atlassian** sert à la fois pour Jira (`JIRA_TOKEN`) et Trello
+> (`TRELLO_TOKEN`) si tu utilises le même compte Atlassian.
+
+## 3. Ajouter les secrets sur GitHub
+
+Repo → **Settings → Secrets and variables → Actions → New repository secret**,
+puis ajoute chacun des secrets ci-dessus. Tant que `JIRA_SITE` est absent, le
+workflow s'exécute en **no-op** (étape « guard »).
+
+## 4. Lancer
+
+- Automatique : toutes les 30 min (cron `17,47 * * * *`).
+- Manuel : onglet **Actions → Jira → Trello sync → Run workflow**.
+
+## Test en local
+
+```bash
+export JIRA_SITE="https://xxx.atlassian.net" JIRA_EMAIL="…" JIRA_TOKEN="…" \
+       JIRA_PROJECT="RG" TRELLO_KEY="…" TRELLO_TOKEN="…" TRELLO_BOARD="XXXXXXXX"
+python3 scripts/jira-trello-sync/sync.py
+```
+
+## Notes
+
+- **Sens unique** Jira → Trello : les modifications faites côté Trello sont
+  écrasées au prochain sync. (Le bidirectionnel demande une gestion de conflits ;
+  on peut l'ajouter si besoin.)
+- Le mapping `status → liste` crée une liste Trello par statut Jira rencontré.
+- Aucune dépendance tierce : `sync.py` n'utilise que la bibliothèque standard.

--- a/scripts/jira-trello-sync/sync.py
+++ b/scripts/jira-trello-sync/sync.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Jira → Trello one-way sync (source of truth = Jira).
+
+For each Jira issue matching JIRA_JQL, ensures a matching Trello card exists on
+the target board and keeps it up to date:
+  - summary      → card name
+  - description  → card description (ADF flattened to text) + Jira link
+  - status       → Trello list (auto-created per distinct status)
+  - duedate      → card due date
+  - issuetype    → Trello label (auto-created)
+
+Idempotent: each card carries a hidden marker `[jira:KEY]` in its description;
+re-runs update the existing card instead of duplicating. Cards whose Jira issue
+disappeared from the JQL result are moved to a "✓ Archivées (Jira)" list (never
+deleted, to stay safe).
+
+No third-party deps — standard library only (runs on GitHub Actions Python).
+
+Required env (set as GitHub Secrets):
+  JIRA_SITE     e.g. https://yourname.atlassian.net
+  JIRA_EMAIL    Atlassian account email
+  JIRA_TOKEN    Atlassian API token (id.atlassian.com → API tokens)
+  JIRA_PROJECT  project key, e.g. RG          (used if JIRA_JQL is unset)
+  JIRA_JQL      optional, overrides the default project query
+  TRELLO_KEY    Trello Power-Up API key
+  TRELLO_TOKEN  Trello token (Atlassian API token works too)
+  TRELLO_BOARD  target board shortlink or id (use a DEDICATED board, not the
+                hand-curated roadmap board)
+"""
+import os, sys, json, base64, urllib.parse, urllib.request, urllib.error
+
+def env(name, default=None, required=False):
+    v = os.environ.get(name, default)
+    if required and not v:
+        sys.exit(f"Missing required env var: {name}")
+    return v
+
+JIRA_SITE   = (env("JIRA_SITE", required=True)).rstrip("/")
+JIRA_EMAIL  = env("JIRA_EMAIL", required=True)
+JIRA_TOKEN  = env("JIRA_TOKEN", required=True)
+JIRA_PROJECT= env("JIRA_PROJECT", "")
+JIRA_JQL    = env("JIRA_JQL", "") or (f'project = "{JIRA_PROJECT}" ORDER BY Rank ASC' if JIRA_PROJECT else "")
+TRELLO_KEY  = env("TRELLO_KEY", required=True)
+TRELLO_TOKEN= env("TRELLO_TOKEN", required=True)
+TRELLO_BOARD= env("TRELLO_BOARD", required=True)
+if not JIRA_JQL:
+    sys.exit("Provide JIRA_PROJECT or JIRA_JQL.")
+
+ARCHIVE_LIST = "✓ Archivées (Jira)"
+
+# ── HTTP ────────────────────────────────────────────────────────────────────
+def _http(method, url, headers=None, body=None):
+    req = urllib.request.Request(url, method=method, headers=headers or {})
+    if body is not None:
+        req.data = body
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            raw = r.read().decode()
+            return r.status, (json.loads(raw) if raw[:1] in "{[" else raw)
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+def jira(method, path, params=None, body=None):
+    url = f"{JIRA_SITE}/rest/api/3{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    auth = base64.b64encode(f"{JIRA_EMAIL}:{JIRA_TOKEN}".encode()).decode()
+    headers = {"Authorization": f"Basic {auth}", "Accept": "application/json"}
+    data = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(body).encode()
+    return _http(method, url, headers, data)
+
+def trello(method, path, **params):
+    params["key"] = TRELLO_KEY
+    params["token"] = TRELLO_TOKEN
+    url = f"https://api.trello.com/1{path}?" + urllib.parse.urlencode(params)
+    return _http(method, url)
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+def adf_to_text(node):
+    """Flatten an Atlassian Document Format node into plain text."""
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    out = []
+    if isinstance(node, dict):
+        if node.get("type") == "text":
+            out.append(node.get("text", ""))
+        for child in node.get("content", []) or []:
+            out.append(adf_to_text(child))
+        if node.get("type") in ("paragraph", "heading", "listItem"):
+            out.append("\n")
+    elif isinstance(node, list):
+        for child in node:
+            out.append(adf_to_text(child))
+    return "".join(out)
+
+def marker(key):
+    return f"[jira:{key}]"
+
+def jira_search():
+    """Fetch issues. Tries the enhanced /search/jql endpoint, falls back to the
+    classic /search for older sites."""
+    fields = "summary,description,status,duedate,issuetype,labels"
+    issues, token = [], None
+    while True:
+        code, data = jira("GET", "/search/jql", params={
+            "jql": JIRA_JQL, "fields": fields, "maxResults": 100,
+            **({"nextPageToken": token} if token else {})
+        })
+        if code == 200 and isinstance(data, dict):
+            issues += data.get("issues", [])
+            token = data.get("nextPageToken")
+            if not token or data.get("isLast", True):
+                return issues
+            continue
+        # Fallback: classic /search (deprecated but still live on many sites)
+        start = 0
+        issues = []
+        while True:
+            code, data = jira("GET", "/search", params={
+                "jql": JIRA_JQL, "fields": fields, "maxResults": 100, "startAt": start
+            })
+            if code != 200 or not isinstance(data, dict):
+                sys.exit(f"Jira search failed: {code} {str(data)[:300]}")
+            issues += data.get("issues", [])
+            start += len(data.get("issues", []))
+            if start >= data.get("total", 0) or not data.get("issues"):
+                return issues
+
+# ── Sync ────────────────────────────────────────────────────────────────────
+def main():
+    code, board = trello("GET", f"/boards/{TRELLO_BOARD}", fields="id,name")
+    if code != 200:
+        sys.exit(f"Trello board not found: {code} {board}")
+    bid = board["id"]
+    print(f"Board: {board['name']} ({bid})")
+
+    # Existing lists / labels / cards on the board
+    lists = {l["name"]: l["id"] for l in trello("GET", f"/boards/{bid}/lists")[1]}
+    labels = {l["name"]: l["id"] for l in trello("GET", f"/boards/{bid}/labels")[1] if l["name"]}
+    cards = trello("GET", f"/boards/{bid}/cards", fields="id,name,desc,due,idList,idLabels")[1]
+
+    # Index existing cards by their Jira marker
+    by_key = {}
+    for c in cards:
+        for line in (c.get("desc") or "").splitlines():
+            line = line.strip()
+            if line.startswith("[jira:") and line.endswith("]"):
+                by_key[line[6:-1]] = c
+
+    LABEL_COLORS = {"Story": "green", "Bug": "red", "Task": "blue", "Epic": "purple",
+                    "Sous-tâche": "sky", "Subtask": "sky"}
+
+    def ensure_list(name):
+        if name not in lists:
+            _, l = trello("POST", f"/boards/{bid}/lists", name=name, pos="bottom")
+            lists[name] = l["id"]
+        return lists[name]
+
+    def ensure_label(name):
+        if not name:
+            return None
+        if name not in labels:
+            _, l = trello("POST", f"/boards/{bid}/labels", name=name,
+                          color=LABEL_COLORS.get(name, "light-gray"))
+            labels[name] = l["id"]
+        return labels[name]
+
+    issues = jira_search()
+    print(f"{len(issues)} issue(s) from Jira.")
+    seen = set()
+
+    for it in issues:
+        key = it["key"]
+        seen.add(key)
+        f = it.get("fields", {})
+        status = (f.get("status") or {}).get("name", "À faire")
+        itype = (f.get("issuetype") or {}).get("name", "")
+        summary = f.get("summary", key)
+        due = f.get("duedate")  # YYYY-MM-DD or None
+        body = adf_to_text(f.get("description")).strip()
+        link = f"{JIRA_SITE}/browse/{key}"
+        desc = f"{body}\n\n— {key} · {link}\n{marker(key)}".strip()
+
+        list_id = ensure_list(status)
+        label_id = ensure_label(itype)
+        due_iso = (due + "T12:00:00.000Z") if due else ""
+
+        if key in by_key:
+            cid = by_key[key]["id"]
+            params = {"name": summary, "desc": desc, "idList": list_id}
+            if due_iso:
+                params["due"] = due_iso
+            trello("PUT", f"/cards/{cid}", **params)
+            if label_id and label_id not in (by_key[key].get("idLabels") or []):
+                trello("POST", f"/cards/{cid}/idLabels", value=label_id)
+            print(f"  ↻ {key} → {status}")
+        else:
+            params = {"idList": list_id, "name": summary, "desc": desc, "pos": "bottom"}
+            if due_iso:
+                params["due"] = due_iso
+            if label_id:
+                params["idLabels"] = label_id
+            trello("POST", "/cards", **params)
+            print(f"  + {key} → {status}")
+
+    # Archive cards whose Jira issue is no longer in scope (never delete)
+    archived = 0
+    for key, c in by_key.items():
+        if key not in seen:
+            trello("PUT", f"/cards/{c['id']}", idList=ensure_list(ARCHIVE_LIST))
+            archived += 1
+    if archived:
+        print(f"  ⤓ {archived} carte(s) archivée(s) (absentes du JQL).")
+
+    print("Sync terminé.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Synchro Jira → Trello

Automatisation **unidirectionnelle Jira (source de vérité) → Trello**, en **GitHub Actions** (toutes les 30 min + manuel). **Aucun credential dans le dépôt** : tout via **GitHub Secrets** ; le workflow est **no-op** tant que `JIRA_SITE` n'est pas configuré (étape guard).

### Contenu
- `scripts/jira-trello-sync/sync.py` — pour chaque ticket du JQL : crée/met à jour une carte (`summary→nom`, description ADF aplatie + lien Jira, `status→liste` auto-créée, `duedate→échéance`, `issuetype→étiquette`). **Idempotent** via marqueur `[jira:KEY]`. Cartes hors-JQL **archivées** (jamais supprimées). **Stdlib uniquement** (aucune dépendance).
- `.github/workflows/jira-trello-sync.yml` — cron `17,47 * * * *` + `workflow_dispatch`. Secrets passés via `env:` (pas d'injection), `checkout` sans ref dynamique.
- `scripts/jira-trello-sync/README.md` — obtention des credentials, ajout des secrets, test local.

### Activation (côté toi)
1. Créer un **board Trello dédié** (pas le board roadmap).
2. Ajouter les secrets repo : `JIRA_SITE`, `JIRA_EMAIL`, `JIRA_TOKEN`, `JIRA_PROJECT` (ou `JIRA_JQL`), `TRELLO_KEY`, `TRELLO_TOKEN`, `TRELLO_BOARD`.
3. Le token API Atlassian sert pour **Jira ET Trello** (même compte).

✅ `py_compile` + YAML validés. Sens unique (bidirectionnel possible en option).