### PR TITLE
fix(player): l'app ramait pendant « Télécharger pour lire »

### DIFF
--- a/Rclone GUI/Services/MediaCacheService.swift
+++ b/Rclone GUI/Services/MediaCacheService.swift
@@ -59,6 +59,14 @@ public actor MediaCacheService {
             try? evictIfNeeded(reservingBytes: sizeHint)
         }
 
+        // Le téléchargement bypasse le throttle d'activité utilisateur : sinon
+        // l'UserActivityMonitor le bride à 512 Ko/s dès qu'on touche l'écran (un
+        // gros fichier mettrait des heures) ET le va-et-vient core/bwlimit ajoute
+        // des RPC lentes qui font ramer l'app. Le streaming partage le process
+        // rclone, donc on évite toute contention superflue pendant le download.
+        await TransferQueue.shared.incrementActivityBypass()
+        defer { Task { await TransferQueue.shared.decrementActivityBypass() } }
+
         // Run rclone copyfile to land the file locally. Source = "<remote>:" with `path`,
         // destination = the cache parent dir (as local fs) with the cache filename.
         let jobID = try await TransferService.shared.copyFileAsync(
@@ -165,7 +173,10 @@ public actor MediaCacheService {
 
     private func waitForJob(jobID: Int) async throws {
         while !Task.isCancelled {
-            try await Task.sleep(for: .milliseconds(500))
+            // 2 s (et non 500 ms) : pendant un gros download rclone est saturé,
+            // chaque job/status met 1–4 s et un poll trop fréquent monopolise le
+            // bridge RPC → l'app rame. 2 s suffit largement pour un transfert long.
+            try await Task.sleep(for: .seconds(2))
             let info = try await TransferService.shared.jobStatus(jobID: jobID)
             if info.finished {
                 if info.success { return }

--- a/Rclone GUI/Views/Player/VLCPlayerView.swift
+++ b/Rclone GUI/Views/Player/VLCPlayerView.swift
@@ -156,6 +156,13 @@ final class VLCPlayerModel: NSObject, ObservableObject {
         player.stop()
     }
 
+    /// Arrête le flux en cours SANS retirer le delegate, pour pouvoir recharger
+    /// ensuite sur le fichier local. À appeler avant un téléchargement afin de
+    /// libérer rclone (sinon stream + download saturent le même process).
+    func haltForDownload() {
+        player.stop()
+    }
+
     private func refreshTracks() {
         let subIDs = (player.videoSubTitlesIndexes as? [NSNumber])?.map { $0.int32Value } ?? []
         let subNames = player.videoSubTitlesNames.map { String(describing: $0) }
@@ -503,6 +510,8 @@ struct EmbeddedVLCPlayerView: View {
         downloading = true
         downloadError = nil
         offerLocalDownload = false
+        // Libère rclone : on arrête le flux pour qu'il ne fasse QUE le download.
+        model.haltForDownload()
         Task {
             do {
                 let url = try await MediaCacheService.shared.localPlayableURL(


### PR DESCRIPTION
Logs device : pendant le download, job/status mettait 1–4s (poll 500ms saturait le bridge RPC), le download était bridé à 512 Ko/s (UserActivityMonitor) avec va-et-vient core/bwlimit, et le flux VLC streamait en parallèle. Fix : download bypasse le throttle (plein débit, plus de toggle bwlimit) + poll job/status 500ms→2s + haltForDownload du flux VLC avant le téléchargement. Build macOS SUCCEEDED.