### PR TITLE
feat(transfers): file réordonnable, indicateur de file, backoff exponentiel, drain réseau

### DIFF
--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -723,24 +723,47 @@ public final class TransferQueue {
         await applyNetworkPolicy()
     }
 
+    /// Génération de politique réseau : invalide une fenêtre de drain en cours
+    /// si un nouvel évènement réseau survient entre-temps.
+    private var networkPolicyGeneration = 0
+    /// Fenêtre de drain (s) avant de suspendre sur bascule vers cellulaire.
+    private static let networkDrainSeconds: UInt64 = 8
+
     /// Applique la limite de bande passante selon le lien (Wi-Fi vs cellulaire),
     /// met en pause auto en cellulaire/hors-ligne si demandé, et reprend les
     /// transferts AUTO-pausés quand la connexion redevient utilisable.
     public func applyNetworkPolicy() async {
+        networkPolicyGeneration &+= 1
+        let gen = networkPolicyGeneration
         let reach = NetworkReachability.shared
-        let online = reach.isOnline
         let cellular = reach.isCellularLike
         let pauseOnCellular = UserDefaults.standard.bool(forKey: Self.pauseOnCellularKey)
         let wifiMBps = UserDefaults.standard.double(forKey: Self.wifiLimitKey)
         let cellMBps = UserDefaults.standard.double(forKey: Self.cellularLimitKey)
 
-        if !online {
+        if !reach.isOnline {
+            // Hors-ligne : pause immédiate (drainer sans réseau n'a aucun sens).
             await LogService.shared.log(.info, category: "transfer",
                 message: "📴 Hors-ligne : pause auto des transferts actifs")
             await autoPauseActive()
             return
         }
         if cellular && pauseOnCellular {
+            // Fenêtre de DRAIN : on laisse les transferts en vol progresser
+            // quelques secondes avant de les suspendre, plutôt qu'un arrêt sec
+            // qui gaspille les octets en cours sur la bascule Wi-Fi → cellulaire.
+            await LogService.shared.log(.info, category: "transfer",
+                message: "📵 Passage en cellulaire : drain \(Self.networkDrainSeconds)s avant pause")
+            try? await Task.sleep(nanoseconds: Self.networkDrainSeconds * 1_000_000_000)
+            // Un nouvel évènement réseau a invalidé ce drain → on laisse la
+            // nouvelle évaluation décider.
+            guard gen == networkPolicyGeneration else { return }
+            // Conditions plus réunies (retour Wi-Fi, option coupée…) → réévalue.
+            guard reach.isOnline, reach.isCellularLike,
+                  UserDefaults.standard.bool(forKey: Self.pauseOnCellularKey) else {
+                await applyNetworkPolicy()
+                return
+            }
             await LogService.shared.log(.info, category: "transfer",
                 message: "📵 Cellulaire + « pause en cellulaire » : transferts suspendus")
             await autoPauseActive()
@@ -1092,7 +1115,12 @@ public final class TransferQueue {
                             message: "🔁 Nouvelle tentative auto \(attempt)/\(maxAutoRetries) : \(finalSrc)"
                         )
                         let toRetry = transfer
-                        let backoff = Double(attempt) * 3.0
+                        // Backoff EXPONENTIEL avec jitter (équilibré), plafonné à
+                        // 60 s : plus doux pour le radio/la batterie que l'ancien
+                        // délai linéaire, et le jitter évite que plusieurs échecs
+                        // simultanés ne retentent tous au même instant.
+                        let capped = min(60.0, 3.0 * pow(2.0, Double(attempt - 1)))
+                        let backoff = capped / 2 + Double.random(in: 0...(capped / 2))
                         Task { @MainActor in
                             try? await Task.sleep(for: .seconds(backoff))
                             try? await self.retry(toRetry)

--- a/Rclone GUI/Views/Transfers/TransferRowView.swift
+++ b/Rclone GUI/Views/Transfers/TransferRowView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct TransferRowView: View {
     let transfer: Transfer
+    /// Rang dans la file d'attente (#n), affiché pour les transferts en attente.
+    var queuePosition: Int? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 9) {
@@ -38,6 +40,16 @@ struct TransferRowView: View {
                 }
 
                 Spacer(minLength: 8)
+
+                if let queuePosition {
+                    Text("#\(queuePosition)")
+                        .font(.caption2.monospacedDigit().weight(.bold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quaternary, in: Capsule())
+                        .accessibilityLabel("Position \(queuePosition) dans la file")
+                }
 
                 statusBadge
             }

--- a/Rclone GUI/Views/Transfers/TransfersView.swift
+++ b/Rclone GUI/Views/Transfers/TransfersView.swift
@@ -93,6 +93,16 @@ struct TransfersView: View {
                 }
                 .accessibilityLabel("Plus d'actions de transferts")
             }
+            #if os(iOS)
+            // Mode édition : permet de réordonner la file « En attente » par
+            // glisser-déposer (handles de déplacement). Affiché seulement s'il
+            // y a une file.
+            if hasQueuedItems {
+                ToolbarItem(placement: .topBarLeading) {
+                    EditButton()
+                }
+            }
+            #endif
         }
         .sheet(isPresented: $showLogShare) {
             if let url = logExportURL {
@@ -147,6 +157,11 @@ struct TransfersView: View {
 
     private var globalPauseShowsResume: Bool {
         !hasActivePausable && hasPausedResumable
+    }
+
+    /// Y a-t-il des transferts en file d'attente (réordonnables) ?
+    private var hasQueuedItems: Bool {
+        transfers.contains { $0.status == .enqueued || $0.status == .pending }
     }
 
     private func toggleGlobalPause() async {
@@ -255,6 +270,107 @@ struct TransfersView: View {
         }
     }
 
+    // MARK: - Lignes & en-têtes
+
+    /// Une ligne de transfert + ses swipes + son menu contextuel. `position`
+    /// est le rang dans la file (#n), affiché uniquement pour les `.enqueued`.
+    @ViewBuilder
+    private func transferRow(_ transfer: Transfer, position: Int?) -> some View {
+        TransferRowView(transfer: transfer, queuePosition: position)
+            .swipeActions(edge: .trailing) {
+                if transfer.status == .running || transfer.status == .pending || transfer.status == .enqueued {
+                    Button(role: .destructive) {
+                        Task { await TransferQueue.shared.cancel(transfer) }
+                    } label: {
+                        Label("Annuler", systemImage: "xmark.circle")
+                    }
+                    if transfer.kind != .delete {
+                        Button {
+                            Task { await pauseTransfer(transfer) }
+                        } label: {
+                            Label("Pause", systemImage: "pause.fill")
+                        }
+                        .tint(.orange)
+                    }
+                } else {
+                    Button(role: .destructive) {
+                        modelContext.delete(transfer)
+                        try? modelContext.save()
+                    } label: {
+                        Label("Supprimer", systemImage: "trash")
+                    }
+                }
+            }
+            .swipeActions(edge: .leading) {
+                if transfer.status == .paused {
+                    Button {
+                        Task { await resumeTransfer(transfer) }
+                    } label: {
+                        Label("Reprendre", systemImage: "play.fill")
+                    }
+                    .tint(.green)
+                } else if transfer.status == .failed {
+                    Button {
+                        Task { await retry(transfer) }
+                    } label: {
+                        Label("Réessayer", systemImage: "arrow.clockwise")
+                    }
+                    .tint(.blue)
+                }
+            }
+            .contextMenu {
+                transferRowMenu(transfer)
+            }
+    }
+
+    @ViewBuilder
+    private func groupHeader(_ group: TransferGroup) -> some View {
+        HStack {
+            Text(group.title)
+            Spacer()
+            if let detail = headerDetail(group) {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+        }
+    }
+
+    /// Indicateur de file : slots utilisés/max sur « En cours », nombre en
+    /// attente sur « En attente ».
+    private func headerDetail(_ group: TransferGroup) -> String? {
+        switch group.role {
+        case .running:
+            return "\(runningQueuedCount)/\(TransferQueue.shared.maxConcurrent) actifs"
+        case .pending:
+            let n = group.items.count
+            return n > 1 ? "\(n) en file" : "1 en file"
+        default:
+            return nil
+        }
+    }
+
+    /// Transferts download/upload réellement en cours (ceux bornés par la file).
+    private var runningQueuedCount: Int {
+        transfers.filter {
+            $0.status == .running && ($0.kind == .download || $0.kind == .upload)
+        }.count
+    }
+
+    /// Glisser-déposer dans la file : renumérote `queueOrder` selon le nouvel
+    /// ordre affiché, puis relance le scheduler.
+    private func moveInQueue(_ items: [Transfer], from source: IndexSet, to destination: Int) {
+        var reordered = items
+        reordered.move(fromOffsets: source, toOffset: destination)
+        for (index, transfer) in reordered.enumerated() {
+            transfer.queueOrder = index
+        }
+        try? modelContext.save()
+        TransferQueue.shared.scheduleNext()
+        hapticTrigger &+= 1
+    }
+
     private func retry(_ transfer: Transfer) async {
         do {
             try await TransferQueue.shared.retry(transfer)
@@ -359,61 +475,26 @@ struct TransfersView: View {
             } else {
                 let groups = TransferGroup.organize(filteredTransfers)
                 ForEach(groups, id: \.title) { group in
-                    Section(group.title) {
+                    Section {
                         // Cap les sections terminales (Terminés/Échoués) qui
                         // peuvent gonfler à plusieurs centaines d'éléments.
-                        let isTerminal = group.title == "Terminés" || group.title == "Échoués"
+                        let isTerminal = group.role == .completed || group.role == .failed
                         let visibleItems = isTerminal
                             ? Array(group.items.prefix(terminalDisplayLimit))
                             : group.items
-                        ForEach(visibleItems) { transfer in
-                            TransferRowView(transfer: transfer)
-                                .swipeActions(edge: .trailing) {
-                                    if transfer.status == .running || transfer.status == .pending || transfer.status == .enqueued {
-                                        Button(role: .destructive) {
-                                            Task {
-                                                await TransferQueue.shared.cancel(transfer)
-                                            }
-                                        } label: {
-                                            Label("Annuler", systemImage: "xmark.circle")
-                                        }
-                                        if transfer.kind != .delete {
-                                            Button {
-                                                Task { await pauseTransfer(transfer) }
-                                            } label: {
-                                                Label("Pause", systemImage: "pause.fill")
-                                            }
-                                            .tint(.orange)
-                                        }
-                                    } else {
-                                        Button(role: .destructive) {
-                                            modelContext.delete(transfer)
-                                            try? modelContext.save()
-                                        } label: {
-                                            Label("Supprimer", systemImage: "trash")
-                                        }
-                                    }
-                                }
-                                .swipeActions(edge: .leading) {
-                                    if transfer.status == .paused {
-                                        Button {
-                                            Task { await resumeTransfer(transfer) }
-                                        } label: {
-                                            Label("Reprendre", systemImage: "play.fill")
-                                        }
-                                        .tint(.green)
-                                    } else if transfer.status == .failed {
-                                        Button {
-                                            Task { await retry(transfer) }
-                                        } label: {
-                                            Label("Réessayer", systemImage: "arrow.clockwise")
-                                        }
-                                        .tint(.blue)
-                                    }
-                                }
-                                .contextMenu {
-                                    transferRowMenu(transfer)
-                                }
+                        if group.reorderable {
+                            // File d'attente : réordonnable par glisser-déposer.
+                            // L'ordre affiché = ordre du scheduler (queueOrder).
+                            ForEach(Array(visibleItems.enumerated()), id: \.element.id) { index, transfer in
+                                transferRow(transfer, position: transfer.status == .enqueued ? index + 1 : nil)
+                            }
+                            .onMove { source, destination in
+                                moveInQueue(visibleItems, from: source, to: destination)
+                            }
+                        } else {
+                            ForEach(visibleItems) { transfer in
+                                transferRow(transfer, position: nil)
+                            }
                         }
                         if isTerminal && group.items.count > visibleItems.count {
                             Button {
@@ -429,6 +510,8 @@ struct TransfersView: View {
                             }
                             .foregroundStyle(.tint)
                         }
+                    } header: {
+                        groupHeader(group)
                     }
                 }
             }
@@ -798,8 +881,12 @@ private enum TransferFilter: String, CaseIterable, Identifiable {
 }
 
 private struct TransferGroup {
+    enum Role { case running, paused, pending, completed, failed }
     let title: String
     let items: [Transfer]
+    let role: Role
+    /// Seule la file « En attente » est réordonnable par glisser-déposer.
+    var reorderable: Bool { role == .pending }
 
     static func organize(_ all: [Transfer]) -> [TransferGroup] {
         var running: [Transfer] = []
@@ -817,12 +904,15 @@ private struct TransferGroup {
             case .failed: failed.append(t)
             }
         }
+        // La file affichée suit l'ordre du scheduler (queueOrder asc, puis
+        // ancienneté) pour que le rang #n et le glisser-déposer soient cohérents.
+        pending.sort { ($0.queueOrder, $0.startedAt) < ($1.queueOrder, $1.startedAt) }
         var groups: [TransferGroup] = []
-        if !running.isEmpty { groups.append(.init(title: String(localized: "En cours"), items: running)) }
-        if !paused.isEmpty { groups.append(.init(title: String(localized: "En pause"), items: paused)) }
-        if !pending.isEmpty { groups.append(.init(title: String(localized: "En attente"), items: pending)) }
-        if !completed.isEmpty { groups.append(.init(title: String(localized: "Terminés"), items: completed)) }
-        if !failed.isEmpty { groups.append(.init(title: String(localized: "Échec"), items: failed)) }
+        if !running.isEmpty { groups.append(.init(title: String(localized: "En cours"), items: running, role: .running)) }
+        if !paused.isEmpty { groups.append(.init(title: String(localized: "En pause"), items: paused, role: .paused)) }
+        if !pending.isEmpty { groups.append(.init(title: String(localized: "En attente"), items: pending, role: .pending)) }
+        if !completed.isEmpty { groups.append(.init(title: String(localized: "Terminés"), items: completed, role: .completed)) }
+        if !failed.isEmpty { groups.append(.init(title: String(localized: "Échec"), items: failed, role: .failed)) }
         return groups
     }
 }


### PR DESCRIPTION
Itérations sur l'epic **Transferts Pro** (#47), demandées par Vitaly.

## 1. Réordonner par glisser-déposer
File « En attente » réordonnable (`onMove` + `EditButton` iOS / drag direct macOS). Renumérote `queueOrder`. La file s'affiche maintenant dans l'**ordre du scheduler** (queueOrder puis ancienneté) pour rester cohérente avec le rang affiché et le drag & drop.

## 2. Indicateur de file dans l'UI
- En-tête **« En cours »** : `slots utilisés / max`.
- En-tête **« En attente »** : `N en file`.
- Chaque ligne en attente affiche son **rang (#n)**.

## 3. Backoff exponentiel + jitter
Retries auto en backoff **exponentiel** (jitter équilibré, plafonné 60 s) au lieu du délai linéaire `attempt×3s` — plus doux pour le radio/la batterie (reco OpenCode Go).

## 4. Fenêtre de drain réseau
Sur bascule vers cellulaire (option « pause en cellulaire »), **drain ~8 s** : les transferts en vol progressent avant suspension au lieu d'un arrêt sec qui gaspille des octets. Invalidé si l'état réseau rechange entre-temps (génération). Le **hors-ligne** reste une pause immédiate.

## Validation
`build_macos` (arm64) : **SUCCEEDED, 0 erreur**. Warnings restants tous préexistants.