### PR TITLE
fix(player): vidéo qui tourne en boucle de buffering (throttle réseau étranglait le flux)

### DIFF
--- a/Rclone GUI/Views/Player/MediaPlayerView.swift
+++ b/Rclone GUI/Views/Player/MediaPlayerView.swift
@@ -284,7 +284,15 @@ struct MediaPlayerHost: View {
             }
         }
         .task(id: index) { await prepare() }
+        .onAppear {
+            // CRITIQUE : le streaming passe par le même process rclone, donc le
+            // throttle d'activité utilisateur (512 Ko/s) étranglerait le flux et
+            // ferait tourner la vidéo en boucle de buffering. On bypass le
+            // throttle pendant toute la lecture (comme l'écran Transferts).
+            TransferQueue.shared.incrementActivityBypass()
+        }
         .onDisappear {
+            TransferQueue.shared.decrementActivityBypass()
             stopCurrentSession()
             NowPlayingService.shared.endPlaybackSession()
         }


### PR DESCRIPTION
## Symptôme
La vidéo se lance mais **tourne en boucle de buffering** et le lecteur devient irresponsive (« on ne peut rien faire »).

## Cause racine
Le streaming média passe par `RclonebridgeStartFileHTTP` — le **même process rclone** que les transferts. Le `core/bwlimit` est process-wide. L'`UserActivityMonitor` bride automatiquement la bande passante à **512 Ko/s** dès qu'on touche l'écran (pour fluidifier la navigation pendant la sync). 512 Ko/s ≈ 4 Mbit/s = **insuffisant pour un film** → le flux s'étrangle, AVPlayer/VLC tombe en buffer underrun et boucle.

Visible dans les logs : `core/bwlimit {"rate":"off"}` ↔ `{"rate":"524288b"}` en va-et-vient pendant la lecture.

## Correctif
`MediaPlayerHost` incrémente `incrementActivityBypass()` à l'apparition et `decrementActivityBypass()` à la fermeture — le pattern **déjà utilisé** par l'écran Transferts et la sync photo pour échapper au throttle. Pendant la lecture vidéo, la bande passante reste au plafond utilisateur. L'audio garde le throttle (512 Ko/s suffit largement).

Build macOS : SUCCEEDED, 0 erreur. À valider sur device.