### PR TITLE
feat(sync): assignés, commentaires bidirectionnels et composants→étiquettes

### DIFF
--- a/.github/workflows/jira-trello-sync.yml
+++ b/.github/workflows/jira-trello-sync.yml
@@ -42,6 +42,7 @@ jobs:
           JIRA_JQL: ${{ secrets.JIRA_JQL }}
           JIRA_ISSUETYPE_ID: ${{ secrets.JIRA_ISSUETYPE_ID }}
           SYNC_DIRECTION: ${{ secrets.SYNC_DIRECTION }}
+          ASSIGNEE_MAP: ${{ secrets.ASSIGNEE_MAP }}
           TRELLO_KEY: ${{ secrets.TRELLO_KEY }}
           TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
           TRELLO_BOARD: ${{ secrets.TRELLO_BOARD }}

--- a/scripts/jira-trello-sync/README.md
+++ b/scripts/jira-trello-sync/README.md
@@ -15,7 +15,9 @@ n'écrit que si la valeur diffère (pas de ping-pong).
 | échéance (`duedate` ↔ `due`) | bidirectionnel |
 | **statut ↔ liste** (nom de liste = nom de statut, transition Jira) | bidirectionnel |
 | description (ADF aplati + lien) | Jira → Trello (autorité Jira) |
-| type, étiquettes | Jira → Trello |
+| type, étiquettes, **composants** (→ étiquette) | Jira → Trello |
+| **assigné ↔ membre** (via `ASSIGNEE_MAP`) | bidirectionnel |
+| **commentaires** (marqueurs anti-boucle `↪ Jira #` / `↪ Trello #`) | bidirectionnel |
 
 **Création** : un ticket Jira sans carte → carte créée ; une **carte Trello sans
 marqueur** → ticket Jira créé puis carte re-liée. Cartes dont le ticket sort du
@@ -42,6 +44,7 @@ récupère son shortlink (l'identifiant dans l'URL `trello.com/b/XXXXXXXX`).
 | `TRELLO_BOARD` | shortlink/id du board mirror (étape 1) |
 | `SYNC_DIRECTION` | *(optionnel)* `bidirectional` (défaut), `jira-to-trello` ou `trello-to-jira` |
 | `JIRA_ISSUETYPE_ID` | *(optionnel)* type des tickets créés depuis une carte Trello (défaut `10042`) |
+| `ASSIGNEE_MAP` | *(optionnel)* JSON `{"<jiraAccountId>":"<trelloMemberId>", …}` pour synchroniser les assignés. `accountId` Jira via `GET /rest/api/3/myself` ; `memberId` Trello via `GET /1/members/me`. Sans cette map, les assignés ne sont pas touchés. |
 
 > Le **token API Atlassian** sert à la fois pour Jira (`JIRA_TOKEN`) et Trello
 > (`TRELLO_TOKEN`) si tu utilises le même compte Atlassian.
@@ -73,5 +76,10 @@ python3 scripts/jira-trello-sync/sync.py
   une transition est jouée vers le statut homonyme de la liste (si disponible
   dans le workflow).
 - La **description** reste pilotée par Jira (autorité) : édite-la côté Jira.
+- Les **composants** Jira deviennent des **étiquettes Trello** (sens Jira → Trello).
+- Les **assignés** ne sont synchronisés que pour les comptes présents dans
+  `ASSIGNEE_MAP` (mapping explicite Jira ↔ Trello). Les autres membres restent intacts.
+- Les **commentaires** sont bidirectionnels avec marqueurs anti-boucle
+  (`↪ Jira #<id>` / `↪ Trello #<id>`) : un miroir n'est jamais renvoyé à sa source.
 - ⚠️ Cible un **board dédié** : déplacer/éditer une carte y est propagé à Jira.
 - Aucune dépendance tierce : `sync.py` n'utilise que la bibliothèque standard.

--- a/scripts/jira-trello-sync/sync.py
+++ b/scripts/jira-trello-sync/sync.py
@@ -37,6 +37,12 @@ JIRA_TOKEN   = env("JIRA_TOKEN", req=True)
 JIRA_PROJECT = env("JIRA_PROJECT", "")
 JIRA_JQL     = env("JIRA_JQL", "") or (f'project = "{JIRA_PROJECT}" ORDER BY Rank ASC' if JIRA_PROJECT else "")
 JIRA_ISSUETYPE_ID = env("JIRA_ISSUETYPE_ID", "10042")  # défaut: Tâche
+# Map assignés Jira ↔ Trello : {"<jiraAccountId>": "<trelloMemberId>", ...}
+try:
+    ASSIGNEE_MAP = json.loads(env("ASSIGNEE_MAP", "") or "{}")
+except Exception:
+    ASSIGNEE_MAP = {}
+ASSIGNEE_MAP_REV = {v: k for k, v in ASSIGNEE_MAP.items()}
 TRELLO_KEY   = env("TRELLO_KEY", req=True)
 TRELLO_TOKEN = env("TRELLO_TOKEN", req=True)
 TRELLO_BOARD = env("TRELLO_BOARD", req=True)
@@ -110,7 +116,7 @@ def marker(key): return f"[jira:{key}]"
 def due_day(iso): return iso[:10] if iso else None  # ISO/date → YYYY-MM-DD
 
 def jira_search():
-    fields = "summary,description,status,duedate,issuetype,labels,priority,updated"
+    fields = "summary,description,status,duedate,issuetype,labels,priority,updated,assignee,components"
     token = None
     out = []
     while True:
@@ -141,6 +147,43 @@ def jira_transition(key, target):
     code, _ = jira("POST", f"/issue/{key}/transitions", body={"transition": {"id": tid}})
     return code in (200, 204)
 
+def sync_comments(key, cid):
+    """Commentaires bidirectionnels, anti-boucle par marqueurs :
+    miroir d'un commentaire Jira #J côté Trello → texte « ↪ Jira #J … » ;
+    miroir d'un commentaire Trello #T côté Jira → « ↪ Trello #T … »."""
+    n = 0
+    _, jc = jira("GET", f"/issue/{key}/comment", params={"maxResults": 100})
+    jcomments = jc.get("comments", []) if isinstance(jc, dict) else []
+    _, tacts = trello("GET", f"/cards/{cid}/actions", filter="commentCard", limit="50")
+    tcomments = tacts if isinstance(tacts, list) else []
+    jtexts = [adf_to_text(c.get("body")) for c in jcomments]
+    ttexts = [(a.get("data", {}) or {}).get("text", "") for a in tcomments]
+
+    if TO_TRELLO:
+        for c in jcomments:
+            jid = c["id"]
+            if any(f"↪ Jira #{jid}" in t for t in ttexts):
+                continue
+            author = (c.get("author") or {}).get("displayName", "Jira")
+            body = adf_to_text(c.get("body")).strip()
+            if not body:
+                continue
+            trello("POST", f"/cards/{cid}/actions/comments", text=f"↪ Jira #{jid} · {author} : {body}")
+            n += 1
+    if TO_JIRA:
+        for a in tcomments:
+            text = (a.get("data", {}) or {}).get("text", "")
+            if text.startswith("↪ Jira #"):
+                continue  # c'est déjà un miroir d'un commentaire Jira
+            tid = a["id"]
+            if any(f"↪ Trello #{tid}" in t for t in jtexts):
+                continue
+            author = (a.get("memberCreator") or {}).get("fullName", "Trello")
+            jira("POST", f"/issue/{key}/comment",
+                 body={"body": text_to_adf(f"↪ Trello #{tid} · {author} : {text}")})
+            n += 1
+    return n
+
 # ── Sync ────────────────────────────────────────────────────────────────────
 def main():
     print(f"Direction: {DIRECTION}")
@@ -152,7 +195,7 @@ def main():
     listname = {v: k for k, v in lists.items()}
     labels = {l["name"]: l["id"] for l in trello("GET", f"/boards/{bid}/labels")[1] if l["name"]}
     cards = trello("GET", f"/boards/{bid}/cards",
-                   fields="id,name,desc,due,idList,idLabels,dateLastActivity")[1]
+                   fields="id,name,desc,due,idList,idLabels,idMembers,dateLastActivity")[1]
 
     by_key, unlinked = {}, []
     for c in cards:
@@ -259,6 +302,33 @@ def main():
             lid = ensure_label((f.get("issuetype") or {}).get("name"))
             if lid and lid not in (c.get("idLabels") or []):
                 trello("POST", f"/cards/{cid}/idLabels", value=lid)
+            # composants Jira → étiquettes Trello
+            for comp in f.get("components") or []:
+                clid = ensure_label(comp.get("name"))
+                if clid and clid not in (c.get("idLabels") or []):
+                    trello("POST", f"/cards/{cid}/idLabels", value=clid)
+
+        # assigné ↔ membre (bidirectionnel, via ASSIGNEE_MAP)
+        if ASSIGNEE_MAP:
+            jacct = (f.get("assignee") or {}).get("accountId")
+            want_member = ASSIGNEE_MAP.get(jacct) if jacct else None
+            cur_mapped = [m for m in (c.get("idMembers") or []) if m in ASSIGNEE_MAP_REV]
+            cur_member = cur_mapped[0] if cur_mapped else None
+            if want_member != cur_member:
+                if jnewer and TO_TRELLO:
+                    for m in cur_mapped:
+                        trello("DELETE", f"/cards/{cid}/idMembers/{m}")
+                    if want_member:
+                        trello("POST", f"/cards/{cid}/idMembers", value=want_member)
+                    changes.append("assigné→Trello")
+                elif (not jnewer) and TO_JIRA:
+                    acct = ASSIGNEE_MAP_REV.get(cur_member) if cur_member else None
+                    jira("PUT", f"/issue/{key}/assignee", body={"accountId": acct})
+                    changes.append("assigné→Jira")
+
+        # commentaires (bidirectionnel, anti-boucle par marqueurs)
+        nc = sync_comments(key, cid)
+        if nc: changes.append(f"{nc} commentaire(s)")
 
         if changes: print(f"  ↻ {key}: {', '.join(changes)}")
 


### PR DESCRIPTION
Étend la synchro Jira ↔ Trello :

- **Assignés** ↔ membres Trello via le secret `ASSIGNEE_MAP` (mapping `accountId`↔`memberId`), arbitrage dernier-modifié-gagne.
- **Commentaires** bidirectionnels avec marqueurs anti-boucle (`↪ Jira #<id>` / `↪ Trello #<id>`).
- **Composants** Jira reflétés en **étiquettes** Trello.
- Workflow CI + README mis à jour (nouveau secret `ASSIGNEE_MAP`).

Vérifié en réel sur le board miroir : RG-1 a reçu le membre, l'étiquette de composant `Sync & transferts` et le commentaire mirroir.