### PR TITLE
fix(player): le download ne fige plus l'app (cède la bande passante à l'UI)

### DIFF
--- a/Rclone GUI/Services/MediaCacheService.swift
+++ b/Rclone GUI/Services/MediaCacheService.swift
@@ -59,13 +59,12 @@ public actor MediaCacheService {
             try? evictIfNeeded(reservingBytes: sizeHint)
         }
 
-        // Le téléchargement bypasse le throttle d'activité utilisateur : sinon
-        // l'UserActivityMonitor le bride à 512 Ko/s dès qu'on touche l'écran (un
-        // gros fichier mettrait des heures) ET le va-et-vient core/bwlimit ajoute
-        // des RPC lentes qui font ramer l'app. Le streaming partage le process
-        // rclone, donc on évite toute contention superflue pendant le download.
-        await TransferQueue.shared.incrementActivityBypass()
-        defer { Task { await TransferQueue.shared.decrementActivityBypass() } }
+        // IMPORTANT : on NE bypasse PAS le throttle d'activité ici. Le download
+        // partage le process rclone ; à plein débit il sature le bridge RPC et
+        // l'app FREEZE dès qu'on touche l'écran (la requête UI attend derrière le
+        // download). En laissant le throttle d'activité agir, le download CÈDE la
+        // bande passante dès qu'on interagit (bridé à 512 Ko/s le temps du geste,
+        // plein débit quand on regarde juste) → l'app reste fluide.
 
         // Run rclone copyfile to land the file locally. Source = "<remote>:" with `path`,
         // destination = the cache parent dir (as local fs) with the cache filename.


### PR DESCRIPTION
Le download plein débit (#65) saturait le bridge RPC rclone → freeze de l'UI dès qu'on interagit. Retrait du bypass de throttle : le download respecte le throttle d'activité → cède la bande passante quand on touche l'écran (512 Ko/s transitoire), plein débit quand on regarde. Build macOS SUCCEEDED.