### PR TITLE
fix(folders): vignettes qui se chevauchent en grille + création de dossier

### DIFF
--- a/Rclone GUI/Views/Folders/FolderView.swift
+++ b/Rclone GUI/Views/Folders/FolderView.swift
@@ -39,6 +39,8 @@ struct FolderView: View {
     @State private var showingDestinationPicker = false
     @State private var showingFileImporter = false
     @State private var showingPhotoPicker = false
+    @State private var showingNewFolderAlert = false
+    @State private var newFolderName = ""
     @State private var selectedPhotoItems: [PhotosPickerItem] = []
     @State private var transientMessage: String?
     @State private var openingEntryID: String?
@@ -368,6 +370,12 @@ struct FolderView: View {
             } message: {
                 Text(transientMessage ?? "")
             }
+            .modifier(NewFolderAlert(
+                isPresented: $showingNewFolderAlert,
+                name: $newFolderName,
+                folderTitle: displayTitle,
+                onCreate: { Task { await createFolder() } }
+            ))
             .confirmationDialog(
                 pasteConflictTitle,
                 isPresented: Binding(
@@ -840,6 +848,13 @@ struct FolderView: View {
             }
 
             Button {
+                newFolderName = ""
+                showingNewFolderAlert = true
+            } label: {
+                Label("Nouveau dossier", systemImage: "folder.badge.plus")
+            }
+
+            Button {
                 showingFileImporter = true
             } label: {
                 Label("Uploader fichiers ou dossiers", systemImage: "arrow.up.doc")
@@ -900,6 +915,34 @@ struct FolderView: View {
                 .error,
                 category: "browse",
                 message: "Échec list \(remote):\(path) : \(error.localizedDescription)"
+            )
+        }
+    }
+
+    /// Crée un sous-dossier dans le dossier courant via rclone `operations/mkdir`
+    /// puis rafraîchit la liste (mkdir est instantané sur la plupart des backends).
+    private func createFolder() async {
+        let name = newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+        newFolderName = ""
+        guard !name.isEmpty else { return }
+        guard !name.contains("/") else {
+            transientMessage = "Le nom de dossier ne peut pas contenir « / »."
+            return
+        }
+        let cleanFolder = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let newPath = cleanFolder.isEmpty ? name : "\(cleanFolder)/\(name)"
+        do {
+            try await TransferService.shared.mkdir(remote: remote, path: newPath)
+            await LogService.shared.log(
+                .info, category: "browse",
+                message: "Dossier créé : \(remote):\(newPath)"
+            )
+            await load()
+        } catch {
+            transientMessage = "Impossible de créer le dossier : \(error.localizedDescription)"
+            await LogService.shared.log(
+                .error, category: "browse",
+                message: "Échec mkdir \(remote):\(newPath) : \(error.localizedDescription)"
             )
         }
     }
@@ -1243,5 +1286,30 @@ private struct FolderCountChip: View {
             .background(tint.opacity(0.14),
                         in: RoundedRectangle(cornerRadius: RG.Radius.pill, style: .continuous))
             .accessibilityHidden(true)
+    }
+}
+
+/// Alerte de création de dossier extraite en `ViewModifier` : isole sa logique
+/// de la grande chaîne de modificateurs de `FolderView` (sinon le type-checker
+/// SwiftUI explose). Saisie du nom + bouton « Créer » désactivé si vide.
+private struct NewFolderAlert: ViewModifier {
+    @Binding var isPresented: Bool
+    @Binding var name: String
+    let folderTitle: String
+    let onCreate: () -> Void
+
+    func body(content: Content) -> some View {
+        content.alert("Nouveau dossier", isPresented: $isPresented) {
+            TextField("Nom du dossier", text: $name)
+                .autocorrectionDisabled()
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                #endif
+            Button("Créer", action: onCreate)
+                .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+            Button("Annuler", role: .cancel) { name = "" }
+        } message: {
+            Text("Le dossier sera créé dans \(folderTitle).")
+        }
     }
 }

--- a/Rclone GUI/Views/Folders/MediaGridCell.swift
+++ b/Rclone GUI/Views/Folders/MediaGridCell.swift
@@ -21,41 +21,49 @@ struct MediaGridCell: View {
 
     var body: some View {
         VStack(spacing: 6) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color.secondary.opacity(0.12))
-
-                if let thumb {
-                    Image(decorative: thumb.image, scale: 1)
-                        .resizable()
-                        .scaledToFill()
-                } else {
-                    Image(systemName: placeholderIcon)
-                        .font(.system(size: 28))
-                        .foregroundStyle(placeholderColor)
-                    if loading {
+            // La taille de la cellule est pilotée par une FORME flexible carrée
+            // (elle prend la largeur de colonne puis impose un ratio 1:1). La
+            // vignette, le placeholder et les badges sont posés en `.overlay` :
+            // un overlay est dimensionné PAR le parent et n'influence JAMAIS sa
+            // taille. Sans ça, l'image `scaledToFill` (qui peut rapporter une
+            // taille > cellule selon son ratio) faisait déborder la cellule de
+            // son slot de grille → vignettes de tailles inégales qui se
+            // chevauchaient (bug iPhone Mini, pire en paysage).
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.secondary.opacity(0.12))
+                .aspectRatio(1, contentMode: .fit)
+                .overlay {
+                    if let thumb {
+                        Image(decorative: thumb.image, scale: 1)
+                            .resizable()
+                            .scaledToFill()
+                    } else {
+                        Image(systemName: placeholderIcon)
+                            .font(.system(size: 28))
+                            .foregroundStyle(placeholderColor)
+                    }
+                }
+                .overlay(alignment: .bottomTrailing) {
+                    if thumb == nil, loading {
                         ProgressView()
                             .controlSize(.small)
                             .padding(6)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                     }
                 }
-
-                if isVideo {
-                    Image(systemName: "play.circle.fill")
-                        .font(.system(size: 22))
-                        .foregroundStyle(.white)
-                        .shadow(radius: 3)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-                        .padding(6)
+                .overlay(alignment: .bottomLeading) {
+                    if isVideo {
+                        Image(systemName: "play.circle.fill")
+                            .font(.system(size: 22))
+                            .foregroundStyle(.white)
+                            .shadow(radius: 3)
+                            .padding(6)
+                    }
                 }
-            }
-            .aspectRatio(1, contentMode: .fit)
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(.quaternary, lineWidth: 0.5)
-            }
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(.quaternary, lineWidth: 0.5)
+                }
 
             Text(entry.name)
                 .font(.caption2)


### PR DESCRIPTION
Deux retours d'un testeur TestFlight (iPhone 13 Mini).

## Bug 1 — Vignettes qui se chevauchent en vue grille
**Cause** : dans `MediaGridCell`, l'image `.resizable().scaledToFill()` était un **enfant du ZStack**. `scaledToFill` (= `aspectRatio(.fill)`) peut **rapporter une taille > cellule** selon le ratio de l'image ; le ZStack adoptait cette taille → la cellule débordait de son slot de grille d'une quantité **variable selon chaque image** → vignettes de tailles inégales qui se chevauchaient (pire en paysage).

**Fix** : la taille est pilotée par une **forme carrée flexible** (`RoundedRectangle.aspectRatio(1, .fit)`) et la vignette + les badges (vidéo, spinner) sont posés en **`.overlay`** — un overlay est dimensionné *par* le parent et n'influence **jamais** sa taille. → cellules carrées uniformes, plus de débordement, en portrait comme en paysage.

## Bug 2 — Création de dossier sans effet
**Cause** : aucune action de création de dossier n'était câblée dans le navigateur (`mkdir` n'était appelé que par la corbeille) → « rien ne se passait ».

**Fix** : action **« Nouveau dossier »** dans le menu Actions → alerte de saisie du nom → `operations/mkdir` (TransferService) → **rafraîchissement** de la liste. Validation du nom (non vide, pas de `/`). L'alerte est extraite en `ViewModifier` dédié pour ne pas faire exploser le type-checker SwiftUI de `FolderView`.

## Validation
`build_macos` (arm64) : **SUCCEEDED, 0 erreur**. Warning restant préexistant.