### PR TITLE
feat(ci): sync Jira ↔ Trello bidirectionnel

### DIFF
--- a/.github/workflows/jira-trello-sync.yml
+++ b/.github/workflows/jira-trello-sync.yml
@@ -1,6 +1,6 @@
-name: Jira → Trello sync
+name: Jira ↔ Trello sync
 
-# Synchronise les tickets Jira (source de vérité) vers un board Trello.
+# Synchronise Jira et un board Trello (bidirectionnel par défaut).
 # Tous les credentials sont des GitHub Secrets — rien en clair dans le dépôt.
 # Désactivé tant que les secrets ne sont pas configurés (le job sort en no-op).
 
@@ -40,6 +40,8 @@ jobs:
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
           JIRA_PROJECT: ${{ secrets.JIRA_PROJECT }}
           JIRA_JQL: ${{ secrets.JIRA_JQL }}
+          JIRA_ISSUETYPE_ID: ${{ secrets.JIRA_ISSUETYPE_ID }}
+          SYNC_DIRECTION: ${{ secrets.SYNC_DIRECTION }}
           TRELLO_KEY: ${{ secrets.TRELLO_KEY }}
           TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
           TRELLO_BOARD: ${{ secrets.TRELLO_BOARD }}

--- a/scripts/jira-trello-sync/README.md
+++ b/scripts/jira-trello-sync/README.md
@@ -1,15 +1,26 @@
-# Jira → Trello sync
+# Jira ↔ Trello sync (bidirectionnel)
 
-Automatisation **Jira → Trello** (Jira = source de vérité) tournant en
-**GitHub Actions** (`.github/workflows/jira-trello-sync.yml`), toutes les 30 min
-+ déclenchement manuel. Aucun credential dans le dépôt : tout passe par les
-**GitHub Secrets**.
+Automatisation **Jira ↔ Trello** tournant en **GitHub Actions**
+(`.github/workflows/jira-trello-sync.yml`), toutes les 30 min + déclenchement
+manuel. Aucun credential dans le dépôt : tout passe par les **GitHub Secrets**.
 
-Chaque ticket Jira retenu par le JQL crée/met à jour une carte Trello :
-`summary → nom`, `description → desc` (ADF aplati + lien Jira), `status → liste`
-(créée automatiquement), `duedate → échéance`, `issuetype → étiquette`. Le sync
-est **idempotent** (marqueur `[jira:KEY]` dans la carte). Les cartes dont le
-ticket disparaît du JQL sont **archivées** (jamais supprimées).
+Chaque ticket Jira (retenu par le JQL) est apparié à une carte Trello via un
+marqueur caché `[jira:KEY]`. **Réconciliation champ par champ** : le côté le plus
+récemment modifié gagne (Jira `updated` vs Trello `dateLastActivity`), et on
+n'écrit que si la valeur diffère (pas de ping-pong).
+
+| Champ | Sens |
+|---|---|
+| résumé ↔ nom de carte | bidirectionnel |
+| échéance (`duedate` ↔ `due`) | bidirectionnel |
+| **statut ↔ liste** (nom de liste = nom de statut, transition Jira) | bidirectionnel |
+| description (ADF aplati + lien) | Jira → Trello (autorité Jira) |
+| type, étiquettes | Jira → Trello |
+
+**Création** : un ticket Jira sans carte → carte créée ; une **carte Trello sans
+marqueur** → ticket Jira créé puis carte re-liée. Cartes dont le ticket sort du
+JQL → **archivées** (jamais supprimées). Le sens est réglable via
+`SYNC_DIRECTION` (`bidirectional` | `jira-to-trello` | `trello-to-jira`).
 
 ## 1. Créer un board Trello dédié
 
@@ -27,8 +38,10 @@ récupère son shortlink (l'identifiant dans l'URL `trello.com/b/XXXXXXXX`).
 | `JIRA_PROJECT` | clé du projet (ex. `RG`) — ou laisse vide et fournis `JIRA_JQL` |
 | `JIRA_JQL` | *(optionnel)* requête JQL personnalisée, ex. `project = RG AND statusCategory != Done` |
 | `TRELLO_KEY` | https://trello.com/power-ups/admin → ton Power-Up → *API key* |
-| `TRELLO_TOKEN` | token Trello (un token API Atlassian fonctionne aussi) |
+| `TRELLO_TOKEN` | token Trello (Power-Up / authorize ; ⚠️ pas un token API Atlassian) |
 | `TRELLO_BOARD` | shortlink/id du board mirror (étape 1) |
+| `SYNC_DIRECTION` | *(optionnel)* `bidirectional` (défaut), `jira-to-trello` ou `trello-to-jira` |
+| `JIRA_ISSUETYPE_ID` | *(optionnel)* type des tickets créés depuis une carte Trello (défaut `10042`) |
 
 > Le **token API Atlassian** sert à la fois pour Jira (`JIRA_TOKEN`) et Trello
 > (`TRELLO_TOKEN`) si tu utilises le même compte Atlassian.
@@ -54,8 +67,11 @@ python3 scripts/jira-trello-sync/sync.py
 
 ## Notes
 
-- **Sens unique** Jira → Trello : les modifications faites côté Trello sont
-  écrasées au prochain sync. (Le bidirectionnel demande une gestion de conflits ;
-  on peut l'ajouter si besoin.)
-- Le mapping `status → liste` crée une liste Trello par statut Jira rencontré.
+- **Bidirectionnel** par défaut, avec arbitrage **dernier-modifié-gagne** au niveau
+  de chaque champ (pas d'écrasement aveugle, pas de ping-pong).
+- Le mapping `statut ↔ liste` crée une liste Trello par statut Jira ; côté Jira,
+  une transition est jouée vers le statut homonyme de la liste (si disponible
+  dans le workflow).
+- La **description** reste pilotée par Jira (autorité) : édite-la côté Jira.
+- ⚠️ Cible un **board dédié** : déplacer/éditer une carte y est propagé à Jira.
 - Aucune dépendance tierce : `sync.py` n'utilise que la bibliothèque standard.

--- a/scripts/jira-trello-sync/sync.py
+++ b/scripts/jira-trello-sync/sync.py
@@ -1,52 +1,50 @@
 #!/usr/bin/env python3
 """
-Jira → Trello one-way sync (source of truth = Jira).
+Jira ↔ Trello sync (bidirectionnel par défaut).
 
-For each Jira issue matching JIRA_JQL, ensures a matching Trello card exists on
-the target board and keeps it up to date:
-  - summary      → card name
-  - description  → card description (ADF flattened to text) + Jira link
-  - status       → Trello list (auto-created per distinct status)
-  - duedate      → card due date
-  - issuetype    → Trello label (auto-created)
+Apparie chaque ticket Jira (JQL) avec une carte Trello via un marqueur caché
+`[jira:KEY]` dans la description de la carte. Pour chaque champ, le côté le plus
+récemment modifié gagne (Jira `updated` vs Trello `dateLastActivity`) — et on
+n'écrit QUE si la valeur diffère (pas de ping-pong).
 
-Idempotent: each card carries a hidden marker `[jira:KEY]` in its description;
-re-runs update the existing card instead of duplicating. Cards whose Jira issue
-disappeared from the JQL result are moved to a "✓ Archivées (Jira)" list (never
-deleted, to stay safe).
+Champs synchronisés :
+  - résumé / nom de carte        (bidirectionnel)
+  - échéance (duedate / due)     (bidirectionnel)
+  - statut ↔ liste               (bidirectionnel ; le nom de liste = nom de statut)
+  - description                  (Jira → Trello, autorité Jira ; ADF aplati)
+  - type, étiquettes             (Jira → Trello)
 
-No third-party deps — standard library only (runs on GitHub Actions Python).
+Création :
+  - ticket Jira sans carte       → carte créée
+  - carte Trello sans marqueur   → ticket Jira créé puis carte re-liée
+Cartes dont le ticket sort du JQL → archivées (jamais supprimées).
 
-Required env (set as GitHub Secrets):
-  JIRA_SITE     e.g. https://yourname.atlassian.net
-  JIRA_EMAIL    Atlassian account email
-  JIRA_TOKEN    Atlassian API token (id.atlassian.com → API tokens)
-  JIRA_PROJECT  project key, e.g. RG          (used if JIRA_JQL is unset)
-  JIRA_JQL      optional, overrides the default project query
-  TRELLO_KEY    Trello Power-Up API key
-  TRELLO_TOKEN  Trello token (Atlassian API token works too)
-  TRELLO_BOARD  target board shortlink or id (use a DEDICATED board, not the
-                hand-curated roadmap board)
+SYNC_DIRECTION : "bidirectional" (défaut) | "jira-to-trello" | "trello-to-jira".
+
+Stdlib uniquement. Env requis : voir README.
 """
-import os, sys, json, base64, urllib.parse, urllib.request, urllib.error
+import os, sys, json, base64, datetime, urllib.parse, urllib.request, urllib.error
 
-def env(name, default=None, required=False):
-    v = os.environ.get(name, default)
-    if required and not v:
-        sys.exit(f"Missing required env var: {name}")
+def env(n, d=None, req=False):
+    v = os.environ.get(n, d)
+    if req and not v:
+        sys.exit(f"Missing required env var: {n}")
     return v
 
-JIRA_SITE   = (env("JIRA_SITE", required=True)).rstrip("/")
-JIRA_EMAIL  = env("JIRA_EMAIL", required=True)
-JIRA_TOKEN  = env("JIRA_TOKEN", required=True)
-JIRA_PROJECT= env("JIRA_PROJECT", "")
-JIRA_JQL    = env("JIRA_JQL", "") or (f'project = "{JIRA_PROJECT}" ORDER BY Rank ASC' if JIRA_PROJECT else "")
-TRELLO_KEY  = env("TRELLO_KEY", required=True)
-TRELLO_TOKEN= env("TRELLO_TOKEN", required=True)
-TRELLO_BOARD= env("TRELLO_BOARD", required=True)
+JIRA_SITE    = env("JIRA_SITE", req=True).rstrip("/")
+JIRA_EMAIL   = env("JIRA_EMAIL", req=True)
+JIRA_TOKEN   = env("JIRA_TOKEN", req=True)
+JIRA_PROJECT = env("JIRA_PROJECT", "")
+JIRA_JQL     = env("JIRA_JQL", "") or (f'project = "{JIRA_PROJECT}" ORDER BY Rank ASC' if JIRA_PROJECT else "")
+JIRA_ISSUETYPE_ID = env("JIRA_ISSUETYPE_ID", "10042")  # défaut: Tâche
+TRELLO_KEY   = env("TRELLO_KEY", req=True)
+TRELLO_TOKEN = env("TRELLO_TOKEN", req=True)
+TRELLO_BOARD = env("TRELLO_BOARD", req=True)
+DIRECTION    = env("SYNC_DIRECTION", "bidirectional")
 if not JIRA_JQL:
     sys.exit("Provide JIRA_PROJECT or JIRA_JQL.")
-
+TO_TRELLO = DIRECTION in ("bidirectional", "jira-to-trello")
+TO_JIRA   = DIRECTION in ("bidirectional", "trello-to-jira")
 ARCHIVE_LIST = "✓ Archivées (Jira)"
 
 # ── HTTP ────────────────────────────────────────────────────────────────────
@@ -56,8 +54,9 @@ def _http(method, url, headers=None, body=None):
         req.data = body
     try:
         with urllib.request.urlopen(req, timeout=60) as r:
-            raw = r.read().decode()
-            return r.status, (json.loads(raw) if raw[:1] in "{[" else raw)
+            raw = r.read().decode().strip()
+            # NB: `"" in "{["` vaut True en Python → tester l'appartenance à un tuple.
+            return r.status, (json.loads(raw) if raw[:1] in ("{", "[") else raw)
     except urllib.error.HTTPError as e:
         return e.code, e.read().decode()
 
@@ -66,161 +65,210 @@ def jira(method, path, params=None, body=None):
     if params:
         url += "?" + urllib.parse.urlencode(params)
     auth = base64.b64encode(f"{JIRA_EMAIL}:{JIRA_TOKEN}".encode()).decode()
-    headers = {"Authorization": f"Basic {auth}", "Accept": "application/json"}
+    h = {"Authorization": f"Basic {auth}", "Accept": "application/json"}
     data = None
     if body is not None:
-        headers["Content-Type"] = "application/json"
-        data = json.dumps(body).encode()
-    return _http(method, url, headers, data)
+        h["Content-Type"] = "application/json"; data = json.dumps(body).encode()
+    return _http(method, url, h, data)
 
 def trello(method, path, **params):
-    params["key"] = TRELLO_KEY
-    params["token"] = TRELLO_TOKEN
-    url = f"https://api.trello.com/1{path}?" + urllib.parse.urlencode(params)
-    return _http(method, url)
+    params["key"] = TRELLO_KEY; params["token"] = TRELLO_TOKEN
+    return _http(method, f"https://api.trello.com/1{path}?" + urllib.parse.urlencode(params))
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 def adf_to_text(node):
-    """Flatten an Atlassian Document Format node into plain text."""
-    if node is None:
-        return ""
-    if isinstance(node, str):
-        return node
+    if node is None: return ""
+    if isinstance(node, str): return node
     out = []
     if isinstance(node, dict):
-        if node.get("type") == "text":
-            out.append(node.get("text", ""))
-        for child in node.get("content", []) or []:
-            out.append(adf_to_text(child))
-        if node.get("type") in ("paragraph", "heading", "listItem"):
-            out.append("\n")
+        if node.get("type") == "text": out.append(node.get("text", ""))
+        for c in node.get("content", []) or []: out.append(adf_to_text(c))
+        if node.get("type") in ("paragraph", "heading", "listItem"): out.append("\n")
     elif isinstance(node, list):
-        for child in node:
-            out.append(adf_to_text(child))
+        for c in node: out.append(adf_to_text(c))
     return "".join(out)
 
-def marker(key):
-    return f"[jira:{key}]"
+def text_to_adf(text):
+    paras = [p for p in (text or "").split("\n")]
+    content = [{"type": "paragraph",
+                "content": ([{"type": "text", "text": p}] if p else [])} for p in paras] or \
+              [{"type": "paragraph", "content": []}]
+    return {"type": "doc", "version": 1, "content": content}
+
+def parse_ts(s):
+    if not s: return datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+    s = s.replace("Z", "+00:00")
+    # Jira: +0000 → +00:00
+    if len(s) >= 5 and s[-5] in "+-" and s[-3] != ":":
+        s = s[:-2] + ":" + s[-2:]
+    try:
+        return datetime.datetime.fromisoformat(s)
+    except ValueError:
+        return datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+
+def marker(key): return f"[jira:{key}]"
+def due_day(iso): return iso[:10] if iso else None  # ISO/date → YYYY-MM-DD
 
 def jira_search():
-    """Fetch issues. Tries the enhanced /search/jql endpoint, falls back to the
-    classic /search for older sites."""
-    fields = "summary,description,status,duedate,issuetype,labels"
-    issues, token = [], None
+    fields = "summary,description,status,duedate,issuetype,labels,priority,updated"
+    token = None
+    out = []
     while True:
         code, data = jira("GET", "/search/jql", params={
             "jql": JIRA_JQL, "fields": fields, "maxResults": 100,
-            **({"nextPageToken": token} if token else {})
-        })
+            **({"nextPageToken": token} if token else {})})
         if code == 200 and isinstance(data, dict):
-            issues += data.get("issues", [])
+            out += data.get("issues", [])
             token = data.get("nextPageToken")
-            if not token or data.get("isLast", True):
-                return issues
+            if not token or data.get("isLast", True): return out
             continue
-        # Fallback: classic /search (deprecated but still live on many sites)
-        start = 0
-        issues = []
+        # fallback /search classique
+        start, out = 0, []
         while True:
             code, data = jira("GET", "/search", params={
-                "jql": JIRA_JQL, "fields": fields, "maxResults": 100, "startAt": start
-            })
+                "jql": JIRA_JQL, "fields": fields, "maxResults": 100, "startAt": start})
             if code != 200 or not isinstance(data, dict):
                 sys.exit(f"Jira search failed: {code} {str(data)[:300]}")
-            issues += data.get("issues", [])
+            out += data.get("issues", [])
             start += len(data.get("issues", []))
-            if start >= data.get("total", 0) or not data.get("issues"):
-                return issues
+            if start >= data.get("total", 0) or not data.get("issues"): return out
+
+def jira_transition(key, target):
+    code, data = jira("GET", f"/issue/{key}/transitions")
+    if code != 200 or not isinstance(data, dict): return False
+    tid = next((t["id"] for t in data.get("transitions", []) if t["to"]["name"] == target), None)
+    if not tid: return False
+    code, _ = jira("POST", f"/issue/{key}/transitions", body={"transition": {"id": tid}})
+    return code in (200, 204)
 
 # ── Sync ────────────────────────────────────────────────────────────────────
 def main():
+    print(f"Direction: {DIRECTION}")
     code, board = trello("GET", f"/boards/{TRELLO_BOARD}", fields="id,name")
-    if code != 200:
-        sys.exit(f"Trello board not found: {code} {board}")
-    bid = board["id"]
-    print(f"Board: {board['name']} ({bid})")
+    if code != 200: sys.exit(f"Trello board not found: {code} {board}")
+    bid = board["id"]; print(f"Board: {board['name']} ({bid})")
 
-    # Existing lists / labels / cards on the board
     lists = {l["name"]: l["id"] for l in trello("GET", f"/boards/{bid}/lists")[1]}
+    listname = {v: k for k, v in lists.items()}
     labels = {l["name"]: l["id"] for l in trello("GET", f"/boards/{bid}/labels")[1] if l["name"]}
-    cards = trello("GET", f"/boards/{bid}/cards", fields="id,name,desc,due,idList,idLabels")[1]
+    cards = trello("GET", f"/boards/{bid}/cards",
+                   fields="id,name,desc,due,idList,idLabels,dateLastActivity")[1]
 
-    # Index existing cards by their Jira marker
-    by_key = {}
+    by_key, unlinked = {}, []
     for c in cards:
+        k = None
         for line in (c.get("desc") or "").splitlines():
             line = line.strip()
-            if line.startswith("[jira:") and line.endswith("]"):
-                by_key[line[6:-1]] = c
+            if line.startswith("[jira:") and line.endswith("]"): k = line[6:-1]
+        (by_key.__setitem__(k, c) if k else unlinked.append(c))
 
-    # Couleurs Trello valides uniquement (pas de "light-gray"). Défaut = sky.
     LABEL_COLORS = {"Story": "green", "Bug": "red", "Task": "blue", "Tâche": "blue",
                     "Epic": "purple", "Fonctionnalité": "lime", "Feature": "lime",
                     "Sous-tâche": "sky", "Subtask": "sky"}
-
     def ensure_list(name):
         if name not in lists:
             _, l = trello("POST", f"/boards/{bid}/lists", name=name, pos="bottom")
-            lists[name] = l["id"]
+            lists[name] = l["id"]; listname[l["id"]] = name
         return lists[name]
-
     def ensure_label(name):
-        if not name:
-            return None
+        if not name: return None
         if name not in labels:
-            code, l = trello("POST", f"/boards/{bid}/labels", name=name,
-                             color=LABEL_COLORS.get(name, "sky"))
-            if code != 200 or not isinstance(l, dict) or "id" not in l:
-                return None  # création échouée → on continue sans étiquette
+            code, l = trello("POST", f"/boards/{bid}/labels", name=name, color=LABEL_COLORS.get(name, "sky"))
+            if code != 200 or not isinstance(l, dict) or "id" not in l: return None
             labels[name] = l["id"]
         return labels[name]
-
-    issues = jira_search()
-    print(f"{len(issues)} issue(s) from Jira.")
-    seen = set()
-
-    for it in issues:
-        key = it["key"]
-        seen.add(key)
-        f = it.get("fields", {})
-        status = (f.get("status") or {}).get("name", "À faire")
-        itype = (f.get("issuetype") or {}).get("name", "")
-        summary = f.get("summary", key)
-        due = f.get("duedate")  # YYYY-MM-DD or None
+    def card_body(it):
+        f = it["fields"]; key = it["key"]
         body = adf_to_text(f.get("description")).strip()
-        link = f"{JIRA_SITE}/browse/{key}"
-        desc = f"{body}\n\n— {key} · {link}\n{marker(key)}".strip()
+        return f"{body}\n\n— {key} · {JIRA_SITE}/browse/{key}\n{marker(key)}".strip()
 
-        list_id = ensure_list(status)
-        label_id = ensure_label(itype)
-        due_iso = (due + "T12:00:00.000Z") if due else ""
+    issues = {it["key"]: it for it in jira_search()}
+    print(f"{len(issues)} ticket(s) Jira · {len(by_key)} carte(s) liée(s) · {len(unlinked)} carte(s) non liée(s)")
 
-        if key in by_key:
-            cid = by_key[key]["id"]
-            params = {"name": summary, "desc": desc, "idList": list_id}
-            if due_iso:
-                params["due"] = due_iso
-            trello("PUT", f"/cards/{cid}", **params)
-            if label_id and label_id not in (by_key[key].get("idLabels") or []):
-                trello("POST", f"/cards/{cid}/idLabels", value=label_id)
-            print(f"  ↻ {key} → {status}")
+    # ── 1. Cartes Trello non liées → créer le ticket Jira (TO_JIRA) ──────────
+    for c in unlinked if TO_JIRA else []:
+        cur_status = listname.get(c["idList"], "À faire")
+        fields = {"project": {"key": JIRA_PROJECT or JIRA_JQL.split('"')[1]},
+                  "issuetype": {"id": JIRA_ISSUETYPE_ID}, "summary": c["name"],
+                  "description": text_to_adf((c.get("desc") or "").strip())}
+        if c.get("due"): fields["duedate"] = due_day(c["due"])
+        code, r = jira("POST", "/issue", body={"fields": fields})
+        if code in (200, 201):
+            key = r["key"]
+            if cur_status not in ("À faire", "To Do", "Backlog"):
+                jira_transition(key, cur_status)
+            newdesc = ((c.get("desc") or "").rstrip() + f"\n\n— {key} · {JIRA_SITE}/browse/{key}\n{marker(key)}").strip()
+            trello("PUT", f"/cards/{c['id']}", desc=newdesc)
+            issues[key] = {"key": key, "fields": {}}  # évite l'archivage immédiat
+            print(f"  ⊕ Jira {key} créé depuis carte « {c['name']} »")
         else:
-            params = {"idList": list_id, "name": summary, "desc": desc, "pos": "bottom"}
-            if due_iso:
-                params["due"] = due_iso
-            if label_id:
-                params["idLabels"] = label_id
-            trello("POST", "/cards", **params)
-            print(f"  + {key} → {status}")
+            print(f"  ✗ création Jira échouée pour « {c['name']} » : {code} {str(r)[:120]}")
 
-    # Archive cards whose Jira issue is no longer in scope (never delete)
-    archived = 0
-    for key, c in by_key.items():
-        if key not in seen:
-            trello("PUT", f"/cards/{c['id']}", idList=ensure_list(ARCHIVE_LIST))
-            archived += 1
-    if archived:
-        print(f"  ⤓ {archived} carte(s) archivée(s) (absentes du JQL).")
+    # ── 2. Paires appariées → réconciliation champ par champ ────────────────
+    for key, it in issues.items():
+        c = by_key.get(key)
+        f = it.get("fields", {})
+        if not c:
+            if not TO_TRELLO: continue
+            # ticket sans carte → créer la carte
+            status = (f.get("status") or {}).get("name", "À faire")
+            params = {"idList": ensure_list(status), "name": f.get("summary", key),
+                      "desc": card_body(it), "pos": "bottom"}
+            if f.get("duedate"): params["due"] = f["duedate"] + "T12:00:00.000Z"
+            lid = ensure_label((f.get("issuetype") or {}).get("name"))
+            if lid: params["idLabels"] = lid
+            trello("POST", "/cards", **params)
+            print(f"  + carte créée pour {key}")
+            continue
+
+        jnewer = parse_ts(f.get("updated")) >= parse_ts(c.get("dateLastActivity"))
+        cid = c["id"]
+        changes = []
+
+        # nom / résumé
+        jsum = f.get("summary", ""); cname = c.get("name", "")
+        if jsum != cname:
+            if jnewer and TO_TRELLO:
+                trello("PUT", f"/cards/{cid}", name=jsum); changes.append("nom→Trello")
+            elif (not jnewer) and TO_JIRA:
+                jira("PUT", f"/issue/{key}", body={"fields": {"summary": cname}}); changes.append("nom→Jira")
+
+        # échéance
+        jdue = f.get("duedate"); cdue = due_day(c.get("due"))
+        if jdue != cdue:
+            if jnewer and TO_TRELLO:
+                trello("PUT", f"/cards/{cid}", due=(jdue + "T12:00:00.000Z") if jdue else "")
+                changes.append("échéance→Trello")
+            elif (not jnewer) and TO_JIRA:
+                jira("PUT", f"/issue/{key}", body={"fields": {"duedate": cdue}}); changes.append("échéance→Jira")
+
+        # statut ↔ liste
+        jstatus = (f.get("status") or {}).get("name", "")
+        clist = listname.get(c["idList"], "")
+        if jstatus and clist and jstatus != clist:
+            if jnewer and TO_TRELLO:
+                trello("PUT", f"/cards/{cid}", idList=ensure_list(jstatus)); changes.append(f"statut→Trello({jstatus})")
+            elif (not jnewer) and TO_JIRA:
+                if jira_transition(key, clist): changes.append(f"statut→Jira({clist})")
+
+        # description : autorité Jira → Trello
+        if TO_TRELLO:
+            want = card_body(it)
+            if (c.get("desc") or "").strip() != want:
+                trello("PUT", f"/cards/{cid}", desc=want); changes.append("desc→Trello")
+            lid = ensure_label((f.get("issuetype") or {}).get("name"))
+            if lid and lid not in (c.get("idLabels") or []):
+                trello("POST", f"/cards/{cid}/idLabels", value=lid)
+
+        if changes: print(f"  ↻ {key}: {', '.join(changes)}")
+
+    # ── 3. Cartes liées dont le ticket a quitté le JQL → archiver ───────────
+    if TO_TRELLO:
+        n = 0
+        for key, c in by_key.items():
+            if key not in issues:
+                trello("PUT", f"/cards/{c['id']}", idList=ensure_list(ARCHIVE_LIST)); n += 1
+        if n: print(f"  ⤓ {n} carte(s) archivée(s).")
 
     print("Sync terminé.")
 


### PR DESCRIPTION
Sync **bidirectionnel** (réglable via `SYNC_DIRECTION`, défaut `bidirectional`).

- **Réconciliation champ par champ**, arbitrage *dernier-modifié-gagne* (Jira `updated` ↔ Trello `dateLastActivity`), écriture seulement si différent → **pas de ping-pong**.
- Bidirectionnel : résumé↔nom, échéance↔due, **statut↔liste** (transition Jira). Jira→Trello : description, type, étiquettes.
- Création : ticket↔carte dans les deux sens (carte sans marqueur → ticket Jira créé + re-lié). Hors-JQL → archivé.
- **Fix** : `"" in "{["` == True en Python → test tuple, sinon `json.loads` plantait sur les 204 (transitions/PUT Jira).

✅ **Validé en réel** : Jira→Trello (RG-1/2 En cours) **et** Trello→Jira (carte RG-5 → Terminé ⇒ transition Jira).