### PR TITLE
fix(folders): pull-to-refresh force un listing frais (vide le cache d'Fs rclone)

### DIFF
--- a/Rclone GUI/Services/RemoteService.swift
+++ b/Rclone GUI/Services/RemoteService.swift
@@ -85,6 +85,17 @@ public actor RemoteService {
         }
     }
 
+    /// Force rclone à recréer ses objets `Fs` (vide le cache d'Fs global via
+    /// `fscache/clear`). À appeler sur un pull-to-refresh EXPLICITE pour
+    /// garantir le listing le plus frais possible : certains backends gardent
+    /// un cache de répertoires en mémoire sur l'Fs (ex. Drive) et ne reflètent
+    /// pas immédiatement un changement fait ailleurs. Best-effort (no-op si la
+    /// RC n'existe pas). N'interrompt PAS un flux média en cours : le serve
+    /// loopback garde sa propre référence forte d'Fs.
+    public func invalidateListingCache() async {
+        _ = try? await RcloneCore.shared.rpcRaw("fscache/clear", "{}")
+    }
+
     // MARK: List folder
 
     /// List the entries inside `<remote>:<path>` via `operations/list`.

--- a/Rclone GUI/Views/Folders/FolderView.swift
+++ b/Rclone GUI/Views/Folders/FolderView.swift
@@ -235,7 +235,7 @@ struct FolderView: View {
                 activeTransferByPath = computeActiveTransferByPath()
             }
             .refreshable {
-                await load()
+                await load(forceFresh: true)
             }
             .safeAreaInset(edge: .bottom) {
                 if selectionMode {
@@ -912,7 +912,13 @@ struct FolderView: View {
         return (path as NSString).lastPathComponent
     }
 
-    private func load() async {
+    private func load(forceFresh: Bool = false) async {
+        // Pull-to-refresh explicite : on vide d'abord le cache d'Fs rclone pour
+        // forcer un listing réellement frais (un changement fait ailleurs n'est
+        // sinon pas garanti d'apparaître si le backend cache ses répertoires).
+        if forceFresh {
+            await RemoteService.shared.invalidateListingCache()
+        }
         loadState = .loading
         do {
             entries = try await RemoteService.shared.list(remote: remote, path: path)


### PR DESCRIPTION
Le pull-to-refresh ne reflétait pas toujours un changement fait ailleurs. Côté app : aucun cache (operations/list est live). La staleness vient du cache d'`Fs` rclone (et du cache de répertoires de certains backends comme Drive). Le refresh explicite appelle maintenant `fscache/clear` avant de relister. Best-effort, sans impact sur un flux média en cours. Build macOS SUCCEEDED. NB : pour un backend qui liste déjà en direct (SFTP/WebDAV), une staleness résiduelle serait côté serveur (consistance éventuelle).