### PR TITLE
fix(ci): sync Jira→Trello — couleur d'étiquette valide + garde défensive

### DIFF
--- a/scripts/jira-trello-sync/sync.py
+++ b/scripts/jira-trello-sync/sync.py
@@ -153,7 +153,9 @@ def main():
             if line.startswith("[jira:") and line.endswith("]"):
                 by_key[line[6:-1]] = c
 
-    LABEL_COLORS = {"Story": "green", "Bug": "red", "Task": "blue", "Epic": "purple",
+    # Couleurs Trello valides uniquement (pas de "light-gray"). Défaut = sky.
+    LABEL_COLORS = {"Story": "green", "Bug": "red", "Task": "blue", "Tâche": "blue",
+                    "Epic": "purple", "Fonctionnalité": "lime", "Feature": "lime",
                     "Sous-tâche": "sky", "Subtask": "sky"}
 
     def ensure_list(name):
@@ -166,8 +168,10 @@ def main():
         if not name:
             return None
         if name not in labels:
-            _, l = trello("POST", f"/boards/{bid}/labels", name=name,
-                          color=LABEL_COLORS.get(name, "light-gray"))
+            code, l = trello("POST", f"/boards/{bid}/labels", name=name,
+                             color=LABEL_COLORS.get(name, "sky"))
+            if code != 200 or not isinstance(l, dict) or "id" not in l:
+                return None  # création échouée → on continue sans étiquette
             labels[name] = l["id"]
         return labels[name]
 


### PR DESCRIPTION
Bug attrapé en test réel : le type « Fonctionnalité » utilisait une couleur Trello inexistante (`light-gray`) → `ensure_label` crashait sur la réponse d'erreur.

- Couleur défaut → `sky` ; mapping ajouté (`Fonctionnalité→lime`, `Tâche→blue`).
- `ensure_label` ignore proprement un échec de création (pas de crash).

✅ **Validé en réel** : 15 fonctionnalités Jira (RG-1..15) → 15 cartes datées sur le board mirror (`BZZ6VIIC`), statut→liste, **idempotent** (2ᵉ run = `↻`, 15 cartes, 0 doublon).