### PR TITLE
feat(transfers): Transferts Pro — file d'attente, priorités, politique réseau, logs exportables

### DIFF
--- a/Rclone GUI/Models/Transfer.swift
+++ b/Rclone GUI/Models/Transfer.swift
@@ -105,6 +105,18 @@ public final class Transfer {
     /// nil → treated as false for backward compat with pre-Sprint-3 records.
     public var isDirectoryTransfer: Bool? = false
 
+    /// File d'attente (Transferts Pro) : ordre manuel stable parmi les
+    /// transferts `.enqueued`. Plus petit = démarre plus tôt. L'action
+    /// « Prioriser » descend cette valeur sous le minimum courant pour passer
+    /// devant. 0 par défaut → ordre FIFO par `startedAt`.
+    public var queueOrder: Int = 0
+
+    /// Pause AUTOMATIQUE (réseau : hors-ligne ou cellulaire avec
+    /// « pause en cellulaire ») par opposition à une pause manuelle. Seuls les
+    /// transferts auto-pausés sont repris automatiquement au retour d'une
+    /// connexion adéquate ; une pause manuelle n'est jamais levée toute seule.
+    public var autoPaused: Bool = false
+
     public var bytesTotal: Int64
     public var bytesTransferred: Int64
 

--- a/Rclone GUI/Rclone_GUIApp.swift
+++ b/Rclone GUI/Rclone_GUIApp.swift
@@ -181,6 +181,15 @@ struct Rclone_GUIApp: App {
                             )
                         }
                     }
+                    // Transferts Pro — politique réseau : applique la limite
+                    // Wi-Fi/cellulaire et la pause/reprise auto à chaque
+                    // changement de lien (et une fois au lancement).
+                    Task { @MainActor in
+                        await TransferQueue.shared.applyNetworkPolicy()
+                        for await _ in NotificationCenter.default.notifications(named: .networkPathDidChange) {
+                            await TransferQueue.shared.handleNetworkChange()
+                        }
+                    }
                 }
         }
         .modelContainer(sharedModelContainer)

--- a/Rclone GUI/Services/LogService.swift
+++ b/Rclone GUI/Services/LogService.swift
@@ -170,19 +170,22 @@ public actor LogService {
         ring.removeAll(keepingCapacity: true)
     }
 
-    /// Write the entire ring to a temp file and return its URL — ready
-    /// to feed to a ShareSheet.
-    public func exportAsFile() throws -> URL {
+    /// Write the ring to a temp file and return its URL — ready to feed to a
+    /// ShareSheet. Pass `category` to export only the lines of one category
+    /// (ex. "transfer" pour les logs de transferts exportables).
+    public func exportAsFile(category: String? = nil) throws -> URL {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
-        let lines = ring.map { e in
+        let scoped = category == nil ? ring : ring.filter { $0.category == category }
+        let lines = scoped.map { e in
             "\(formatter.string(from: e.timestamp)) [\(e.level.rawValue)] [\(e.category)] \(e.message)"
         }
         let text = lines.joined(separator: "\n")
+        let suffix = category.map { "-\($0)" } ?? ""
         let url = FileManager.default
             .temporaryDirectory
-            .appending(path: "rclone-gui-logs-\(UUID().uuidString.prefix(8)).log")
+            .appending(path: "rclone-gui-logs\(suffix)-\(UUID().uuidString.prefix(8)).log")
         try text.data(using: .utf8)?.write(to: url, options: .atomic)
         return url
     }

--- a/Rclone GUI/Services/NetworkReachability.swift
+++ b/Rclone GUI/Services/NetworkReachability.swift
@@ -10,6 +10,13 @@
 import Foundation
 import Network
 
+extension Notification.Name {
+    /// Postée (sur la main queue) quand l'état réseau pertinent change
+    /// (en ligne/hors-ligne, cellulaire/bridé). La TransferQueue s'y abonne
+    /// pour appliquer sa politique réseau (limite cellulaire, pause/reprise auto).
+    static let networkPathDidChange = Notification.Name("rclone.networkPathDidChange")
+}
+
 final class NetworkReachability: @unchecked Sendable {
     static let shared = NetworkReachability()
 
@@ -23,11 +30,24 @@ final class NetworkReachability: @unchecked Sendable {
     private init() {
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
+            let newExpensive = path.isExpensive       // cellulaire, partage de connexion…
+            let newConstrained = path.isConstrained   // mode données réduites
+            let newSatisfied = (path.status == .satisfied)
             self.lock.lock()
-            self._isExpensive = path.isExpensive          // cellulaire, partage de connexion…
-            self._isConstrained = path.isConstrained      // mode données réduites
-            self._isSatisfied = (path.status == .satisfied)
+            let changed = newExpensive != self._isExpensive
+                || newConstrained != self._isConstrained
+                || newSatisfied != self._isSatisfied
+            self._isExpensive = newExpensive
+            self._isConstrained = newConstrained
+            self._isSatisfied = newSatisfied
             self.lock.unlock()
+            // Notifie les observateurs (politique de transfert) uniquement
+            // quand un champ pertinent bascule, pour ne pas spammer.
+            if changed {
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: .networkPathDidChange, object: nil)
+                }
+            }
         }
         monitor.start(queue: queue)
     }
@@ -52,5 +72,14 @@ final class NetworkReachability: @unchecked Sendable {
     var isUnmetered: Bool {
         lock.lock(); defer { lock.unlock() }
         return _isSatisfied && !_isExpensive && !_isConstrained
+    }
+
+    /// À traiter comme du « cellulaire » pour la politique de bande passante :
+    /// soit cellulaire (`isExpensive`), soit Wi-Fi bridé / données réduites
+    /// (`isConstrained`). Un hotspot ou un Wi-Fi metered ne doit pas laisser
+    /// filer un gros transfert comme un Wi-Fi domestique.
+    var isCellularLike: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _isExpensive || _isConstrained
     }
 }

--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -64,19 +64,8 @@ public final class TransferQueue {
             displayName: localURL.lastPathComponent,
             sourceKind: .remote
         )
-        transfer.status = .running
-        modelContext?.insert(transfer)
-        try modelContext?.save()
-
-        let jobID = try await TransferService.shared.copyFileAsync(
-            srcFs: "\(remote):",
-            srcPath: path,
-            dstFs: parent.path,
-            dstPath: localURL.lastPathComponent
-        )
-        transfer.jobID = jobID
-        try modelContext?.save()
-        startPolling(transfer)
+        // Le dispatch effectif (copyfile) est fait par le scheduler via relaunch().
+        enqueueAndSchedule(transfer)
     }
 
     @discardableResult
@@ -134,17 +123,7 @@ public final class TransferQueue {
                 sourceKind: .remote
             )
             transfer.isDirectoryTransfer = true
-            transfer.status = .running
-            modelContext?.insert(transfer)
-            try modelContext?.save()
-
-            let jobID = try await TransferService.shared.copyDirAsync(
-                srcFs: "\(remote):\(entry.pathInRemote)",
-                dstFs: destinationURL.path
-            )
-            transfer.jobID = jobID
-            try modelContext?.save()
-            startPolling(transfer)
+            enqueueAndSchedule(transfer)
         } else {
             let transfer = Transfer(
                 kind: .download,
@@ -158,20 +137,7 @@ public final class TransferQueue {
                 bytesTotal: entry.size
             )
             transfer.isDirectoryTransfer = false
-            transfer.status = .running
-            modelContext?.insert(transfer)
-            try modelContext?.save()
-
-            let parent = destinationURL.deletingLastPathComponent()
-            let jobID = try await TransferService.shared.copyFileAsync(
-                srcFs: "\(remote):",
-                srcPath: entry.pathInRemote,
-                dstFs: parent.path,
-                dstPath: destinationURL.lastPathComponent
-            )
-            transfer.jobID = jobID
-            try modelContext?.save()
-            startPolling(transfer)
+            enqueueAndSchedule(transfer)
         }
     }
 
@@ -194,19 +160,7 @@ public final class TransferQueue {
             sourceKind: sourceKind,
             bytesTotal: fileSize(at: local)
         )
-        transfer.status = .running
-        modelContext?.insert(transfer)
-        try modelContext?.save()
-
-        let jobID = try await TransferService.shared.copyFileAsync(
-            srcFs: local.deletingLastPathComponent().path,
-            srcPath: local.lastPathComponent,
-            dstFs: "\(remote):",
-            dstPath: path
-        )
-        transfer.jobID = jobID
-        try modelContext?.save()
-        startPolling(transfer)
+        enqueueAndSchedule(transfer)
     }
 
     @discardableResult
@@ -271,17 +225,7 @@ public final class TransferQueue {
             sourceKind: sourceKind,
             bytesTotal: directorySize(at: localFolder)
         )
-        transfer.status = .running
-        modelContext?.insert(transfer)
-        try modelContext?.save()
-
-        let jobID = try await TransferService.shared.copyDirAsync(
-            srcFs: localFolder.path,
-            dstFs: "\(remote):\(destinationFolder)"
-        )
-        transfer.jobID = jobID
-        try modelContext?.save()
-        startPolling(transfer)
+        enqueueAndSchedule(transfer)
     }
 
     public func enqueueDelete(remote: String, path: String, isDirectory: Bool) async throws {
@@ -499,6 +443,7 @@ public final class TransferQueue {
         transfer.lastError = "Annulé par l'utilisateur"
         transfer.finishedAt = .now
         try? modelContext?.save()
+        scheduleNext()   // libère un slot → démarre le suivant en file
     }
 
     // MARK: - Pause / reprise par transfert
@@ -521,37 +466,53 @@ public final class TransferQueue {
         transfer.jobID = nil
         transfer.status = .paused
         transfer.finishedAt = nil
+        transfer.autoPaused = false   // pause manuelle par défaut (autoPauseActive remet true)
         try? modelContext?.save()
         await LogService.shared.log(
             .info,
             category: "transfer",
             message: "⏸️ Transfert en pause : \(transfer.sourcePath)"
         )
+        scheduleNext()   // libère un slot → démarre le suivant en file
     }
 
     /// Reprend un transfert mis en pause : relance l'opération rclone sur le
     /// MÊME enregistrement (la ligne reste en place et reprend sa progression).
     public func resume(_ transfer: Transfer) async throws {
         guard transfer.status == .paused else { return }
-        transfer.status = .running
+        transfer.autoPaused = false
         transfer.lastError = nil
         transfer.finishedAt = nil
-        try? modelContext?.save()
-        do {
-            let jobID = try await relaunch(transfer)
-            transfer.jobID = jobID
+        if isQueuedKind(transfer) {
+            // Repasse par la file bornée (respecte la concurrence max + priorité).
+            transfer.status = .enqueued
             try? modelContext?.save()
-            startPolling(transfer)
+            scheduleNext()
             await LogService.shared.log(
                 .info,
                 category: "transfer",
-                message: "▶️ Transfert repris : \(transfer.sourcePath)"
+                message: "▶️ Transfert remis en file : \(transfer.sourcePath)"
             )
-        } catch {
-            transfer.status = .paused
-            transfer.lastError = error.localizedDescription
+        } else {
+            // copy/move/sync : relance immédiate hors file bornée.
+            transfer.status = .running
             try? modelContext?.save()
-            throw error
+            do {
+                let jobID = try await relaunch(transfer)
+                transfer.jobID = jobID
+                try? modelContext?.save()
+                startPolling(transfer)
+                await LogService.shared.log(
+                    .info,
+                    category: "transfer",
+                    message: "▶️ Transfert repris : \(transfer.sourcePath)"
+                )
+            } catch {
+                transfer.status = .paused
+                transfer.lastError = error.localizedDescription
+                try? modelContext?.save()
+                throw error
+            }
         }
     }
 
@@ -638,6 +599,181 @@ public final class TransferQueue {
         case .delete:
             throw TransferQueueError.cannotRetry("Une suppression ne peut pas être reprise.")
         }
+    }
+
+    // MARK: - Scheduler (file d'attente à concurrence bornée)
+
+    static let maxConcurrentKey = "transfer.maxConcurrentTransfers"
+    static let pauseOnCellularKey = "transfer.pauseOnCellular"
+    static let cellularLimitKey = "transfer.cellularLimitMBps"
+    static let wifiLimitKey = "transfer.bandwidthLimitMBps"
+
+    /// Nombre max de transferts download/upload simultanés (défaut 3, borné 1…8).
+    public var maxConcurrent: Int {
+        let v = UserDefaults.standard.integer(forKey: Self.maxConcurrentKey)
+        return v <= 0 ? 3 : min(v, 8)
+    }
+
+    /// Seuls les transferts « lourds » (download/upload) passent par la file
+    /// bornée ; copy/move/sync/rename/delete restent dispatchés immédiatement.
+    private func isQueuedKind(_ t: Transfer) -> Bool {
+        t.kind == .download || t.kind == .upload
+    }
+
+    /// Peut-on démarrer de nouveaux transferts ? Faux si pause globale,
+    /// hors-ligne, ou cellulaire avec l'option « pause en cellulaire ».
+    private var canStartNewTransfers: Bool {
+        if isPausedGlobally { return false }
+        let reach = NetworkReachability.shared
+        if !reach.isOnline { return false }
+        if reach.isCellularLike && UserDefaults.standard.bool(forKey: Self.pauseOnCellularKey) {
+            return false
+        }
+        return true
+    }
+
+    /// Cœur de la file : démarre autant de transferts `.enqueued` que de slots
+    /// libres, par priorité (queueOrder) puis ancienneté. Synchrone : réclame
+    /// les slots de façon ATOMIQUE (statut `.running` posé avant tout await),
+    /// puis dispatch chaque job en arrière-plan via startClaimed.
+    public func scheduleNext() {
+        guard modelContext != nil, canStartNewTransfers else { return }
+        let slots = maxConcurrent - countRunningQueued()
+        guard slots > 0 else { return }
+        let waiting = Array(fetchEnqueuedSorted().prefix(slots))
+        guard !waiting.isEmpty else { return }
+        for t in waiting { t.status = .running }   // réservation atomique du slot
+        try? modelContext?.save()
+        for t in waiting { startClaimed(t) }
+    }
+
+    private func countRunningQueued() -> Int {
+        guard let modelContext else { return 0 }
+        let descriptor = FetchDescriptor<Transfer>(
+            predicate: #Predicate { $0.statusRaw == "running" }
+        )
+        let running = (try? modelContext.fetch(descriptor)) ?? []
+        return running.filter { isQueuedKind($0) }.count
+    }
+
+    private func fetchEnqueuedSorted() -> [Transfer] {
+        guard let modelContext else { return [] }
+        let descriptor = FetchDescriptor<Transfer>(
+            predicate: #Predicate { $0.statusRaw == "enqueued" },
+            sortBy: [SortDescriptor(\.queueOrder, order: .forward),
+                     SortDescriptor(\.startedAt, order: .forward)]
+        )
+        let all = (try? modelContext.fetch(descriptor)) ?? []
+        return all.filter { isQueuedKind($0) }
+    }
+
+    /// Dispatch effectif d'un transfert déjà réservé (.running) par scheduleNext.
+    private func startClaimed(_ transfer: Transfer) {
+        let id = transfer.id
+        Task { @MainActor in
+            do {
+                let jobID = try await relaunch(transfer)
+                guard let t = fetchTransfer(id: id), t.status == .running else { return }
+                t.jobID = jobID
+                try? modelContext?.save()
+                startPolling(t)
+            } catch {
+                if let t = fetchTransfer(id: id) {
+                    t.status = .failed
+                    t.lastError = error.localizedDescription
+                    t.finishedAt = .now
+                    try? modelContext?.save()
+                }
+                await LogService.shared.log(.error, category: "transfer",
+                    message: "Démarrage du transfert échoué : \(error.localizedDescription)")
+                scheduleNext()
+            }
+        }
+    }
+
+    /// Crée le transfert EN FILE D'ATTENTE (.enqueued) puis tente de démarrer.
+    /// Utilisé par les enqueue download/upload à la place du démarrage immédiat.
+    private func enqueueAndSchedule(_ transfer: Transfer) {
+        transfer.status = .enqueued
+        modelContext?.insert(transfer)
+        try? modelContext?.save()
+        scheduleNext()
+    }
+
+    /// Change le nombre de transferts simultanés et relance le scheduler.
+    public func setMaxConcurrent(_ n: Int) {
+        UserDefaults.standard.set(min(max(n, 1), 8), forKey: Self.maxConcurrentKey)
+        scheduleNext()
+    }
+
+    /// Fait passer un transfert en attente en TÊTE de file (priorité souple :
+    /// pas de préemption d'un job en cours, mais premier servi au slot suivant).
+    public func prioritize(_ transfer: Transfer) {
+        let minOrder = fetchEnqueuedSorted().map(\.queueOrder).min() ?? 0
+        transfer.queueOrder = minOrder - 1
+        try? modelContext?.save()
+        scheduleNext()
+    }
+
+    // MARK: - Politique réseau (Wi-Fi / cellulaire)
+
+    /// Abonné aux changements de lien (`.networkPathDidChange`) : applique la
+    /// politique réseau courante.
+    public func handleNetworkChange() async {
+        await applyNetworkPolicy()
+    }
+
+    /// Applique la limite de bande passante selon le lien (Wi-Fi vs cellulaire),
+    /// met en pause auto en cellulaire/hors-ligne si demandé, et reprend les
+    /// transferts AUTO-pausés quand la connexion redevient utilisable.
+    public func applyNetworkPolicy() async {
+        let reach = NetworkReachability.shared
+        let online = reach.isOnline
+        let cellular = reach.isCellularLike
+        let pauseOnCellular = UserDefaults.standard.bool(forKey: Self.pauseOnCellularKey)
+        let wifiMBps = UserDefaults.standard.double(forKey: Self.wifiLimitKey)
+        let cellMBps = UserDefaults.standard.double(forKey: Self.cellularLimitKey)
+
+        if !online {
+            await LogService.shared.log(.info, category: "transfer",
+                message: "📴 Hors-ligne : pause auto des transferts actifs")
+            await autoPauseActive()
+            return
+        }
+        if cellular && pauseOnCellular {
+            await LogService.shared.log(.info, category: "transfer",
+                message: "📵 Cellulaire + « pause en cellulaire » : transferts suspendus")
+            await autoPauseActive()
+            return
+        }
+        let bytes = cellular ? Int64(cellMBps * 1024 * 1024) : Int64(wifiMBps * 1024 * 1024)
+        try? await TransferService.shared.setBandwidthLimit(bytesPerSecond: bytes)
+        await LogService.shared.log(.info, category: "transfer",
+            message: cellular
+                ? "📶 Cellulaire : limite \(cellMBps <= 0 ? "illimitée" : String(format: "%.1f MB/s", cellMBps))"
+                : "📶 Wi-Fi : limite \(wifiMBps <= 0 ? "illimitée" : String(format: "%.1f MB/s", wifiMBps))")
+        resumeAutoPaused()
+    }
+
+    /// Met en pause AUTO tous les transferts download/upload actifs (marqués
+    /// `autoPaused` pour distinguer d'une pause manuelle).
+    private func autoPauseActive() async {
+        for t in fetchActivePausable() where isQueuedKind(t) {
+            await pause(t)
+            t.autoPaused = true
+        }
+        try? modelContext?.save()
+    }
+
+    /// Remet en file les transferts AUTO-pausés (jamais ceux pausés à la main).
+    private func resumeAutoPaused() {
+        let paused = fetchPaused().filter { $0.autoPaused }
+        for t in paused {
+            t.autoPaused = false
+            t.status = .enqueued
+        }
+        if !paused.isEmpty { try? modelContext?.save() }
+        scheduleNext()
     }
 
     /// Retry a failed transfer by re-enqueuing an equivalent operation. The
@@ -1003,6 +1139,9 @@ public final class TransferQueue {
             }
         }
         pollTasks[jobID] = nil
+        // Un transfert vient de se terminer (succès/échec) → libère son slot
+        // et démarre le suivant en file d'attente.
+        scheduleNext()
     }
 
     private func fetchTransfer(id: String) -> Transfer? {
@@ -1106,18 +1245,30 @@ public final class TransferQueue {
 
     private func replayInterrupted() async {
         guard let modelContext else { return }
+        // Respecte une pause globale persistée : sinon le scheduler relancerait
+        // les transferts dès le boot alors que l'utilisateur avait tout suspendu.
+        isPausedGlobally = UserDefaults.standard.bool(forKey: Self.persistedPauseKey)
         let descriptor = FetchDescriptor<Transfer>(
-            predicate: #Predicate { $0.statusRaw == "running" || $0.statusRaw == "pending" }
+            predicate: #Predicate { $0.statusRaw == "running" || $0.statusRaw == "pending" || $0.statusRaw == "enqueued" }
         )
         guard let candidates = try? modelContext.fetch(descriptor) else { return }
         for transfer in candidates {
-            // For Phase C, we mark them failed and let the user retry manually.
-            // Phase E will re-enqueue automatically based on transfer.kind.
-            transfer.status = .failed
-            transfer.lastError = "Interrompu — relance manuelle requise"
-            transfer.finishedAt = .now
+            if isQueuedKind(transfer) {
+                // Reprise robuste au démarrage à froid : le job rclone n'existe
+                // plus après la mort du process → on remet en file pour relance
+                // automatique (rclone saute les fichiers déjà transférés).
+                transfer.jobID = nil
+                transfer.autoPaused = false
+                transfer.status = .enqueued
+            } else {
+                // copy/move/sync/rename : pas de reprise auto, relance manuelle.
+                transfer.status = .failed
+                transfer.lastError = "Interrompu — relance manuelle requise"
+                transfer.finishedAt = .now
+            }
         }
         try? modelContext.save()
+        scheduleNext()
     }
 
     // MARK: - Batch helpers

--- a/Rclone GUI/Views/Settings/PerformanceSettingsView.swift
+++ b/Rclone GUI/Views/Settings/PerformanceSettingsView.swift
@@ -15,6 +15,12 @@ struct PerformanceSettingsView: View {
     /// Granularity 0.5 MB/s — fine enough for cellular tuning, coarse enough
     /// to keep the slider readable.
     @AppStorage("transfer.bandwidthLimitMBps") private var bandwidthLimitMBps: Double = 0
+    /// File d'attente (Transferts Pro) : nb max de transferts simultanés.
+    @AppStorage("transfer.maxConcurrentTransfers") private var maxConcurrent: Int = 3
+    /// Suspend les transferts en cellulaire (et Wi-Fi bridé).
+    @AppStorage("transfer.pauseOnCellular") private var pauseOnCellular: Bool = false
+    /// Limite de bande passante distincte appliquée en cellulaire (0 = illimité).
+    @AppStorage("transfer.cellularLimitMBps") private var cellularLimitMBps: Double = 0
 
     @State private var isPaused = false
     @State private var transientMessage: String?
@@ -86,6 +92,73 @@ struct PerformanceSettingsView: View {
                 }
                 .disabled(isApplying)
             }
+
+            Section {
+                Stepper(value: Binding(
+                    get: { maxConcurrent },
+                    set: { newValue in
+                        maxConcurrent = newValue
+                        TransferQueue.shared.setMaxConcurrent(newValue)
+                    }
+                ), in: 1...8) {
+                    HStack {
+                        Text("Transferts simultanés")
+                        Spacer()
+                        Text("\(maxConcurrent)")
+                            .font(.body.weight(.semibold))
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } header: {
+                Text("File d'attente")
+            } footer: {
+                Text("Nombre maximum de téléchargements/envois actifs en même temps. Les suivants patientent dans la file et démarrent automatiquement dès qu'un slot se libère.")
+            }
+
+            Section {
+                Toggle(isOn: Binding(
+                    get: { pauseOnCellular },
+                    set: { newValue in
+                        pauseOnCellular = newValue
+                        Task { await TransferQueue.shared.applyNetworkPolicy() }
+                    }
+                )) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Pause en cellulaire")
+                            .font(.body.weight(.medium))
+                        Text("Suspend les transferts sur données cellulaires (et Wi-Fi en mode données réduites). Ils reprennent automatiquement en Wi-Fi.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if !pauseOnCellular {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Text("Limite cellulaire")
+                                .font(.subheadline)
+                            Spacer()
+                            Text(cellularRateLabel)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                        Slider(value: Binding(
+                            get: { cellularLimitMBps },
+                            set: { newValue in
+                                cellularLimitMBps = newValue
+                                Task { await TransferQueue.shared.applyNetworkPolicy() }
+                            }
+                        ), in: 0...Self.maxMBps, step: 0.5)
+                        .accessibilityValue(cellularRateLabel)
+                    }
+                    .padding(.vertical, 2)
+                }
+            } header: {
+                Text("Réseau cellulaire")
+            } footer: {
+                Text("Limite distincte appliquée quand l'appareil est en cellulaire. 0 MB/s = sans limite.")
+            }
         }
         .navigationTitle("Performance")
         .alert("Info", isPresented: Binding(
@@ -145,6 +218,14 @@ struct PerformanceSettingsView: View {
             return "\(Int(bandwidthLimitMBps * 1024)) KB/s"
         }
         return String(format: "%.1f MB/s", bandwidthLimitMBps)
+    }
+
+    private var cellularRateLabel: String {
+        if cellularLimitMBps <= 0 { return String(localized: "Illimité") }
+        if cellularLimitMBps < 1 {
+            return "\(Int(cellularLimitMBps * 1024)) KB/s"
+        }
+        return String(format: "%.1f MB/s", cellularLimitMBps)
     }
 
     @ViewBuilder

--- a/Rclone GUI/Views/Transfers/TransfersView.swift
+++ b/Rclone GUI/Views/Transfers/TransfersView.swift
@@ -19,6 +19,9 @@ struct TransfersView: View {
     /// par un toast non-bloquant qui se dismiss tout seul.
     @State private var toast: AppToast?
     @State private var hapticTrigger = 0
+    /// Export des logs de transfert (catégorie "transfer") → ShareSheet.
+    @State private var logExportURL: URL?
+    @State private var showLogShare = false
 
     // Pagination des sections Terminés/Échoués : un historique de plusieurs
     // centaines de transferts faisait freezer la liste (pas de virtualisation
@@ -74,6 +77,11 @@ struct TransfersView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 Menu {
+                    Button {
+                        Task { await exportTransferLogs() }
+                    } label: {
+                        Label("Exporter les logs de transfert", systemImage: "square.and.arrow.up")
+                    }
                     Button(role: .destructive) {
                         clearCompleted()
                     } label: {
@@ -84,6 +92,14 @@ struct TransfersView: View {
                     Image(systemName: "ellipsis.circle")
                 }
                 .accessibilityLabel("Plus d'actions de transferts")
+            }
+        }
+        .sheet(isPresented: $showLogShare) {
+            if let url = logExportURL {
+                ShareLink(item: url) {
+                    Label("Partager le fichier de logs", systemImage: "square.and.arrow.up")
+                        .padding()
+                }
             }
         }
         .appToast($toast)
@@ -173,6 +189,14 @@ struct TransfersView: View {
     private func transferRowMenu(_ transfer: Transfer) -> some View {
         switch transfer.status {
         case .running, .pending, .enqueued:
+            if transfer.status == .enqueued {
+                Button {
+                    TransferQueue.shared.prioritize(transfer)
+                    hapticTrigger &+= 1
+                } label: {
+                    Label("Prioriser", systemImage: "arrow.up.to.line")
+                }
+            }
             if transfer.kind != .delete {
                 Button {
                     Task { await pauseTransfer(transfer) }
@@ -219,6 +243,16 @@ struct TransfersView: View {
     private func deleteTransfer(_ transfer: Transfer) {
         modelContext.delete(transfer)
         try? modelContext.save()
+    }
+
+    private func exportTransferLogs() async {
+        do {
+            let url = try await LogService.shared.exportAsFile(category: "transfer")
+            logExportURL = url
+            showLogShare = true
+        } catch {
+            toast = AppToast(title: String(localized: "Export échoué"), message: error.localizedDescription, severity: .error)
+        }
     }
 
     private func retry(_ transfer: Transfer) async {


### PR DESCRIPTION
Implémente l'epic **RG-1 « Transferts Pro »** pour la v1.8 : *file d'attente, priorités, reprise robuste, limites Wi-Fi/cellulaire, logs exportables.*

## File d'attente à concurrence bornée
- Vrai état `.enqueued` + scheduler (`scheduleNext`) qui démarre au plus **N** transferts simultanés (réglable 1…8, défaut 3) et enchaîne dès qu'un slot se libère. Réservation **atomique** du slot (`.running` posé avant le dispatch) pour éviter le sur-ordonnancement.
- Seuls download/upload passent par la file ; copy/move/sync/rename/delete restent immédiats.

## Priorités
- Champ `queueOrder` + action **« Prioriser »** (menu contextuel) → tête de file. Priorité **souple** (pas de préemption d'un job en cours).

## Reprise robuste
- **Cold-start** : transferts interrompus remis en file et relancés auto (rclone saute l'existant) au lieu d'être marqués échoués.
- **Réseau** : pause auto hors-ligne/cellulaire + reprise auto au retour (flag `autoPaused` pour ne jamais lever une pause manuelle).

## Limites Wi-Fi / cellulaire
- `NetworkReachability` diffuse `.networkPathDidChange`. Limite de bande passante **distincte selon le lien**, Wi-Fi bridé (`isConstrained`) traité comme cellulaire, option **« pause en cellulaire »**. Réglages dans *Performance*.

## Logs exportables
- `LogService.exportAsFile(category:)` + action **« Exporter les logs de transfert »** (ShareSheet) dans l'écran Transferts. Décisions réseau/limite/pause journalisées.

## Conception
Synthèse multi-LLM (Codex + OpenCode Go) : scheduler avec points de reconcile, priorité souple, reprise = redémarrage (jamais confiance au `jobID` après cold-start), `core/bwlimit` global, `isConstrained` = cellulaire.

## Validation
`build_macos` (arm64) : **SUCCEEDED, 0 erreur**. Warnings restants tous préexistants (Swift 6 isolated conformance, etc.), hors fichiers modifiés.

S'appuie sur la pause/reprise par transfert de #46.