### PR TITLE
feat(transfers): pause/reprise par transfert + fix reprise globale + annulation dossier

### DIFF
--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -494,10 +494,150 @@ public final class TransferQueue {
             pollTasks[id] = nil
             try? await TransferService.shared.stopJob(jobID: id)
         }
+        transfer.jobID = nil
         transfer.status = .failed
         transfer.lastError = "Annulé par l'utilisateur"
         transfer.finishedAt = .now
         try? modelContext?.save()
+    }
+
+    // MARK: - Pause / reprise par transfert
+
+    /// Met EN PAUSE un transfert précis (et lui seul). rclone ne sait pas
+    /// suspendre un job en cours : on l'arrête proprement (`job/stop`) tout en
+    /// conservant TOUTES les métadonnées du transfert, puis on passe la ligne
+    /// en `.paused`. La reprise relancera l'opération via `relaunch(_:)`.
+    /// Les copies de DOSSIER reprennent efficacement (rclone saute les fichiers
+    /// déjà transférés) ; un fichier seul redémarre depuis le début.
+    public func pause(_ transfer: Transfer) async {
+        guard transfer.status == .running
+            || transfer.status == .pending
+            || transfer.status == .enqueued else { return }
+        if let id = transfer.jobID {
+            pollTasks[id]?.cancel()
+            pollTasks[id] = nil
+            try? await TransferService.shared.stopJob(jobID: id)
+        }
+        transfer.jobID = nil
+        transfer.status = .paused
+        transfer.finishedAt = nil
+        try? modelContext?.save()
+        await LogService.shared.log(
+            .info,
+            category: "transfer",
+            message: "⏸️ Transfert en pause : \(transfer.sourcePath)"
+        )
+    }
+
+    /// Reprend un transfert mis en pause : relance l'opération rclone sur le
+    /// MÊME enregistrement (la ligne reste en place et reprend sa progression).
+    public func resume(_ transfer: Transfer) async throws {
+        guard transfer.status == .paused else { return }
+        transfer.status = .running
+        transfer.lastError = nil
+        transfer.finishedAt = nil
+        try? modelContext?.save()
+        do {
+            let jobID = try await relaunch(transfer)
+            transfer.jobID = jobID
+            try? modelContext?.save()
+            startPolling(transfer)
+            await LogService.shared.log(
+                .info,
+                category: "transfer",
+                message: "▶️ Transfert repris : \(transfer.sourcePath)"
+            )
+        } catch {
+            transfer.status = .paused
+            transfer.lastError = error.localizedDescription
+            try? modelContext?.save()
+            throw error
+        }
+    }
+
+    /// Relance l'opération rclone d'un transfert et renvoie le nouveau jobID.
+    /// Centralise le routage (fichier vs dossier ; download/upload/copy/move/
+    /// sync) utilisé par la reprise (`resume`). Les uploads issus de Fichiers
+    /// peuvent échouer si le fichier local temporaire a été purgé entre-temps.
+    private func relaunch(_ t: Transfer) async throws -> Int {
+        switch t.kind {
+        case .download:
+            guard let remote = t.sourceRemote else {
+                throw TransferQueueError.cannotRetry("Remote source manquant.")
+            }
+            let destinationURL = URL(fileURLWithPath: t.destinationPath)
+            if t.isDirectoryTransfer ?? false {
+                try FileManager.default.createDirectory(at: destinationURL, withIntermediateDirectories: true)
+                return try await TransferService.shared.copyDirAsync(
+                    srcFs: "\(remote):\(t.sourcePath)",
+                    dstFs: destinationURL.path
+                )
+            } else {
+                let parent = destinationURL.deletingLastPathComponent()
+                try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+                return try await TransferService.shared.copyFileAsync(
+                    srcFs: "\(remote):",
+                    srcPath: t.sourcePath,
+                    dstFs: parent.path,
+                    dstPath: destinationURL.lastPathComponent
+                )
+            }
+
+        case .upload:
+            guard let remote = t.destinationRemote else {
+                throw TransferQueueError.cannotRetry("Remote destination manquant.")
+            }
+            let localURL = URL(fileURLWithPath: t.sourcePath)
+            let isFolder = t.sourceKind == .localFolder
+                || (t.isDirectoryTransfer ?? false)
+                || isDirectory(localURL)
+            if isFolder {
+                return try await TransferService.shared.copyDirAsync(
+                    srcFs: localURL.path,
+                    dstFs: "\(remote):\(t.destinationPath)"
+                )
+            } else {
+                return try await TransferService.shared.copyFileAsync(
+                    srcFs: localURL.deletingLastPathComponent().path,
+                    srcPath: localURL.lastPathComponent,
+                    dstFs: "\(remote):",
+                    dstPath: t.destinationPath
+                )
+            }
+
+        case .copy, .move, .sync:
+            guard let srcRemote = t.sourceRemote,
+                  let dstRemote = t.destinationRemote else {
+                throw TransferQueueError.cannotRetry("Source ou destination manquante.")
+            }
+            switch (t.kind, t.isDirectoryTransfer ?? false) {
+            case (.copy, false), (.sync, false):
+                return try await TransferService.shared.copyFileAsync(
+                    srcFs: "\(srcRemote):", srcPath: t.sourcePath,
+                    dstFs: "\(dstRemote):", dstPath: t.destinationPath)
+            case (.copy, true):
+                return try await TransferService.shared.copyDirAsync(
+                    srcFs: "\(srcRemote):\(t.sourcePath)",
+                    dstFs: "\(dstRemote):\(t.destinationPath)")
+            case (.move, false):
+                return try await TransferService.shared.moveFileAsync(
+                    srcFs: "\(srcRemote):", srcPath: t.sourcePath,
+                    dstFs: "\(dstRemote):", dstPath: t.destinationPath)
+            case (.move, true):
+                return try await TransferService.shared.moveDirAsync(
+                    srcFs: "\(srcRemote):\(t.sourcePath)",
+                    dstFs: "\(dstRemote):\(t.destinationPath)")
+            case (.sync, true):
+                return try await TransferService.shared.syncDirAsync(
+                    srcFs: "\(srcRemote):\(t.sourcePath)",
+                    dstFs: "\(dstRemote):\(t.destinationPath)")
+            default:
+                throw TransferQueueError.cannotRetry("Type de transfert non supporté.")
+            }
+
+        case .delete:
+            throw TransferQueueError.cannotRetry("Une suppression ne peut pas être reprise.")
+        }
     }
 
     /// Retry a failed transfer by re-enqueuing an equivalent operation. The
@@ -565,20 +705,46 @@ public final class TransferQueue {
     /// runs, so we replay this flag at boot via `restoreFromPersistedState`.
     public static let persistedPauseKey = "transfer.isPausedGlobally"
 
-    /// Pause every running rclone job by lowering the global bandwidth ceiling
-    /// to 1 byte/second (rclone treats rate "0" as "unlimited"). Idempotent.
+    /// Met en pause TOUS les transferts actifs, individuellement (stop + état
+    /// `.paused`), au lieu de l'ancien `core/bwlimit 1b` global qui finissait
+    /// par faire timeout/mourir les jobs (d'où « ça ne redémarre pas »).
+    /// Exclut PhotoSync (qui a sa propre pause) et les suppressions (instantanées).
     public func pauseAllTransfers() async throws {
-        try await TransferService.shared.pauseAllTransfers()
+        for t in fetchActivePausable() where t.sourceKind != .photoLibrary && t.kind != .delete {
+            await pause(t)
+        }
         isPausedGlobally = true
         UserDefaults.standard.set(true, forKey: Self.persistedPauseKey)
     }
 
-    /// Restore the user's preferred bandwidth ceiling and resume progress.
+    /// Reprend TOUS les transferts en pause (relance chaque opération) et
+    /// restaure la limite de bande passante préférée de l'utilisateur.
     /// `bytesPerSecond == 0` means "no limit" (rate "off").
     public func resumeAllTransfers(bytesPerSecond: Int64) async throws {
-        try await TransferService.shared.resumeAllTransfers(bytesPerSecond: bytesPerSecond)
+        // La pause par-transfert ne touche pas le bwlimit, mais on réapplique
+        // la préférence utilisateur par sécurité (no-op si déjà correcte).
+        try? await TransferService.shared.setBandwidthLimit(bytesPerSecond: bytesPerSecond)
+        for t in fetchPaused() where t.sourceKind != .photoLibrary {
+            try? await resume(t)
+        }
         isPausedGlobally = false
         UserDefaults.standard.set(false, forKey: Self.persistedPauseKey)
+    }
+
+    private func fetchActivePausable() -> [Transfer] {
+        guard let modelContext else { return [] }
+        let descriptor = FetchDescriptor<Transfer>(
+            predicate: #Predicate { $0.statusRaw == "running" || $0.statusRaw == "pending" || $0.statusRaw == "enqueued" }
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    private func fetchPaused() -> [Transfer] {
+        guard let modelContext else { return [] }
+        let descriptor = FetchDescriptor<Transfer>(
+            predicate: #Predicate { $0.statusRaw == "paused" }
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
     }
 
     /// Apply the user's bandwidth setting without toggling pause state.

--- a/Rclone GUI/Views/Transfers/TransfersView.swift
+++ b/Rclone GUI/Views/Transfers/TransfersView.swift
@@ -15,7 +15,6 @@ struct TransfersView: View {
     @State private var filter: TransferFilter = .all
 
     @AppStorage("transfer.bandwidthLimitMBps") private var bandwidthLimitMBps: Double = 0
-    @State private var isPausedGlobally = false
     /// C3 : remplace l'ancien `transientMessage` + `.alert` bloquant
     /// par un toast non-bloquant qui se dismiss tout seul.
     @State private var toast: AppToast?
@@ -66,11 +65,12 @@ struct TransfersView: View {
                     Task { await toggleGlobalPause() }
                 } label: {
                     Label(
-                        isPausedGlobally ? "Reprendre" : "Pause",
-                        systemImage: isPausedGlobally ? "play.fill" : "pause.fill"
+                        globalPauseShowsResume ? "Reprendre" : "Pause",
+                        systemImage: globalPauseShowsResume ? "play.fill" : "pause.fill"
                     )
                 }
-                .accessibilityLabel(isPausedGlobally ? "Reprendre tous les transferts" : "Mettre tous les transferts en pause")
+                .disabled(!hasActivePausable && !hasPausedResumable)
+                .accessibilityLabel(globalPauseShowsResume ? "Reprendre tous les transferts" : "Mettre tous les transferts en pause")
             }
             ToolbarItem(placement: .primaryAction) {
                 Menu {
@@ -89,7 +89,6 @@ struct TransfersView: View {
         .appToast($toast)
         .sensoryFeedback(.selection, trigger: hapticTrigger)
         .task {
-            isPausedGlobally = TransferQueue.shared.isPausedGlobally
             await refreshPhotoSyncState()
             while !Task.isCancelled {
                 let interval = photoSyncPollingInterval
@@ -110,22 +109,116 @@ struct TransfersView: View {
 
     // MARK: - Actions
 
+    /// Le bouton global est piloté par l'état RÉEL des transferts (et non par
+    /// un flag local qui pouvait désynchroniser des pauses par-ligne) : s'il
+    /// reste des transferts actifs on propose « Pause », sinon « Reprendre ».
+    private func isActivePausable(_ t: Transfer) -> Bool {
+        let isActive: Bool = t.status == .running || t.status == .pending || t.status == .enqueued
+        return isActive && t.sourceKind != .photoLibrary && t.kind != .delete
+    }
+
+    private func isPausedResumable(_ t: Transfer) -> Bool {
+        t.status == .paused && t.sourceKind != .photoLibrary
+    }
+
+    private var hasActivePausable: Bool {
+        transfers.contains(where: isActivePausable)
+    }
+
+    private var hasPausedResumable: Bool {
+        transfers.contains(where: isPausedResumable)
+    }
+
+    private var globalPauseShowsResume: Bool {
+        !hasActivePausable && hasPausedResumable
+    }
+
     private func toggleGlobalPause() async {
         do {
-            if isPausedGlobally {
+            if globalPauseShowsResume {
                 let bytesPerSecond = Int64(bandwidthLimitMBps * 1024 * 1024)
                 try await TransferQueue.shared.resumeAllTransfers(bytesPerSecond: bytesPerSecond)
-                isPausedGlobally = false
                 toast = AppToast(title: String(localized: "Transferts repris"), severity: .success)
             } else {
                 try await TransferQueue.shared.pauseAllTransfers()
-                isPausedGlobally = true
                 toast = AppToast(title: String(localized: "Tous les transferts sont en pause"), severity: .info)
             }
             hapticTrigger &+= 1
         } catch {
             toast = AppToast(title: String(localized: "Échec"), message: error.localizedDescription, severity: .error)
         }
+    }
+
+    private func pauseTransfer(_ transfer: Transfer) async {
+        await TransferQueue.shared.pause(transfer)
+        toast = AppToast(title: String(localized: "Transfert en pause"), severity: .info)
+        hapticTrigger &+= 1
+    }
+
+    private func resumeTransfer(_ transfer: Transfer) async {
+        do {
+            try await TransferQueue.shared.resume(transfer)
+            toast = AppToast(title: String(localized: "Transfert repris"), severity: .success)
+            hapticTrigger &+= 1
+        } catch {
+            toast = AppToast(title: String(localized: "Reprise impossible"), message: error.localizedDescription, severity: .error)
+        }
+    }
+
+    /// Menu contextuel (appui long / clic droit) — mêmes actions que les
+    /// swipe gauche/droite, mais robuste au rafraîchissement continu de la
+    /// liste pendant un transfert long (le swipe se referme tout seul quand
+    /// les stats live re-render la ligne) et bien plus naturel sur macOS.
+    @ViewBuilder
+    private func transferRowMenu(_ transfer: Transfer) -> some View {
+        switch transfer.status {
+        case .running, .pending, .enqueued:
+            if transfer.kind != .delete {
+                Button {
+                    Task { await pauseTransfer(transfer) }
+                } label: {
+                    Label("Pause", systemImage: "pause.fill")
+                }
+            }
+            Button(role: .destructive) {
+                Task { await TransferQueue.shared.cancel(transfer) }
+            } label: {
+                Label("Annuler", systemImage: "xmark.circle")
+            }
+        case .paused:
+            Button {
+                Task { await resumeTransfer(transfer) }
+            } label: {
+                Label("Reprendre", systemImage: "play.fill")
+            }
+            Button(role: .destructive) {
+                deleteTransfer(transfer)
+            } label: {
+                Label("Supprimer", systemImage: "trash")
+            }
+        case .failed:
+            Button {
+                Task { await retry(transfer) }
+            } label: {
+                Label("Réessayer", systemImage: "arrow.clockwise")
+            }
+            Button(role: .destructive) {
+                deleteTransfer(transfer)
+            } label: {
+                Label("Supprimer", systemImage: "trash")
+            }
+        case .completed:
+            Button(role: .destructive) {
+                deleteTransfer(transfer)
+            } label: {
+                Label("Supprimer", systemImage: "trash")
+            }
+        }
+    }
+
+    private func deleteTransfer(_ transfer: Transfer) {
+        modelContext.delete(transfer)
+        try? modelContext.save()
     }
 
     private func retry(_ transfer: Transfer) async {
@@ -250,6 +343,14 @@ struct TransfersView: View {
                                         } label: {
                                             Label("Annuler", systemImage: "xmark.circle")
                                         }
+                                        if transfer.kind != .delete {
+                                            Button {
+                                                Task { await pauseTransfer(transfer) }
+                                            } label: {
+                                                Label("Pause", systemImage: "pause.fill")
+                                            }
+                                            .tint(.orange)
+                                        }
                                     } else {
                                         Button(role: .destructive) {
                                             modelContext.delete(transfer)
@@ -260,7 +361,14 @@ struct TransfersView: View {
                                     }
                                 }
                                 .swipeActions(edge: .leading) {
-                                    if transfer.status == .failed {
+                                    if transfer.status == .paused {
+                                        Button {
+                                            Task { await resumeTransfer(transfer) }
+                                        } label: {
+                                            Label("Reprendre", systemImage: "play.fill")
+                                        }
+                                        .tint(.green)
+                                    } else if transfer.status == .failed {
                                         Button {
                                             Task { await retry(transfer) }
                                         } label: {
@@ -268,6 +376,9 @@ struct TransfersView: View {
                                         }
                                         .tint(.blue)
                                     }
+                                }
+                                .contextMenu {
+                                    transferRowMenu(transfer)
                                 }
                         }
                         if isTerminal && group.items.count > visibleItems.count {
@@ -658,6 +769,7 @@ private struct TransferGroup {
 
     static func organize(_ all: [Transfer]) -> [TransferGroup] {
         var running: [Transfer] = []
+        var paused: [Transfer] = []
         var pending: [Transfer] = []
         var completed: [Transfer] = []
         var failed: [Transfer] = []
@@ -666,13 +778,14 @@ private struct TransferGroup {
             case .running: running.append(t)
             case .pending: pending.append(t)
             case .enqueued: pending.append(t)
-            case .paused:  pending.append(t)
+            case .paused:  paused.append(t)
             case .completed: completed.append(t)
             case .failed: failed.append(t)
             }
         }
         var groups: [TransferGroup] = []
         if !running.isEmpty { groups.append(.init(title: String(localized: "En cours"), items: running)) }
+        if !paused.isEmpty { groups.append(.init(title: String(localized: "En pause"), items: paused)) }
         if !pending.isEmpty { groups.append(.init(title: String(localized: "En attente"), items: pending)) }
         if !completed.isEmpty { groups.append(.init(title: String(localized: "Terminés"), items: completed)) }
         if !failed.isEmpty { groups.append(.init(title: String(localized: "Échec"), items: failed)) }


### PR DESCRIPTION
## Problèmes corrigés

Signalés par l'usage :
1. **Annuler/retirer un téléchargement de dossier** ne marchait pas de façon fiable.
2. **La pause ne redémarrait pas** (« quand je mets en pause ça ne redémarre pas »).
3. Besoin de **pauser/reprendre un transfert spécifique**, pas tout d'un coup.

## Cause racine

- La pause était **globale** via `core/bwlimit` à `1 byte/s`. À ce débit, les jobs rclone finissent par **timeout/mourir** → au resume il n'y a plus rien à reprendre.
- rclone **ne sait pas suspendre** un job en cours : aucune pause par-transfert native.
- Sur un dossier (transfert long), la liste se rafraîchit en continu (stats live) et **ferme le swipe** avant qu'on tape « Annuler ».

## Solution

- **Pause/reprise par transfert** : `pause()` arrête le job (`job/stop`) en conservant les métadonnées et passe la ligne en `.paused` ; `resume()` relance l'opération sur la **même ligne** via un routeur unifié `relaunch()` (fichier/dossier × download/upload/copy/move/sync). Les copies de **dossier** reprennent efficacement (rclone saute les fichiers déjà transférés).
- **Pause globale réécrite** sur ce mécanisme robuste (stop + relance par transfert) au lieu du `bwlimit` → la reprise marche enfin. La bande passante préférée est restaurée au resume.
- **Menu contextuel** (appui long / clic droit) avec Pause / Reprendre / Annuler / Réessayer / Supprimer, en plus des swipes — robuste au re-render et naturel sur macOS.
- UI : groupe « En pause » dédié, bouton global piloté par l'état réel des transferts.

## Validation

`build_macos` (arm64) : **SUCCEEDED**, 0 erreur. Le seul warning (`RecapAndTestView.swift:301`, Swift 6 isolated conformance) est préexistant et sans rapport.