### PR TITLE
feat(site): accordéon de l'historique des versions

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -177,6 +177,10 @@ const Icon = ({
       return /*#__PURE__*/React.createElement("svg", common, /*#__PURE__*/React.createElement("path", {
         d: "M9 6l6 6-6 6"
       }));
+    case 'chevron.down':
+      return /*#__PURE__*/React.createElement("svg", common, /*#__PURE__*/React.createElement("path", {
+        d: "M6 9l6 6 6-6"
+      }));
     case 'check':
       return /*#__PURE__*/React.createElement("svg", common, /*#__PURE__*/React.createElement("path", {
         d: "M5 12.5l4.5 4.5L19 7.5"
@@ -3635,6 +3639,9 @@ const VERSIONS = [{
 const Versions = () => {
   const t = useT();
   const lang = React.useContext(LangContext);
+  const [showAll, setShowAll] = React.useState(false);
+  const shown = showAll ? VERSIONS : VERSIONS.slice(0, 2);
+  const hidden = VERSIONS.length - 2;
   return /*#__PURE__*/React.createElement("section", {
     id: "versions"
   }, /*#__PURE__*/React.createElement("div", {
@@ -3647,7 +3654,7 @@ const Versions = () => {
     className: "sec-sub"
   }, t('L\'historique complet des mises à jour et ce qu\'elles apportent.', 'The full update history and what each one adds.')), /*#__PURE__*/React.createElement("div", {
     className: "versions"
-  }, VERSIONS.map(rel => /*#__PURE__*/React.createElement("div", {
+  }, shown.map(rel => /*#__PURE__*/React.createElement("div", {
     key: rel.v,
     className: rel.current ? 'ver current' : 'ver'
   }, /*#__PURE__*/React.createElement("div", {
@@ -3665,7 +3672,18 @@ const Versions = () => {
   }, /*#__PURE__*/React.createElement(Icon, {
     name: "check.circle",
     size: 18
-  }), it[lang] || it.en))))))));
+  }), it[lang] || it.en)))))), hidden > 0 && /*#__PURE__*/React.createElement("button", {
+    className: "ver-toggle",
+    onClick: () => setShowAll(v => !v),
+    "aria-expanded": showAll
+  }, showAll ? t('Réduire l\'historique', 'Show less') : t('Voir les ' + hidden + ' versions précédentes', 'Show ' + hidden + ' earlier versions'), /*#__PURE__*/React.createElement(Icon, {
+    name: "chevron.down",
+    size: 16,
+    style: {
+      transform: showAll ? 'rotate(180deg)' : 'none',
+      transition: 'transform .2s ease'
+    }
+  }))));
 };
 const ROADMAP = [{
   key: 'short',

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -50,6 +50,7 @@ const Icon = ({ name, size = 18, weight = 'regular', style }) => {
     case 'gear': return <svg {...common}><circle cx="12" cy="12" r="3"/><path d="M19.4 14a1.6 1.6 0 0 0 .3 1.7l.05.05a2 2 0 0 1-2.83 2.83l-.05-.05a1.6 1.6 0 0 0-1.7-.3 1.6 1.6 0 0 0-1 1.46V20a2 2 0 0 1-4 0v-.08a1.6 1.6 0 0 0-1-1.46 1.6 1.6 0 0 0-1.7.3l-.05.05a2 2 0 0 1-2.83-2.83l.05-.05a1.6 1.6 0 0 0 .3-1.7 1.6 1.6 0 0 0-1.46-1H4a2 2 0 0 1 0-4h.08a1.6 1.6 0 0 0 1.46-1 1.6 1.6 0 0 0-.3-1.7l-.05-.05a2 2 0 0 1 2.83-2.83l.05.05a1.6 1.6 0 0 0 1.7.3h.01a1.6 1.6 0 0 0 1-1.46V4a2 2 0 0 1 4 0v.08a1.6 1.6 0 0 0 1 1.46 1.6 1.6 0 0 0 1.7-.3l.05-.05a2 2 0 0 1 2.83 2.83l-.05.05a1.6 1.6 0 0 0-.3 1.7v.01a1.6 1.6 0 0 0 1.46 1H20a2 2 0 0 1 0 4h-.08a1.6 1.6 0 0 0-1.46 1Z"/></svg>;
     case 'arrows': return <svg {...common}><path d="M7 4v14M7 18l-3-3M7 18l3-3"/><path d="M17 20V6M17 6l-3 3M17 6l3 3"/></svg>;
     case 'chevron.right': return <svg {...common}><path d="M9 6l6 6-6 6"/></svg>;
+    case 'chevron.down': return <svg {...common}><path d="M6 9l6 6 6-6"/></svg>;
     case 'check': return <svg {...common}><path d="M5 12.5l4.5 4.5L19 7.5"/></svg>;
     case 'check.circle': return <svg {...common} fill="currentColor" stroke="none"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm-1.2 14L6.5 11.7l1.4-1.4 2.9 2.9 5.3-5.3 1.4 1.4-6.7 6.7Z"/></svg>;
     case 'plus': return <svg {...common}><path d="M12 5v14M5 12h14"/></svg>;
@@ -1048,6 +1049,9 @@ const VERSIONS = [
 const Versions = () => {
   const t = useT();
   const lang = React.useContext(LangContext);
+  const [showAll, setShowAll] = React.useState(false);
+  const shown = showAll ? VERSIONS : VERSIONS.slice(0, 2);
+  const hidden = VERSIONS.length - 2;
   return (
     <section id="versions">
       <div className="wrap">
@@ -1055,7 +1059,7 @@ const Versions = () => {
         <h2 className="sec">{t('Chaque version, en mieux','Every release, better')}</h2>
         <p className="sec-sub">{t('L\'historique complet des mises à jour et ce qu\'elles apportent.','The full update history and what each one adds.')}</p>
         <div className="versions">
-          {VERSIONS.map(rel => (
+          {shown.map(rel => (
             <div key={rel.v} className={rel.current ? 'ver current' : 'ver'}>
               <div className="ver-head">
                 <span className="ver-num">{t('Version ','Version ')}{rel.v}</span>
@@ -1070,6 +1074,14 @@ const Versions = () => {
             </div>
           ))}
         </div>
+        {hidden > 0 && (
+          <button className="ver-toggle" onClick={() => setShowAll(v => !v)} aria-expanded={showAll}>
+            {showAll
+              ? t('Réduire l\'historique', 'Show less')
+              : t('Voir les ' + hidden + ' versions précédentes', 'Show ' + hidden + ' earlier versions')}
+            <Icon name="chevron.down" size={16} style={{ transform: showAll ? 'rotate(180deg)' : 'none', transition:'transform .2s ease' }}/>
+          </button>
+        )}
       </div>
     </section>
   );

--- a/docs/index.html
+++ b/docs/index.html
@@ -278,6 +278,12 @@
   .ver-list{list-style:none;padding:0;margin:14px 0 0;display:flex;flex-direction:column;gap:9px}
   .ver-list li{display:flex;gap:10px;font-size:14.5px;font-weight:500;line-height:1.4;align-items:flex-start}
   .ver-list li svg{flex:0 0 auto;margin-top:2px;color:var(--accent)}
+  .ver-toggle{display:flex;align-items:center;justify-content:center;gap:8px;margin:18px auto 0;
+    max-width:760px;width:100%;padding:13px 20px;border:1px solid var(--line);border-radius:14px;
+    background:#fff;color:var(--accent-deep);font-size:14px;font-weight:700;cursor:pointer;
+    box-shadow:0 8px 26px rgba(11,8,32,.05);transition:box-shadow .2s ease,border-color .2s ease}
+  .ver-toggle:hover{border-color:var(--accent);box-shadow:0 12px 30px rgba(124,58,237,.16)}
+  .ver-toggle svg{color:var(--accent)}
   /* faq */
   .faq{max-width:760px;margin:38px auto 0;display:flex;flex-direction:column;gap:12px}
   .faq-item{background:#fff;border:1px solid var(--line);border-radius:16px;padding:2px 20px;


### PR DESCRIPTION
Replie l'historique des versions pour ne pas submerger la page.

- **2 dernières versions visibles** par défaut (1.7 + 1.6)
- Bouton **« Voir les N versions précédentes »** / **« Réduire »** pour tout dérouler
- Nouvelle icône `chevron.down` (pivote à l'ouverture) + styles `.ver-toggle`

Vérifié via Playwright : 2 versions au départ → clic → 8 versions → clic → repli (0 erreur).