### PR TITLE
feat(site): board Trello roadmap en direct sur le site

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -379,6 +379,26 @@ const Icon = ({
       return /*#__PURE__*/React.createElement("svg", common, /*#__PURE__*/React.createElement("path", {
         d: "M3 12a9 9 0 0 1 15.4-6.4L21 8M21 4v4h-4M21 12a9 9 0 0 1-15.4 6.4L3 16M3 20v-4h4"
       }));
+    case 'columns':
+      return /*#__PURE__*/React.createElement("svg", common, /*#__PURE__*/React.createElement("rect", {
+        x: "3.5",
+        y: "4.5",
+        width: "5",
+        height: "15",
+        rx: "1.4"
+      }), /*#__PURE__*/React.createElement("rect", {
+        x: "9.5",
+        y: "4.5",
+        width: "5",
+        height: "11",
+        rx: "1.4"
+      }), /*#__PURE__*/React.createElement("rect", {
+        x: "15.5",
+        y: "4.5",
+        width: "5",
+        height: "8",
+        rx: "1.4"
+      }));
     default:
       return /*#__PURE__*/React.createElement("svg", common, /*#__PURE__*/React.createElement("rect", {
         x: "4",
@@ -3845,6 +3865,107 @@ const ROADMAP = [{
     }
   }]
 }];
+const TRELLO_BOARD_ID = 'QjhP4sDK';
+const TRELLO_BOARD_URL = 'https://trello.com/b/QjhP4sDK';
+const TRELLO_LABEL_HEX = {
+  green: '#4bce97',
+  yellow: '#e2b203',
+  orange: '#fea362',
+  red: '#f87168',
+  purple: '#9f8fef',
+  blue: '#579dff',
+  sky: '#6cc3e0',
+  lime: '#94c748',
+  pink: '#e774bb',
+  black: '#8c9bab'
+};
+const TrelloBoard = ({
+  lang
+}) => {
+  const t = useT();
+  const [cols, setCols] = React.useState(null);
+  const [err, setErr] = React.useState(false);
+  React.useEffect(() => {
+    const base = 'https://api.trello.com/1/boards/' + TRELLO_BOARD_ID;
+    Promise.all([fetch(base + '/lists?fields=name').then(r => r.json()), fetch(base + '/cards?fields=name,due,idList,labels').then(r => r.json())]).then(([lists, cards]) => {
+      if (!Array.isArray(lists) || !Array.isArray(cards)) throw new Error('bad payload');
+      const byList = {};
+      cards.forEach(c => {
+        (byList[c.idList] = byList[c.idList] || []).push(c);
+      });
+      setCols(lists.map(l => ({
+        id: l.id,
+        name: l.name,
+        cards: byList[l.id] || []
+      })));
+    }).catch(() => setErr(true));
+  }, []);
+  const fmtDue = iso => {
+    if (!iso) return null;
+    try {
+      return new Date(iso).toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US', {
+        month: 'short',
+        year: 'numeric'
+      });
+    } catch (e) {
+      return null;
+    }
+  };
+  return /*#__PURE__*/React.createElement("div", {
+    className: "tb"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "tb-head"
+  }, /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("span", {
+    className: "tb-live"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "tb-dot"
+  }), t('Suivi en direct', 'Live tracking')), /*#__PURE__*/React.createElement("p", {
+    className: "tb-sub"
+  }, t('Notre board public, synchronisé automatiquement avec notre suivi interne (Jira ↔ Trello).', 'Our public board, automatically kept in sync with our internal tracker (Jira ↔ Trello).'))), /*#__PURE__*/React.createElement("a", {
+    className: "btn btn-violet tb-open",
+    href: TRELLO_BOARD_URL,
+    target: "_blank",
+    rel: "noopener"
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "columns",
+    size: 16
+  }), t('Ouvrir sur Trello', 'Open in Trello'))), err && /*#__PURE__*/React.createElement("p", {
+    className: "tb-msg"
+  }, t('Board momentanément indisponible — ', 'Board temporarily unavailable — '), /*#__PURE__*/React.createElement("a", {
+    href: TRELLO_BOARD_URL,
+    target: "_blank",
+    rel: "noopener"
+  }, t('ouvrir sur Trello', 'open in Trello')), "."), !err && !cols && /*#__PURE__*/React.createElement("p", {
+    className: "tb-msg"
+  }, t('Chargement du board…', 'Loading board…')), !err && cols && /*#__PURE__*/React.createElement("div", {
+    className: "tb-board"
+  }, cols.map(col => /*#__PURE__*/React.createElement("div", {
+    className: "tb-col",
+    key: col.id
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "tb-col-head"
+  }, /*#__PURE__*/React.createElement("span", null, col.name), /*#__PURE__*/React.createElement("span", {
+    className: "tb-count"
+  }, col.cards.length)), col.cards.map(c => /*#__PURE__*/React.createElement("div", {
+    className: "tb-card",
+    key: c.id
+  }, c.labels && c.labels.length > 0 && /*#__PURE__*/React.createElement("div", {
+    className: "tb-labels"
+  }, c.labels.map(l => /*#__PURE__*/React.createElement("span", {
+    className: "tb-lab",
+    key: l.id,
+    style: {
+      background: TRELLO_LABEL_HEX[l.color] || '#8c9bab'
+    }
+  }, l.name || ''))), /*#__PURE__*/React.createElement("div", {
+    className: "tb-name"
+  }, c.name), c.due && /*#__PURE__*/React.createElement("div", {
+    className: "tb-due"
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "clock",
+    size: 12
+  }), fmtDue(c.due))))))));
+};
 const Roadmap = ({
   lang
 }) => {
@@ -3884,7 +4005,9 @@ const Roadmap = ({
   }, /*#__PURE__*/React.createElement(Icon, {
     name: "bolt.fill",
     size: 16
-  }), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, t('Pari produit', 'Product bet'), " : "), t('« Capability, pas compte » — le partage et le multi-appareils deviennent des objets cryptographiques que tu possèdes et révoques, jamais une ligne dans une base (puisqu\'il n\'y en a pas).', '"Capability, not account" — sharing and multi-device become cryptographic objects you own and revoke, never a row in a database (because there isn\'t one).'))), /*#__PURE__*/React.createElement("p", {
+  }), /*#__PURE__*/React.createElement("span", null, /*#__PURE__*/React.createElement("b", null, t('Pari produit', 'Product bet'), " : "), t('« Capability, pas compte » — le partage et le multi-appareils deviennent des objets cryptographiques que tu possèdes et révoques, jamais une ligne dans une base (puisqu\'il n\'y en a pas).', '"Capability, not account" — sharing and multi-device become cryptographic objects you own and revoke, never a row in a database (because there isn\'t one).'))), /*#__PURE__*/React.createElement(TrelloBoard, {
+    lang: lang
+  }), /*#__PURE__*/React.createElement("p", {
     className: "rm-note"
   }, t('Dates cibles, susceptibles d\'évoluer — priorisées avec vos retours. Open source : suivez l\'avancement sur GitHub.', 'Target dates, subject to change — prioritized with your feedback. Open source: follow progress on GitHub.'))));
 };

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -77,6 +77,7 @@ const Icon = ({ name, size = 18, weight = 'regular', style }) => {
     case 'wand': return <svg {...common}><path d="m4 20 12-12M14 6l4 4M11 3l1 2M19 11l2 1M16 14l1 2M6 5l2 1"/></svg>;
     case 'arrow.up': return <svg {...common}><path d="M12 19V5M6 11l6-6 6 6"/></svg>;
     case 'rotate': return <svg {...common}><path d="M3 12a9 9 0 0 1 15.4-6.4L21 8M21 4v4h-4M21 12a9 9 0 0 1-15.4 6.4L3 16M3 20v-4h4"/></svg>;
+    case 'columns': return <svg {...common}><rect x="3.5" y="4.5" width="5" height="15" rx="1.4"/><rect x="9.5" y="4.5" width="5" height="11" rx="1.4"/><rect x="15.5" y="4.5" width="5" height="8" rx="1.4"/></svg>;
     default: return <svg {...common}><rect x="4" y="4" width="16" height="16" rx="3"/></svg>;
   }
 };
@@ -1087,6 +1088,70 @@ const ROADMAP = [
     { n:{ fr:'CipherSpace', en:'CipherSpace' }, when:{ fr:'T3 2027', en:'Q3 2027' }, d:{ fr:'Explorer ses archives chiffrées dans l\'espace, sur visionOS.', en:'Explore your encrypted archives in space, on visionOS.' } },
   ] },
 ];
+const TRELLO_BOARD_ID = 'QjhP4sDK';
+const TRELLO_BOARD_URL = 'https://trello.com/b/QjhP4sDK';
+const TRELLO_LABEL_HEX = {
+  green:'#4bce97', yellow:'#e2b203', orange:'#fea362', red:'#f87168',
+  purple:'#9f8fef', blue:'#579dff', sky:'#6cc3e0', lime:'#94c748',
+  pink:'#e774bb', black:'#8c9bab'
+};
+const TrelloBoard = ({ lang }) => {
+  const t = useT();
+  const [cols, setCols] = React.useState(null);
+  const [err, setErr] = React.useState(false);
+  React.useEffect(() => {
+    const base = 'https://api.trello.com/1/boards/' + TRELLO_BOARD_ID;
+    Promise.all([
+      fetch(base + '/lists?fields=name').then(r => r.json()),
+      fetch(base + '/cards?fields=name,due,idList,labels').then(r => r.json()),
+    ]).then(([lists, cards]) => {
+      if (!Array.isArray(lists) || !Array.isArray(cards)) throw new Error('bad payload');
+      const byList = {};
+      cards.forEach(c => { (byList[c.idList] = byList[c.idList] || []).push(c); });
+      setCols(lists.map(l => ({ id:l.id, name:l.name, cards: byList[l.id] || [] })));
+    }).catch(() => setErr(true));
+  }, []);
+  const fmtDue = (iso) => {
+    if (!iso) return null;
+    try { return new Date(iso).toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US', { month:'short', year:'numeric' }); }
+    catch (e) { return null; }
+  };
+  return (
+    <div className="tb">
+      <div className="tb-head">
+        <div>
+          <span className="tb-live"><span className="tb-dot"/>{t('Suivi en direct','Live tracking')}</span>
+          <p className="tb-sub">{t('Notre board public, synchronisé automatiquement avec notre suivi interne (Jira ↔ Trello).','Our public board, automatically kept in sync with our internal tracker (Jira ↔ Trello).')}</p>
+        </div>
+        <a className="btn btn-violet tb-open" href={TRELLO_BOARD_URL} target="_blank" rel="noopener"><Icon name="columns" size={16}/>{t('Ouvrir sur Trello','Open in Trello')}</a>
+      </div>
+      {err && <p className="tb-msg">{t('Board momentanément indisponible — ','Board temporarily unavailable — ')}<a href={TRELLO_BOARD_URL} target="_blank" rel="noopener">{t('ouvrir sur Trello','open in Trello')}</a>.</p>}
+      {!err && !cols && <p className="tb-msg">{t('Chargement du board…','Loading board…')}</p>}
+      {!err && cols && (
+        <div className="tb-board">
+          {cols.map(col => (
+            <div className="tb-col" key={col.id}>
+              <div className="tb-col-head"><span>{col.name}</span><span className="tb-count">{col.cards.length}</span></div>
+              {col.cards.map(c => (
+                <div className="tb-card" key={c.id}>
+                  {(c.labels && c.labels.length > 0) && (
+                    <div className="tb-labels">
+                      {c.labels.map(l => (
+                        <span className="tb-lab" key={l.id} style={{ background: TRELLO_LABEL_HEX[l.color] || '#8c9bab' }}>{l.name || ''}</span>
+                      ))}
+                    </div>
+                  )}
+                  <div className="tb-name">{c.name}</div>
+                  {c.due && <div className="tb-due"><Icon name="clock" size={12}/>{fmtDue(c.due)}</div>}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 const Roadmap = ({ lang }) => {
   const t = useT();
   return (
@@ -1120,6 +1185,7 @@ const Roadmap = ({ lang }) => {
           <Icon name="bolt.fill" size={16}/>
           <span><b>{t('Pari produit','Product bet')} : </b>{t('« Capability, pas compte » — le partage et le multi-appareils deviennent des objets cryptographiques que tu possèdes et révoques, jamais une ligne dans une base (puisqu\'il n\'y en a pas).','"Capability, not account" — sharing and multi-device become cryptographic objects you own and revoke, never a row in a database (because there isn\'t one).')}</span>
         </div>
+        <TrelloBoard lang={lang}/>
         <p className="rm-note">{t('Dates cibles, susceptibles d\'évoluer — priorisées avec vos retours. Open source : suivez l\'avancement sur GitHub.','Target dates, subject to change — prioritized with your feedback. Open source: follow progress on GitHub.')}</p>
       </div>
     </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -316,6 +316,39 @@
   .rm-bet svg{flex:0 0 auto;margin-top:2px}
   .rm-note{text-align:center;color:var(--muted);font-size:13px;font-weight:500;margin:18px auto 0;max-width:620px}
   @media(max-width:760px){.roadmap{grid-template-columns:1fr}}
+  /* live Trello board */
+  .tb{margin:30px auto 0;max-width:1040px}
+  .tb-head{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap}
+  .tb-live{display:inline-flex;align-items:center;gap:7px;font-size:13px;font-weight:800;
+    letter-spacing:.3px;color:var(--accent-deep);text-transform:uppercase}
+  .tb-dot{width:8px;height:8px;border-radius:50%;background:#34C759;box-shadow:0 0 0 0 rgba(52,199,89,.6);
+    animation:tbpulse 2s infinite}
+  @keyframes tbpulse{0%{box-shadow:0 0 0 0 rgba(52,199,89,.5)}70%{box-shadow:0 0 0 7px rgba(52,199,89,0)}100%{box-shadow:0 0 0 0 rgba(52,199,89,0)}}
+  .tb-sub{margin:6px 0 0;font-size:13.5px;color:var(--muted);font-weight:500;max-width:560px}
+  .tb-open{font-size:14px;padding:11px 18px;flex:0 0 auto}
+  .tb-msg{margin:16px 0 0;color:var(--muted);font-size:13.5px;font-weight:500}
+  .tb-msg a{color:var(--accent-deep);font-weight:700}
+  .tb-board{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-top:18px;align-items:start}
+  .tb-col{background:#F3F1FA;border:1px solid var(--line);border-radius:16px;padding:14px 12px}
+  .tb-col-head{display:flex;align-items:center;justify-content:space-between;gap:8px;
+    font-size:13px;font-weight:800;letter-spacing:-.1px;color:var(--ink);padding:2px 4px 12px}
+  .tb-count{flex:0 0 auto;font-size:11px;font-weight:800;color:var(--accent-deep);
+    background:var(--accent-soft);padding:2px 8px;border-radius:999px}
+  .tb-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:11px 12px;
+    margin-bottom:9px;box-shadow:0 2px 8px rgba(11,8,32,.04)}
+  .tb-card:last-child{margin-bottom:0}
+  .tb-labels{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:7px}
+  .tb-lab{font-size:10px;font-weight:800;letter-spacing:.2px;color:#fff;padding:2px 8px;
+    border-radius:999px;line-height:1.5}
+  .tb-name{font-size:14px;font-weight:700;letter-spacing:-.2px;color:var(--ink);line-height:1.35}
+  .tb-due{display:inline-flex;align-items:center;gap:4px;margin-top:7px;font-size:11.5px;
+    font-weight:700;color:var(--muted)}
+  @media(max-width:760px){
+    .tb-board{grid-template-columns:none;grid-auto-flow:column;grid-auto-columns:82%;
+      overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;
+      margin-left:-20px;margin-right:-20px;padding:0 20px 6px}
+    .tb-col{scroll-snap-align:start}
+  }
   /* new badge on gallery panels */
   .panel .newtag{position:absolute;top:16px;right:16px;background:var(--accent);color:#fff;font-size:10px;
     font-weight:800;letter-spacing:.5px;padding:4px 9px;border-radius:999px;z-index:3;


### PR DESCRIPTION
Ajoute un **board Trello live** dans la section Roadmap de rclone.rougetet.com.

- Composant `TrelloBoard` qui interroge l'**API REST publique** du board (rendu public, `Access-Control-Allow-Origin: *`) — **aucun token exposé**.
- 3 colonnes (court / moyen / long terme), cartes avec **étiquettes de composant colorées** et **échéances**.
- En-tête « Suivi en direct » (point pulsant) + bouton « Ouvrir sur Trello ». Scroll horizontal sur mobile.
- Données live : reflète automatiquement la synchro Jira ↔ Trello.

Vérifié via Playwright : 3 colonnes, 15 cartes, 0 erreur console.