### PR TITLE
feat(settings): écran « Historique des versions » dans les Réglages

### DIFF
--- a/Rclone GUI/Views/Settings/ChangelogView.swift
+++ b/Rclone GUI/Views/Settings/ChangelogView.swift
@@ -1,0 +1,200 @@
+//
+//  ChangelogView.swift
+//  Rclone GUI — Views/Settings
+//
+//  Historique des versions (« Nouveautés ») accessible depuis Réglages.
+//  Contenu bilingue FR/EN rendu en `verbatim` : il est localisé à la main
+//  (FR pour les appareils français, EN sinon) et n'alimente donc PAS le
+//  String Catalog — on évite tout reformatage du catalogue. Le contenu
+//  reflète l'historique publié sur rclone.rougetet.com.
+//
+
+import SwiftUI
+
+struct ChangelogView: View {
+    private var useFrench: Bool {
+        Locale.current.language.languageCode?.identifier == "fr"
+    }
+
+    private var currentVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
+
+    var body: some View {
+        Form {
+            ForEach(Self.releases, id: \.version) { release in
+                Section {
+                    ForEach(Array((useFrench ? release.itemsFR : release.itemsEN).enumerated()), id: \.offset) { _, item in
+                        Label {
+                            Text(verbatim: item)
+                                .font(.subheadline)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } icon: {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                } header: {
+                    header(for: release)
+                }
+            }
+        }
+        .navigationTitle(useFrench ? "Historique des versions" : "Version history")
+        #if os(iOS)
+        .rgInlineNavTitle()
+        #endif
+    }
+
+    @ViewBuilder
+    private func header(for release: Release) -> some View {
+        HStack(spacing: 8) {
+            Text(verbatim: (useFrench ? "Version " : "Version ") + release.version)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+            if release.version == currentVersion {
+                Text(verbatim: useFrench ? "ACTUELLE" : "CURRENT")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.accentColor, in: Capsule())
+            }
+            Spacer()
+            Text(verbatim: useFrench ? release.dateFR : release.dateEN)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .textCase(nil)
+    }
+
+    private struct Release {
+        let version: String
+        let dateFR: String
+        let dateEN: String
+        let itemsFR: [String]
+        let itemsEN: [String]
+    }
+
+    // Historique aligné sur rclone.rougetet.com (le plus récent en premier).
+    private static let releases: [Release] = [
+        Release(
+            version: "1.7", dateFR: "Juin 2026", dateEN: "June 2026",
+            itemsFR: [
+                "Téléchargez des dossiers entiers en une fois (récursif).",
+                "Raccourcis & Siri : ouvrez un remote ou lancez un envoi de fichier depuis l'app Raccourcis, grâce aux App Intents.",
+                "Confidentialité renforcée : le cache média est effacé automatiquement au verrouillage par inactivité, et vous pouvez plafonner sa taille (éviction automatique).",
+                "Transferts plus fiables : les transferts échoués sont relancés automatiquement, dans une limite raisonnable.",
+                "Assistant guidé pour créer votre coffre chiffré « Crypt ».",
+                "Journaux internes en direct pour diagnostiquer une connexion.",
+                "Nouvel écran « Feuille de route » pour découvrir ce qui arrive.",
+                "Améliorations de stabilité et de performance.",
+            ],
+            itemsEN: [
+                "Download entire folders in one go (recursive).",
+                "Shortcuts & Siri: open a remote or start a file upload from the Shortcuts app, powered by App Intents.",
+                "Stronger privacy: the media cache is wiped automatically when the app locks on inactivity, and you can cap its size (automatic eviction).",
+                "More reliable transfers: failed transfers are retried automatically, within a sensible limit.",
+                "Guided assistant to set up your encrypted \"Crypt\" vault.",
+                "Live internal logs to diagnose a connection.",
+                "New \"Roadmap\" screen to see what's coming next.",
+                "Stability and performance improvements.",
+            ]
+        ),
+        Release(
+            version: "1.6", dateFR: "Juin 2026", dateEN: "June 2026",
+            itemsFR: [
+                "Connexion par fichier : quand un backend exige un fichier pour s'authentifier (clé privée SSH, known_hosts, JSON de compte de service Google, certificat TLS…), importez-le directement depuis Fichiers — fini les chemins impossibles à saisir.",
+                "Les identifiants importés sont copiés en sécurité sur l'appareil et ne sont jamais transmis ailleurs.",
+                "Améliorations de stabilité et de performance.",
+            ],
+            itemsEN: [
+                "Connect with a file: when a backend needs a file to sign in (SSH private key, known_hosts, Google service-account JSON, TLS certificate…), import it straight from Files — no more impossible-to-type paths.",
+                "Imported credentials are copied securely on-device and never sent anywhere else.",
+                "Stability and performance improvements.",
+            ]
+        ),
+        Release(
+            version: "1.5", dateFR: "Juin 2026", dateEN: "June 2026",
+            itemsFR: [
+                "Lecteur vidéo intégré multi-format (MKV, AVI, WebM, TS…) : sous-titres intégrés et fichiers externes, pistes audio, reprise là où vous étiez.",
+                "Au choix : lecture dans l'app ou dans une app externe (Infuse, VLC).",
+                "Galerie en grille avec vignettes pour photos et vidéos : bascule liste/grille, mode « Médias uniquement », génération des vignettes en Wi-Fi par défaut.",
+                "Nouvelle option pour exclure les données de l'app des sauvegardes iCloud.",
+                "Stabilité et performances.",
+            ],
+            itemsEN: [
+                "Built-in multi-format video player (MKV, AVI, WebM, TS…): embedded and sidecar subtitles, audio tracks, resume where you left off.",
+                "Your choice: play in-app or in an external app (Infuse, VLC).",
+                "Grid gallery with thumbnails for photos and videos: list/grid toggle, \"Media only\" mode, Wi-Fi-only thumbnail generation by default.",
+                "New option to exclude the app's data from iCloud backups.",
+                "Stability and performance improvements.",
+            ]
+        ),
+        Release(
+            version: "1.4", dateFR: "Juin 2026", dateEN: "June 2026",
+            itemsFR: [
+                "Nouveaux clouds : Drime, Internxt et Filen (Internxt et Filen chiffrés de bout en bout).",
+                "Panneau « où trouver vos identifiants » pour Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage…",
+                "Sélecteur de stockage pour les remotes composites (alias, union, combine) — fini la saisie manuelle de « remote:chemin ».",
+                "Correction de la connexion aux remotes protégés par mot de passe (SFTP, FTP, WebDAV, SMB…).",
+                "Remotes verrouillés masqués des Récents et Favoris.",
+            ],
+            itemsEN: [
+                "New clouds: Drime, Internxt and Filen (Internxt and Filen are end-to-end encrypted).",
+                "\"Where to get your credentials\" panel for Pixeldrain, 1Fichier, ImageKit, Internet Archive, Gofile, Storj, NetStorage…",
+                "Storage picker for composite remotes (alias, union, combine) — no more typing \"remote:path\" by hand.",
+                "Fixed connecting to password-protected remotes (SFTP, FTP, WebDAV, SMB…).",
+                "Locked remotes hidden from Recents and Favorites.",
+            ]
+        ),
+        Release(
+            version: "1.3", dateFR: "Juin 2026", dateEN: "June 2026",
+            itemsFR: [
+                "Correctif important : l'import d'une configuration rclone chiffrée par mot de passe ne plante plus.",
+                "Bouton « J'ai un code » pour utiliser des codes promo.",
+                "Page « Contacter le développeur » dans Réglages → Support.",
+                "Traduction anglaise complète de l'app + code source désormais public sur GitHub.",
+            ],
+            itemsEN: [
+                "Important fix: importing a password-encrypted rclone configuration no longer crashes the app.",
+                "\"I have a code\" button to redeem promo codes.",
+                "\"Contact the Developer\" page in Settings → Support.",
+                "Completed English translation across the whole app + source code now public on GitHub.",
+            ]
+        ),
+        Release(
+            version: "1.2", dateFR: "Juin 2026", dateEN: "June 2026",
+            itemsFR: [
+                "App macOS native (Mac Apple Silicon) : barre latérale et intégration Finder.",
+                "Assistant guidé pour les remotes chiffrés (crypt) : choix du stockage, navigation jusqu'au dossier, mot de passe — sans saisie de chemin.",
+                "Assistant d'ajout amélioré : bouton Retour et sélecteur de fichier natif pour importer rclone.conf.",
+            ],
+            itemsEN: [
+                "Native macOS app (Apple Silicon Macs): sidebar layout and Finder integration.",
+                "Guided wizard for encrypted (crypt) remotes: pick storage, browse to the folder, set a password — no manual path typing.",
+                "Improved add-remote wizard: Back button and native file picker to import rclone.conf.",
+            ]
+        ),
+        Release(
+            version: "1.1", dateFR: "Mai 2026", dateEN: "May 2026",
+            itemsFR: [
+                "Localisation anglaise complète : l'interface suit la langue de l'appareil.",
+                "Première ouverture plus fluide, stabilité et finitions.",
+            ],
+            itemsEN: [
+                "Full English localization: the interface follows your device language.",
+                "Smoother first-launch, stability and polish.",
+            ]
+        ),
+        Release(
+            version: "1.0", dateFR: "Mai 2026", dateEN: "May 2026",
+            itemsFR: [
+                "Première version publique : client rclone natif, 70+ backends, intégration Fichiers (File Provider), chiffrement crypt de bout en bout, sync photo, Face ID, zéro tracking.",
+            ],
+            itemsEN: [
+                "First public release: native rclone client, 70+ backends, Files integration (File Provider), end-to-end crypt encryption, photo sync, Face ID, zero tracking.",
+            ]
+        ),
+    ]
+}

--- a/Rclone GUI/Views/Settings/SettingsView.swift
+++ b/Rclone GUI/Views/Settings/SettingsView.swift
@@ -169,6 +169,16 @@ struct SettingsView: View {
                     )
                 }
                 NavigationLink {
+                    ChangelogView()
+                } label: {
+                    SettingsNavigationRow(
+                        icon: "clock.arrow.circlepath",
+                        title: "Historique des versions",
+                        subtitle: "Les nouveautés de chaque mise à jour",
+                        tint: .orange
+                    )
+                }
+                NavigationLink {
                     RoadmapView()
                 } label: {
                     SettingsNavigationRow(


### PR DESCRIPTION
Ajoute, dans **Réglages → Diagnostic** (juste après « À propos »), un bouton **« Historique des versions »** qui ouvre un écran listant chaque version publiée et ses nouveautés — aligné sur rclone.rougetet.com.

- **Bilingue FR/EN** rendu en `verbatim` (localisé à la main : FR sur appareil français, EN sinon) → **n'alimente pas le String Catalog**, pas de reformatage du catalogue.
- La version en cours d'exécution (`CFBundleShortVersionString`) est marquée **« ACTUELLE »**.
- Versions **1.0 → 1.7**.
- Nouveau fichier auto-inclus via le groupe synchronisé du projet.

## Validation
`build_macos` (arm64) : **SUCCEEDED, 0 erreur**. Warning restant préexistant.