### PR TITLE
feat(site): teaser pré-release 1.8 + accès TestFlight (20€ Stripe)

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2977,6 +2977,9 @@ const Header = ({
     href: "#versions"
   }, t('Nouveautés', 'What\'s new')), /*#__PURE__*/React.createElement("a", {
     className: "ghost navlink",
+    href: "#prerelease"
+  }, t('Pré-release', 'Pre-release')), /*#__PURE__*/React.createElement("a", {
+    className: "ghost navlink",
     href: "#roadmap"
   }, "Roadmap"), /*#__PURE__*/React.createElement("a", {
     className: "ghost navlink",
@@ -3685,6 +3688,60 @@ const Versions = () => {
     }
   }))));
 };
+const PRERELEASE_URL = 'https://buy.stripe.com/dRm7sMgDL4j97UzfjHfAc00';
+const Prerelease = ({
+  lang
+}) => {
+  const t = useT();
+  return /*#__PURE__*/React.createElement("section", {
+    id: "prerelease"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "wrap"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "pr-card"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "pr-left"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "pr-badge"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "pr-dot"
+  }), t('PRÉ-RELEASE', 'PRE-RELEASE')), /*#__PURE__*/React.createElement("h2", {
+    className: "pr-title"
+  }, t('Version 1.8', 'Version 1.8'), /*#__PURE__*/React.createElement("span", {
+    className: "pr-when"
+  }, " · ", t('1ᵉʳ juillet 2026', 'July 1, 2026'))), /*#__PURE__*/React.createElement("p", {
+    className: "pr-sub"
+  }, t('Soyez les premiers à tester la prochaine version. Accès anticipé via TestFlight, avant la sortie publique sur l\'App Store.', 'Be the first to try the next release. Early access via TestFlight, before it ships publicly on the App Store.')), /*#__PURE__*/React.createElement("ul", {
+    className: "pr-list"
+  }, /*#__PURE__*/React.createElement("li", null, /*#__PURE__*/React.createElement(Icon, {
+    name: "check.circle",
+    size: 18
+  }), t('Transferts Pro : file d\'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire.', 'Pro Transfers: queue, priorities, robust resume, Wi-Fi/cellular limits.')), /*#__PURE__*/React.createElement("li", null, /*#__PURE__*/React.createElement(Icon, {
+    name: "check.circle",
+    size: 18
+  }), t('Flows : automatisations 100 % locales (Raccourcis + App Intents) et Live Activity « santé du backup ».', 'Flows: 100% local automations (Shortcuts + App Intents) and a "backup health" Live Activity.')), /*#__PURE__*/React.createElement("li", null, /*#__PURE__*/React.createElement(Icon, {
+    name: "check.circle",
+    size: 18
+  }), t('Votre retour façonne directement la version finale.', 'Your feedback directly shapes the final release.')))), /*#__PURE__*/React.createElement("div", {
+    className: "pr-right"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "pr-price"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "pr-amount"
+  }, "20 €"), /*#__PURE__*/React.createElement("span", {
+    className: "pr-once"
+  }, t('accès pré-release', 'pre-release access'))), /*#__PURE__*/React.createElement("a", {
+    className: "btn btn-big pr-btn",
+    href: PRERELEASE_URL,
+    target: "_blank",
+    rel: "noopener"
+  }, /*#__PURE__*/React.createElement(Icon, {
+    name: "bolt.fill",
+    size: 18
+  }), t('Rejoindre la pré-release', 'Join the pre-release')), /*#__PURE__*/React.createElement("p", {
+    className: "pr-note"
+  }, t('Paiement sécurisé via Stripe. Le lien d\'invitation TestFlight s\'affiche juste après le paiement.', 'Secure payment via Stripe. Your TestFlight invite link appears right after payment.'))))));
+};
 const ROADMAP = [{
   key: 'short',
   label: {
@@ -4127,6 +4184,8 @@ const Footer = () => {
   }), /*#__PURE__*/React.createElement("a", {
     href: "#versions"
   }, t('Nouveautés', 'What\'s new')), /*#__PURE__*/React.createElement("a", {
+    href: "#prerelease"
+  }, t('Pré-release', 'Pre-release')), /*#__PURE__*/React.createElement("a", {
     href: "#roadmap"
   }, "Roadmap"), /*#__PURE__*/React.createElement("a", {
     href: "#faq"
@@ -4157,7 +4216,9 @@ const App = () => {
     setLang: setLang
   }), /*#__PURE__*/React.createElement(Hero, null), /*#__PURE__*/React.createElement(Gallery, {
     lang: lang
-  }), /*#__PURE__*/React.createElement(Features, null), /*#__PURE__*/React.createElement(Versions, null), /*#__PURE__*/React.createElement(Roadmap, {
+  }), /*#__PURE__*/React.createElement(Features, null), /*#__PURE__*/React.createElement(Versions, null), /*#__PURE__*/React.createElement(Prerelease, {
+    lang: lang
+  }), /*#__PURE__*/React.createElement(Roadmap, {
     lang: lang
   }), /*#__PURE__*/React.createElement(Pricing, null), /*#__PURE__*/React.createElement(FreeMonth, null), /*#__PURE__*/React.createElement(FAQ, null), /*#__PURE__*/React.createElement(Footer, null));
 };

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -702,6 +702,7 @@ const Header = ({ lang, setLang }) => {
       <a className="brand" href="#top"><img src="icon.png" alt="Rclone GUI"/>Rclone GUI</a>
       <div className="nav-sp"/>
       <a className="ghost navlink" href="#versions">{t('Nouveautés','What\'s new')}</a>
+      <a className="ghost navlink" href="#prerelease">{t('Pré-release','Pre-release')}</a>
       <a className="ghost navlink" href="#roadmap">Roadmap</a>
       <a className="ghost navlink" href="#faq">FAQ</a>
       <a className="ghost" href={GITHUB_URL} target="_blank" rel="noopener" style={{ marginRight:6 }}>GitHub</a>
@@ -1087,6 +1088,34 @@ const Versions = () => {
   );
 };
 
+const PRERELEASE_URL = 'https://buy.stripe.com/dRm7sMgDL4j97UzfjHfAc00';
+const Prerelease = ({ lang }) => {
+  const t = useT();
+  return (
+    <section id="prerelease">
+      <div className="wrap">
+        <div className="pr-card">
+          <div className="pr-left">
+            <span className="pr-badge"><span className="pr-dot"/>{t('PRÉ-RELEASE','PRE-RELEASE')}</span>
+            <h2 className="pr-title">{t('Version 1.8','Version 1.8')}<span className="pr-when"> · {t('1ᵉʳ juillet 2026','July 1, 2026')}</span></h2>
+            <p className="pr-sub">{t('Soyez les premiers à tester la prochaine version. Accès anticipé via TestFlight, avant la sortie publique sur l\'App Store.','Be the first to try the next release. Early access via TestFlight, before it ships publicly on the App Store.')}</p>
+            <ul className="pr-list">
+              <li><Icon name="check.circle" size={18}/>{t('Transferts Pro : file d\'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire.','Pro Transfers: queue, priorities, robust resume, Wi-Fi/cellular limits.')}</li>
+              <li><Icon name="check.circle" size={18}/>{t('Flows : automatisations 100 % locales (Raccourcis + App Intents) et Live Activity « santé du backup ».','Flows: 100% local automations (Shortcuts + App Intents) and a "backup health" Live Activity.')}</li>
+              <li><Icon name="check.circle" size={18}/>{t('Votre retour façonne directement la version finale.','Your feedback directly shapes the final release.')}</li>
+            </ul>
+          </div>
+          <div className="pr-right">
+            <div className="pr-price"><span className="pr-amount">20 €</span><span className="pr-once">{t('accès pré-release','pre-release access')}</span></div>
+            <a className="btn btn-big pr-btn" href={PRERELEASE_URL} target="_blank" rel="noopener"><Icon name="bolt.fill" size={18}/>{t('Rejoindre la pré-release','Join the pre-release')}</a>
+            <p className="pr-note">{t('Paiement sécurisé via Stripe. Le lien d\'invitation TestFlight s\'affiche juste après le paiement.','Secure payment via Stripe. Your TestFlight invite link appears right after payment.')}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
 const ROADMAP = [
   { key:'short', label:{ fr:'Court terme', en:'Short term' }, tag:{ fr:'Juil.–sept. 2026', en:'Jul–Sep 2026' }, items:[
     { n:{ fr:'Transferts Pro', en:'Pro Transfers' }, when:{ fr:'Juil. 2026', en:'Jul 2026' }, d:{ fr:'File d\'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire, logs exportables.', en:'Queue, priorities, robust resume, Wi-Fi/cellular limits, exportable logs.' } },
@@ -1262,6 +1291,7 @@ const Footer = () => {
           <a className="brand" href="#top"><img src="icon.png" alt="" style={{ width:26, height:26, borderRadius:7 }}/>Rclone GUI</a>
           <div className="nav-sp"/>
           <a href="#versions">{t('Nouveautés','What\'s new')}</a>
+          <a href="#prerelease">{t('Pré-release','Pre-release')}</a>
           <a href="#roadmap">Roadmap</a>
           <a href="#faq">FAQ</a>
           <a href={APP_STORE_URL} target="_blank" rel="noopener">App Store</a>
@@ -1284,6 +1314,7 @@ const App = () => {
       <Gallery lang={lang}/>
       <Features/>
       <Versions/>
+      <Prerelease lang={lang}/>
       <Roadmap lang={lang}/>
       <Pricing/>
       <FreeMonth/>

--- a/docs/index.html
+++ b/docs/index.html
@@ -284,6 +284,30 @@
     box-shadow:0 8px 26px rgba(11,8,32,.05);transition:box-shadow .2s ease,border-color .2s ease}
   .ver-toggle:hover{border-color:var(--accent);box-shadow:0 12px 30px rgba(124,58,237,.16)}
   .ver-toggle svg{color:var(--accent)}
+  /* pre-release */
+  #prerelease{padding-top:6px}
+  .pr-card{max-width:980px;margin:0 auto;display:grid;grid-template-columns:1.45fr 1fr;gap:32px;
+    background:linear-gradient(135deg,var(--accent),var(--accent-deep));color:#fff;border-radius:28px;
+    padding:36px 40px;box-shadow:0 24px 60px rgba(124,58,237,.35);align-items:center}
+  .pr-badge{display:inline-flex;align-items:center;gap:7px;font-size:12px;font-weight:800;letter-spacing:1px;
+    background:rgba(255,255,255,.18);padding:5px 12px;border-radius:999px}
+  .pr-dot{width:7px;height:7px;border-radius:50%;background:#fff;box-shadow:0 0 0 0 rgba(255,255,255,.6);
+    animation:prpulse 2s infinite}
+  @keyframes prpulse{0%{box-shadow:0 0 0 0 rgba(255,255,255,.5)}70%{box-shadow:0 0 0 7px rgba(255,255,255,0)}100%{box-shadow:0 0 0 0 rgba(255,255,255,0)}}
+  .pr-title{font-size:30px;font-weight:800;letter-spacing:-1px;margin:14px 0 0;line-height:1.1}
+  .pr-when{font-weight:700;opacity:.85;font-size:19px}
+  .pr-sub{margin:9px 0 0;font-size:15px;line-height:1.5;opacity:.93}
+  .pr-list{list-style:none;padding:0;margin:18px 0 0;display:flex;flex-direction:column;gap:9px}
+  .pr-list li{display:flex;gap:9px;font-size:14px;line-height:1.4;align-items:flex-start;font-weight:500}
+  .pr-list li svg{flex:0 0 auto;margin-top:1px;color:#fff;opacity:.95}
+  .pr-right{background:rgba(255,255,255,.10);border:1px solid rgba(255,255,255,.20);border-radius:20px;padding:26px 24px;text-align:center}
+  .pr-price{display:flex;flex-direction:column;align-items:center;margin-bottom:16px}
+  .pr-amount{font-size:42px;font-weight:800;letter-spacing:-1.5px;line-height:1}
+  .pr-once{font-size:13px;opacity:.85;margin-top:5px;font-weight:600}
+  .pr-btn{width:100%;justify-content:center;background:#fff;color:var(--accent-deep)}
+  .pr-btn:hover{box-shadow:0 14px 30px rgba(0,0,0,.25)}
+  .pr-note{margin:13px 0 0;font-size:12px;opacity:.85;line-height:1.45}
+  @media(max-width:760px){.pr-card{grid-template-columns:1fr;padding:28px 22px;gap:22px}}
   /* faq */
   .faq{max-width:760px;margin:38px auto 0;display:flex;flex-direction:column;gap:12px}
   .faq-item{background:#fff;border:1px solid var(--line);border-radius:16px;padding:2px 20px;


### PR DESCRIPTION
Ajoute la section **Pré-release** sur rclone.rougetet.com :

- Teaser **« Version 1.8 · 1ᵉʳ juillet 2026 »** (badge PRÉ-RELEASE pulsant)
- Features en avant-première : **Transferts Pro** + **Flows**
- **Accès anticipé TestFlight via paiement Stripe 20 €** (Payment Link). Le lien d'invitation TestFlight est **caché** et révélé uniquement sur la page de confirmation Stripe **après paiement**.
- Lien **« Pré-release »** ajouté à la nav (header + footer)

Vérifié : Payment Link live (HTTP 200), section rendue (Playwright), 0 erreur.