### PR TITLE
fix(audio): AVAudioSession.setActive hors du main thread (évite le hang UI)

### DIFF
--- a/Rclone GUI/Services/NowPlayingService.swift
+++ b/Rclone GUI/Services/NowPlayingService.swift
@@ -46,14 +46,23 @@ final class NowPlayingService {
         artwork = nil
         let session = AVAudioSession.sharedInstance()
         let mode: AVAudioSession.Mode = isVideo ? .moviePlayback : .default
+        // setCategory est rapide et doit être posé AVANT play() (détermine le
+        // comportement du switch silencieux) → on le garde synchrone.
         try? session.setCategory(.playback, mode: mode, options: [])
-        try? session.setActive(true, options: [])
+        // setActive fait un IPC bloquant avec mediaserverd → hors du main thread
+        // pour ne pas figer l'UI (cf. avertissement AVAudioSession_iOS.mm:975).
+        Task.detached {
+            try? AVAudioSession.sharedInstance().setActive(true, options: [])
+        }
     }
 
     func endPlaybackSession() {
         removeRemoteCommands()
         clearNowPlaying()
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        // Désactivation hors du main thread (IPC bloquant — même raison que begin).
+        Task.detached {
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        }
     }
 
     /// Comme `removeRemoteCommands` mais sans désactiver la session audio :


### PR DESCRIPTION
L'avertissement `AVAudioSession_iOS.mm:975` signale que `setActive` sur le main thread peut figer l'UI (IPC bloquant avec mediaserverd). `NowPlayingService` étant @MainActor, begin/endPlaybackSession l'appelaient sur le main thread. `setActive(true/false)` passe désormais dans un `Task.detached` ; `setCategory` reste synchrone (rapide, doit précéder play()). Build macOS SUCCEEDED.