### PR TITLE
fix(player): buffer réseau VLC 1s→3s (saccades sur 4K/gros débits)

### DIFF
--- a/Rclone GUI/Views/Player/VLCPlayerView.swift
+++ b/Rclone GUI/Views/Player/VLCPlayerView.swift
@@ -24,7 +24,11 @@ import VLCKitSPM
 /// VLCKit délivre ses callbacks de délégué sur le thread principal, donc les
 /// mutations de `@Published` y sont sûres.
 final class VLCPlayerModel: NSObject, ObservableObject {
-    let player = VLCMediaPlayer()
+    // network-caching relevé à 3 s (défaut VLC = 1 s). Le flux arrive du bridge
+    // loopback alimenté en SFTP (débit variable) ; un buffer plus large absorbe
+    // la gigue et supprime les saccades sur les gros débits (ex. WEBRip 4K) —
+    // le décodage 4K HEVC est matériel (VideoToolbox), le goulot est le réseau.
+    let player = VLCMediaPlayer(options: ["--network-caching=3000"])
 
     @Published var isPlaying = false
     @Published var isBuffering = true


### PR DESCRIPTION
Le `VLCMediaPlayer` était initialisé sans options → `network-caching` au défaut (1s), insuffisant pour un WEBRip 4K servi par un flux SFTP au débit variable → saccades/glitch/démarrage difficile. Relevé à 3s (`--network-caching=3000`) pour absorber la gigue. Décodage 4K = matériel (VideoToolbox), le goulot était le buffer. Build macOS SUCCEEDED (VLCKit compile sur macOS). À valider sur device.