### PR TITLE
feat(player): buffers gonflés pour la fiabilité 4K (jalon 1 refonte lecteur)

### DIFF
--- a/Rclone GUI/Views/Player/MediaPlayerView.swift
+++ b/Rclone GUI/Views/Player/MediaPlayerView.swift
@@ -60,7 +60,7 @@ struct MediaPlayerView: UIViewControllerRepresentable {
             item.extendedLanguageTag = "und"
             player.currentItem?.externalMetadata = [item]
         }
-        player.currentItem?.preferredForwardBufferDuration = 2.0
+        player.currentItem?.preferredForwardBufferDuration = 30.0
 
         context.coordinator.attach(to: player)
         player.play()
@@ -199,7 +199,7 @@ struct MediaPlayerView: View {
             .onAppear {
                 let p = AVPlayer(url: url)
                 p.automaticallyWaitsToMinimizeStalling = true
-                p.currentItem?.preferredForwardBufferDuration = 2.0
+                p.currentItem?.preferredForwardBufferDuration = 30.0
                 player = p
                 if let resume = PlaybackProgressStore.resumePosition(remote: remote, path: path), resume > 1 {
                     // Attendre que l'item soit prêt avant de seek, sinon

--- a/Rclone GUI/Views/Player/VLCPlayerView.swift
+++ b/Rclone GUI/Views/Player/VLCPlayerView.swift
@@ -24,11 +24,11 @@ import VLCKitSPM
 /// VLCKit délivre ses callbacks de délégué sur le thread principal, donc les
 /// mutations de `@Published` y sont sûres.
 final class VLCPlayerModel: NSObject, ObservableObject {
-    // network-caching relevé à 3 s (défaut VLC = 1 s). Le flux arrive du bridge
-    // loopback alimenté en SFTP (débit variable) ; un buffer plus large absorbe
-    // la gigue et supprime les saccades sur les gros débits (ex. WEBRip 4K) —
-    // le décodage 4K HEVC est matériel (VideoToolbox), le goulot est le réseau.
-    let player = VLCMediaPlayer(options: ["--network-caching=3000"])
+    // network-caching relevé à 8 s (défaut VLC = 1 s). Le flux arrive du bridge
+    // loopback alimenté en SFTP (débit variable) ; un buffer large absorbe la
+    // gigue et supprime les saccades sur les gros débits (ex. WEBRip 4K) — le
+    // décodage 4K HEVC est matériel (VideoToolbox), le goulot est le réseau.
+    let player = VLCMediaPlayer(options: ["--network-caching=8000"])
 
     @Published var isPlaying = false
     @Published var isBuffering = true


### PR DESCRIPTION
Premier jalon de la refonte lecteur, faible risque : AVPlayer `preferredForwardBufferDuration` 2s→30s + VLC `network-caching` 3s→8s. Absorbe la gigue réseau sur les gros débits 4K. Build macOS SUCCEEDED. À valider sur device (si le démarrage devient trop lent, on ajustera).