### PR TITLE
feat(site): notes de version 1.7 + retry réseau gomobile

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -3011,7 +3011,7 @@ const Hero = () => {
   }, /*#__PURE__*/React.createElement(Icon, {
     name: "bolt.fill",
     size: 14
-  }), t('v1.6 · ESSAI GRATUIT', 'v1.6 · FREE TRIAL'))), /*#__PURE__*/React.createElement("h1", {
+  }), t('v1.7 · ESSAI GRATUIT', 'v1.7 · FREE TRIAL'))), /*#__PURE__*/React.createElement("h1", {
     className: "title"
   }, ML(t('Tous vos clouds.\nChiffrés.', 'Every cloud.\nEncrypted.'))), /*#__PURE__*/React.createElement("p", {
     className: "sub"
@@ -3482,8 +3482,39 @@ const FreeMonth = () => {
   }, s.n), /*#__PURE__*/React.createElement("h5", null, s.h), /*#__PURE__*/React.createElement("p", null, s.p)))))));
 };
 const VERSIONS = [{
-  v: '1.6',
+  v: '1.7',
   current: true,
+  date: {
+    fr: 'Juin 2026',
+    en: 'June 2026'
+  },
+  items: [{
+    fr: 'Téléchargez des dossiers entiers en une fois (récursif).',
+    en: 'Download entire folders in one go (recursive).'
+  }, {
+    fr: 'Raccourcis & Siri : ouvrez un remote ou lancez un envoi de fichier depuis l\'app Raccourcis, grâce aux App Intents.',
+    en: 'Shortcuts & Siri: open a remote or start a file upload from the Shortcuts app, powered by App Intents.'
+  }, {
+    fr: 'Confidentialité renforcée : le cache média est effacé automatiquement au verrouillage par inactivité, et vous pouvez plafonner sa taille (éviction automatique).',
+    en: 'Stronger privacy: the media cache is wiped automatically when the app locks on inactivity, and you can cap its size (automatic eviction).'
+  }, {
+    fr: 'Transferts plus fiables : les transferts échoués sont relancés automatiquement, dans une limite raisonnable.',
+    en: 'More reliable transfers: failed transfers are retried automatically, within a sensible limit.'
+  }, {
+    fr: 'Assistant guidé pour créer votre coffre chiffré « Crypt ».',
+    en: 'Guided assistant to set up your encrypted "Crypt" vault.'
+  }, {
+    fr: 'Journaux internes en direct pour diagnostiquer une connexion.',
+    en: 'Live internal logs to diagnose a connection.'
+  }, {
+    fr: 'Nouvel écran « Feuille de route » pour découvrir ce qui arrive.',
+    en: 'New "Roadmap" screen to see what\'s coming next.'
+  }, {
+    fr: 'Améliorations de stabilité et de performance.',
+    en: 'Stability and performance improvements.'
+  }]
+}, {
+  v: '1.6',
   date: {
     fr: 'Juin 2026',
     en: 'June 2026'

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -719,7 +719,7 @@ const Hero = () => {
     <section className="hero" id="top">
       <div className="wrap">
         <img className="icon" src="icon.png" alt="Rclone GUI"/>
-        <div><span className="pill"><Icon name="bolt.fill" size={14}/>{t('v1.6 · ESSAI GRATUIT','v1.6 · FREE TRIAL')}</span></div>
+        <div><span className="pill"><Icon name="bolt.fill" size={14}/>{t('v1.7 · ESSAI GRATUIT','v1.7 · FREE TRIAL')}</span></div>
         <h1 className="title">{ML(t('Tous vos clouds.\nChiffrés.','Every cloud.\nEncrypted.'))}</h1>
         <p className="sub">{t('Parcourez 80+ services cloud — y compris vos remotes rclone chiffrés — directement dans Fichiers. iPhone, iPad & Mac.','Browse 80+ cloud services — including your encrypted rclone crypt remotes — right inside Files. iPhone, iPad & Mac.')}</p>
         <div className="cta-row">
@@ -997,7 +997,17 @@ const FreeMonth = () => {
 };
 
 const VERSIONS = [
-  { v:'1.6', current:true, date:{ fr:'Juin 2026', en:'June 2026' }, items:[
+  { v:'1.7', current:true, date:{ fr:'Juin 2026', en:'June 2026' }, items:[
+    { fr:'Téléchargez des dossiers entiers en une fois (récursif).', en:'Download entire folders in one go (recursive).' },
+    { fr:'Raccourcis & Siri : ouvrez un remote ou lancez un envoi de fichier depuis l\'app Raccourcis, grâce aux App Intents.', en:'Shortcuts & Siri: open a remote or start a file upload from the Shortcuts app, powered by App Intents.' },
+    { fr:'Confidentialité renforcée : le cache média est effacé automatiquement au verrouillage par inactivité, et vous pouvez plafonner sa taille (éviction automatique).', en:'Stronger privacy: the media cache is wiped automatically when the app locks on inactivity, and you can cap its size (automatic eviction).' },
+    { fr:'Transferts plus fiables : les transferts échoués sont relancés automatiquement, dans une limite raisonnable.', en:'More reliable transfers: failed transfers are retried automatically, within a sensible limit.' },
+    { fr:'Assistant guidé pour créer votre coffre chiffré « Crypt ».', en:'Guided assistant to set up your encrypted "Crypt" vault.' },
+    { fr:'Journaux internes en direct pour diagnostiquer une connexion.', en:'Live internal logs to diagnose a connection.' },
+    { fr:'Nouvel écran « Feuille de route » pour découvrir ce qui arrive.', en:'New "Roadmap" screen to see what\'s coming next.' },
+    { fr:'Améliorations de stabilité et de performance.', en:'Stability and performance improvements.' },
+  ] },
+  { v:'1.6', date:{ fr:'Juin 2026', en:'June 2026' }, items:[
     { fr:'Connexion par fichier : quand un backend exige un fichier pour s\'authentifier (clé privée SSH, known_hosts, JSON de compte de service Google, certificat TLS…), importez-le directement depuis Fichiers — fini les chemins impossibles à saisir.', en:'Connect with a file: when a backend needs a file to sign in (SSH private key, known_hosts, Google service-account JSON, TLS certificate…), import it straight from Files — no more impossible-to-type paths.' },
     { fr:'Les identifiants importés sont copiés en sécurité sur l\'appareil et ne sont jamais transmis ailleurs.', en:'Imported credentials are copied securely on-device and never sent anywhere else.' },
     { fr:'Améliorations de stabilité et de performance.', en:'Stability and performance improvements.' },

--- a/scripts/build-rclone.sh
+++ b/scripts/build-rclone.sh
@@ -68,10 +68,26 @@ echo "Xcode SDK     : $(xcrun --show-sdk-path 2>/dev/null | head -1)"
 
 # --- Install / init gomobile -------------------------------------------------
 
+# Xcode Cloud runners occasionally fail to resolve proxy.golang.org (transient
+# DNS, e.g. "lookup proxy.golang.org: no such host"). Retry network-dependent
+# Go downloads with backoff so a flaky lookup doesn't fail the whole build.
+retry() {
+    n=0; max=5
+    until "$@"; do
+        n=$((n + 1))
+        if [ "$n" -ge "$max" ]; then
+            echo "ERROR: command failed after $max attempts: $*"
+            return 1
+        fi
+        echo "  …retry $n/$max in $((n * 10))s: $*"
+        sleep $((n * 10))
+    done
+}
+
 if ! command -v gomobile >/dev/null 2>&1; then
     echo ""
     echo "Installing gomobile (golang.org/x/mobile/cmd/gomobile)..."
-    go install golang.org/x/mobile/cmd/gomobile@latest
+    retry go install golang.org/x/mobile/cmd/gomobile@latest
     GOPATH="${GOPATH:-$HOME/go}"
     export PATH="$PATH:$GOPATH/bin"
     if ! command -v gomobile >/dev/null 2>&1; then
@@ -83,7 +99,7 @@ fi
 echo "gomobile      : $(command -v gomobile)"
 
 # Init is idempotent and downloads the iOS support code if needed
-gomobile init
+retry gomobile init
 
 # --- Clone rclone ------------------------------------------------------------
 


### PR DESCRIPTION
**Publie les notes de la version 1.7 sur le site** (rclone.rougetet.com) :
- Entrée **1.7** en tête de l'historique des versions (badge ACTUELLE)
- Bandeau Hero `v1.6` → `v1.7`
- Contenu : téléchargement récursif de dossiers, Raccourcis/App Intents, wipe + plafond du cache, re-enqueue auto des transferts, assistant Crypt, logs internes live, écran Feuille de route.

**CI** : `build-rclone.sh` réessaie désormais l'install `gomobile` / `gomobile init` avec backoff — absorbe les échecs DNS transitoires (`proxy.golang.org`) observés sur les runners macOS Xcode Cloud (cause de l'échec du build #72).

> Le merge déclenche un build Xcode Cloud 1.7 (iOS + macOS) plus robuste.