### PR TITLE
feat(flows): automatisations locales (App Intents + Raccourcis) + écran Flows

### DIFF
--- a/Rclone GUI/AppIntents/FlowIntents.swift
+++ b/Rclone GUI/AppIntents/FlowIntents.swift
@@ -1,0 +1,126 @@
+//
+//  FlowIntents.swift
+//  Rclone GUI — AppIntents (Flows / automatisations locales)
+//
+//  Intents « Flows » (RG-2) : briques d'automatisation 100 % locales,
+//  composables dans l'app Raccourcis et par Siri. Aucune dépendance serveur.
+//
+//    - RunPhotoSyncIntent   : « Sauvegarder mes photos » (lance PhotoSync)
+//    - BackupFolderIntent   : « Sauvegarder un dossier » (sync remote → remote)
+//    - PauseTransfersIntent  : met en pause tous les transferts
+//    - ResumeTransfersIntent : reprend tous les transferts
+//
+//  Ces intents sont `AppIntent` (découvrables dans Raccourcis), à la
+//  différence des LiveActivityIntent de PhotoSyncIntents.swift qui pilotent
+//  l'Island.
+//
+
+import AppIntents
+import Foundation
+
+// MARK: - Sauvegarder mes photos
+
+@available(iOS 17.0, *)
+public struct RunPhotoSyncIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Sauvegarder mes photos"
+    public static let description = IntentDescription(
+        "Lance une sauvegarde de la photothèque via PhotoSync. Idéal pour une automatisation (ex. tous les soirs, sur secteur)."
+    )
+
+    public init() {}
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        let summary = await PhotoSyncService.shared.startFullSync()
+        let done = summary.completedCount
+        let failed = summary.failedCount
+        let msg = failed > 0
+            ? "Sauvegarde photos lancée — \(done) envoyée(s), \(failed) à revoir."
+            : "Sauvegarde photos lancée — \(done) élément(s) traité(s)."
+        return .result(dialog: IntentDialog(stringLiteral: msg))
+    }
+}
+
+// MARK: - Sauvegarder un dossier (remote → remote)
+
+@available(iOS 17.0, *)
+public struct BackupFolderIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Sauvegarder un dossier"
+    public static let description = IntentDescription(
+        "Synchronise un dossier d'un remote vers un autre (sauvegarde rclone). Le dossier de destination est mis à jour pour refléter la source."
+    )
+
+    @Parameter(title: "Remote source")
+    public var sourceRemote: String
+
+    @Parameter(title: "Dossier source", default: "")
+    public var sourcePath: String
+
+    @Parameter(title: "Remote destination")
+    public var destinationRemote: String
+
+    @Parameter(title: "Dossier destination", default: "")
+    public var destinationPath: String
+
+    public init() {}
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        let src = sourcePath.trimmingCharacters(in: CharacterSet(charactersIn: "/ "))
+        let dst = destinationPath.trimmingCharacters(in: CharacterSet(charactersIn: "/ "))
+        let entry = RemoteEntryDTO(
+            pathInRemote: src,
+            name: src.isEmpty ? sourceRemote : (src as NSString).lastPathComponent,
+            isDirectory: true,
+            size: 0,
+            modTime: Date(),
+            mimeType: nil,
+            hashMD5: nil,
+            hashSHA1: nil
+        )
+        try await TransferQueue.shared.enqueueRemoteTransfer(
+            kind: .sync,
+            srcRemote: sourceRemote,
+            entry: entry,
+            dstRemote: destinationRemote,
+            dstPath: dst
+        )
+        return .result(dialog: "Sauvegarde de \(sourceRemote):\(src) vers \(destinationRemote):\(dst) lancée.")
+    }
+}
+
+// MARK: - Pause / reprise globale des transferts
+
+@available(iOS 17.0, *)
+public struct PauseTransfersIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Mettre les transferts en pause"
+    public static let description = IntentDescription(
+        "Met en pause tous les transferts en cours (utile pour économiser les données ou la batterie)."
+    )
+
+    public init() {}
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await TransferQueue.shared.pauseAllTransfers()
+        return .result(dialog: "Transferts mis en pause.")
+    }
+}
+
+@available(iOS 17.0, *)
+public struct ResumeTransfersIntent: AppIntent {
+    public static let title: LocalizedStringResource = "Reprendre les transferts"
+    public static let description = IntentDescription(
+        "Reprend tous les transferts mis en pause."
+    )
+
+    public init() {}
+
+    @MainActor
+    public func perform() async throws -> some IntentResult & ProvidesDialog {
+        let mbps = UserDefaults.standard.double(forKey: "transfer.bandwidthLimitMBps")
+        let bytesPerSecond = Int64(mbps * 1024 * 1024)
+        try await TransferQueue.shared.resumeAllTransfers(bytesPerSecond: bytesPerSecond)
+        return .result(dialog: "Transferts repris.")
+    }
+}

--- a/Rclone GUI/AppIntents/RcloneGUIIntents.swift
+++ b/Rclone GUI/AppIntents/RcloneGUIIntents.swift
@@ -40,6 +40,31 @@ public struct RcloneGUIShortcuts: AppShortcutsProvider {
             shortTitle: "Ouvrir un remote",
             systemImageName: "externaldrive.fill"
         )
+        AppShortcut(
+            intent: RunPhotoSyncIntent(),
+            phrases: [
+                "Sauvegarder mes photos avec \(.applicationName)",
+                "Lancer la sauvegarde photos \(.applicationName)",
+            ],
+            shortTitle: "Sauvegarder mes photos",
+            systemImageName: "photo.on.rectangle.angled"
+        )
+        AppShortcut(
+            intent: PauseTransfersIntent(),
+            phrases: [
+                "Mettre en pause les transferts \(.applicationName)",
+            ],
+            shortTitle: "Pause des transferts",
+            systemImageName: "pause.circle.fill"
+        )
+        AppShortcut(
+            intent: ResumeTransfersIntent(),
+            phrases: [
+                "Reprendre les transferts \(.applicationName)",
+            ],
+            shortTitle: "Reprendre les transferts",
+            systemImageName: "play.circle.fill"
+        )
     }
 }
 

--- a/Rclone GUI/Views/Settings/FlowsView.swift
+++ b/Rclone GUI/Views/Settings/FlowsView.swift
@@ -1,0 +1,123 @@
+//
+//  FlowsView.swift
+//  Rclone GUI — Views/Settings
+//
+//  Écran « Flows » (RG-2) : présente les automatisations 100 % locales
+//  exposées via App Intents, et invite à les composer dans l'app Raccourcis.
+//  Aucun serveur, aucun tracking — tout s'exécute sur l'appareil.
+//
+//  Contenu bilingue FR/EN rendu en `verbatim` (localisé à la main) → n'alimente
+//  pas le String Catalog.
+//
+
+import SwiftUI
+
+struct FlowsView: View {
+    @Environment(\.openURL) private var openURL
+
+    private var useFrench: Bool {
+        Locale.current.language.languageCode?.identifier == "fr"
+    }
+
+    private struct Flow: Identifiable {
+        let id = UUID()
+        let icon: String
+        let tint: Color
+        let titleFR: String
+        let titleEN: String
+        let descFR: String
+        let descEN: String
+    }
+
+    private var flows: [Flow] {
+        [
+            Flow(icon: "photo.on.rectangle.angled", tint: .pink,
+                 titleFR: "Sauvegarder mes photos", titleEN: "Back up my photos",
+                 descFR: "Lance PhotoSync. Parfait en automatisation : chaque nuit, sur secteur et en Wi-Fi.",
+                 descEN: "Runs PhotoSync. Great as an automation: every night, while charging and on Wi-Fi."),
+            Flow(icon: "arrow.triangle.2.circlepath", tint: .purple,
+                 titleFR: "Sauvegarder un dossier", titleEN: "Back up a folder",
+                 descFR: "Synchronise un dossier d'un remote vers un autre (sauvegarde rclone).",
+                 descEN: "Syncs a folder from one remote to another (rclone backup)."),
+            Flow(icon: "pause.circle.fill", tint: .orange,
+                 titleFR: "Mettre les transferts en pause", titleEN: "Pause transfers",
+                 descFR: "Suspend tous les transferts — utile pour économiser données ou batterie.",
+                 descEN: "Pauses all transfers — handy to save data or battery."),
+            Flow(icon: "play.circle.fill", tint: .green,
+                 titleFR: "Reprendre les transferts", titleEN: "Resume transfers",
+                 descFR: "Relance tous les transferts mis en pause.",
+                 descEN: "Resumes all paused transfers."),
+            Flow(icon: "externaldrive.fill", tint: .blue,
+                 titleFR: "Ouvrir un remote", titleEN: "Open a remote",
+                 descFR: "Ouvre directement un remote dans l'app.",
+                 descEN: "Opens a remote directly in the app."),
+            Flow(icon: "arrow.up.doc", tint: .indigo,
+                 titleFR: "Téléverser un fichier", titleEN: "Upload a file",
+                 descFR: "Envoie un fichier vers un remote depuis Raccourcis ou la feuille de partage.",
+                 descEN: "Sends a file to a remote from Shortcuts or the Share sheet."),
+        ]
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label {
+                        Text(verbatim: useFrench ? "Automatisations 100 % locales" : "100% local automations")
+                            .font(.headline)
+                    } icon: {
+                        Image(systemName: "wand.and.stars")
+                            .foregroundStyle(.purple)
+                    }
+                    Text(verbatim: useFrench
+                         ? "Composez vos propres automatisations dans l'app Raccourcis avec les actions de Rclone GUI. Tout s'exécute sur votre appareil — aucun serveur, aucun tracking."
+                         : "Build your own automations in the Shortcuts app using Rclone GUI actions. Everything runs on your device — no server, no tracking.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 2)
+            }
+
+            Section {
+                ForEach(flows) { flow in
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(verbatim: useFrench ? flow.titleFR : flow.titleEN)
+                                .font(.body.weight(.medium))
+                            Text(verbatim: useFrench ? flow.descFR : flow.descEN)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    } icon: {
+                        Image(systemName: flow.icon)
+                            .foregroundStyle(flow.tint)
+                    }
+                    .padding(.vertical, 2)
+                }
+            } header: {
+                Text(verbatim: useFrench ? "Actions disponibles dans Raccourcis" : "Actions available in Shortcuts")
+            }
+
+            Section {
+                Button {
+                    if let url = URL(string: "shortcuts://") { openURL(url) }
+                } label: {
+                    Label {
+                        Text(verbatim: useFrench ? "Ouvrir l'app Raccourcis" : "Open the Shortcuts app")
+                    } icon: {
+                        Image(systemName: "square.stack.3d.up")
+                    }
+                }
+            } footer: {
+                Text(verbatim: useFrench
+                     ? "Astuce : dans Raccourcis → onglet Automatisation, déclenchez « Sauvegarder mes photos » chaque nuit, quand l'appareil est en charge. Vous pouvez aussi demander à Siri : « Sauvegarder mes photos avec Rclone GUI »."
+                     : "Tip: in Shortcuts → Automation tab, trigger \"Back up my photos\" every night while charging. You can also ask Siri: \"Back up my photos with Rclone GUI\".")
+            }
+        }
+        .navigationTitle(useFrench ? "Flows" : "Flows")
+        #if os(iOS)
+        .rgInlineNavTitle()
+        #endif
+    }
+}

--- a/Rclone GUI/Views/Settings/SettingsView.swift
+++ b/Rclone GUI/Views/Settings/SettingsView.swift
@@ -77,6 +77,17 @@ struct SettingsView: View {
                         tint: .green
                     )
                 }
+
+                NavigationLink {
+                    FlowsView()
+                } label: {
+                    SettingsNavigationRow(
+                        icon: "wand.and.stars",
+                        title: "Flows & automatisations",
+                        subtitle: "Raccourcis et actions Siri, 100 % locaux",
+                        tint: .purple
+                    )
+                }
             }
 
             Section("Stockage") {


### PR DESCRIPTION
Premier volet de l'epic **« Flows » (RG-2)** pour la 1.9 — *Automatisations 100 % locales (Raccourcis + App Intents)*.

## Nouveaux App Intents (découvrables dans Raccourcis + Siri)
- **Sauvegarder mes photos** → lance PhotoSync (`startFullSync`). Idéal en automatisation nocturne sur secteur.
- **Sauvegarder un dossier** → synchronise un dossier remote→remote (paramétrable : remote/dossier source + destination).
- **Mettre les transferts en pause** / **Reprendre les transferts**.
- (déjà présents : Ouvrir un remote, Lister, Télécharger, Téléverser.)

Tous **100 % locaux**, aucun serveur. Enregistrés comme App Shortcuts avec phrases Siri.

## Écran in-app « Flows & automatisations »
Réglages → Configuration → **Flows & automatisations** : présente les actions disponibles, explique les automatisations, bouton **Ouvrir l'app Raccourcis** + astuce Siri. Bilingue FR/EN en verbatim (zéro impact String Catalog).

## Reste à faire (itération suivante)
- **Live Activity « santé du backup »** (ActivityKit + extension widget). NB : l'app a déjà une Live Activity PhotoSync qui couvre la sauvegarde en cours.

## Validation
`build_macos` (arm64) : **SUCCEEDED, 0 erreur**.