### PR TITLE
fix(player): plafonne le débit du download vidéo (app fluide)

### DIFF
--- a/Rclone GUI/Services/MediaCacheService.swift
+++ b/Rclone GUI/Services/MediaCacheService.swift
@@ -25,6 +25,11 @@ public actor MediaCacheService {
     private static let maxSizeKey = "mediaCache.maxSizeBytes"
     private static let staleAfter: TimeInterval = 24 * 60 * 60
 
+    /// Plafond de débit appliqué pendant un téléchargement pour lecture (octets/s).
+    /// ~8 Mbit/s : laisse de la marge à rclone pour que l'app reste fluide (un
+    /// download plein débit le saturait et figeait l'UI). Ajustable.
+    static let mediaDownloadCapBytes: Int64 = 1_048_576
+
     public var maxSizeBytes: Int64 {
         let stored = UserDefaults.standard.object(forKey: Self.maxSizeKey) as? Int64
         return stored.flatMap { $0 > 0 ? $0 : nil } ?? Self.defaultMaxSizeBytes
@@ -59,12 +64,12 @@ public actor MediaCacheService {
             try? evictIfNeeded(reservingBytes: sizeHint)
         }
 
-        // IMPORTANT : on NE bypasse PAS le throttle d'activité ici. Le download
-        // partage le process rclone ; à plein débit il sature le bridge RPC et
-        // l'app FREEZE dès qu'on touche l'écran (la requête UI attend derrière le
-        // download). En laissant le throttle d'activité agir, le download CÈDE la
-        // bande passante dès qu'on interagit (bridé à 512 Ko/s le temps du geste,
-        // plein débit quand on regarde juste) → l'app reste fluide.
+        // Plafonne le débit du download le temps du transfert : un download plein
+        // débit sature le process rclone et FIGE l'app (même à l'inactivité, où le
+        // throttle d'activité repasse au ceiling utilisateur illimité). Le cap
+        // laisse de la marge → l'app reste fluide. Retiré à la fin (defer).
+        await TransferQueue.shared.setMediaDownloadCap(Self.mediaDownloadCapBytes)
+        defer { Task { await TransferQueue.shared.setMediaDownloadCap(0) } }
 
         // Run rclone copyfile to land the file locally. Source = "<remote>:" with `path`,
         // destination = the cache parent dir (as local fs) with the cache filename.

--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -941,6 +941,27 @@ public final class TransferQueue {
     /// regarde explicitement les transferts (il veut voir le débit réel).
     private var userActivityBypassCount: Int = 0
     private var isThrottlingForUserActivity = false
+    /// Dernière limite réellement appliquée (octets/s) — évite les RPC bwlimit
+    /// redondantes ET permet de réappliquer quand le cap média change sans que
+    /// l'état de throttle d'activité bouge.
+    private var lastAppliedBwlimit: Int64 = -1
+    /// Plafond de débit pendant un téléchargement vidéo (0 = pas de cap). Sans
+    /// lui, à l'inactivité le download repasse plein débit (ceiling utilisateur),
+    /// sature le process rclone et fige l'app. Avec, il reste plafonné en continu.
+    private var mediaDownloadCapBytes: Int64 = 0
+
+    /// Plafonne une limite « débit utilisateur » par le cap média s'il est actif.
+    private func clampToMediaCap(_ bytes: Int64) -> Int64 {
+        guard mediaDownloadCapBytes > 0 else { return bytes }
+        if bytes == 0 { return mediaDownloadCapBytes }   // 0 = illimité côté user
+        return min(bytes, mediaDownloadCapBytes)
+    }
+
+    /// Active (bytes>0) ou retire (0) le plafond de débit « téléchargement vidéo ».
+    public func setMediaDownloadCap(_ bytes: Int64) async {
+        mediaDownloadCapBytes = max(0, bytes)
+        await reevaluateUserActivityThrottle()
+    }
 
     public func incrementActivityBypass() {
         userActivityBypassCount += 1
@@ -963,20 +984,19 @@ public final class TransferQueue {
             // Ne throttle que si la valeur normale est >1MB/s (sinon useless)
             && (userPreferredBytes == 0 || userPreferredBytes > Self.userActivityThrottleBytes)
 
-        guard shouldThrottle != isThrottlingForUserActivity else { return }
+        // Limite effective : 512 Ko/s pendant l'interaction, sinon le ceiling
+        // utilisateur — MAIS plafonné par le cap « téléchargement vidéo » s'il est
+        // actif (sinon le download repasse plein débit à l'inactivité → fige l'app).
+        let target = shouldThrottle
+            ? Self.userActivityThrottleBytes
+            : clampToMediaCap(userPreferredBytes)
+
+        guard target != lastAppliedBwlimit else { return }
 
         do {
-            if shouldThrottle {
-                try await TransferService.shared.setBandwidthLimit(
-                    bytesPerSecond: Self.userActivityThrottleBytes
-                )
-                isThrottlingForUserActivity = true
-            } else {
-                try await TransferService.shared.setBandwidthLimit(
-                    bytesPerSecond: userPreferredBytes
-                )
-                isThrottlingForUserActivity = false
-            }
+            try await TransferService.shared.setBandwidthLimit(bytesPerSecond: target)
+            lastAppliedBwlimit = target
+            isThrottlingForUserActivity = shouldThrottle
         } catch {
             // Best effort : si la RPC bwlimit fail, on log mais on n'altère
             // pas le flag pour qu'un retry futur tente à nouveau.


### PR DESCRIPTION
Le retrait du bypass (#69) ne suffisait pas : à l'inactivité, le download repassait plein débit (ceiling illimité) → saturation → freeze. Ajout d'un cap 'téléchargement vidéo' (~8 Mbit/s) dans TransferQueue, appliqué en continu pendant le download (même à l'inactivité), retiré à la fin. Build macOS SUCCEEDED. Valeur ajustable si encore lent/freeze.