### PR TITLE
perf(engine): supprime le churn moteur au repos + limite de débit intelligente

### DIFF
--- a/Rclone GUI/Core/RcloneCore.swift
+++ b/Rclone GUI/Core/RcloneCore.swift
@@ -46,24 +46,38 @@ public actor RcloneCore {
 
     // MARK: - Raw RPC
 
+    /// Méthodes RPC à HAUTE FRÉQUENCE (polling) : leurs traces `→`/`←` noyaient
+    /// les logs ET coûtaient deux hops sur l'actor `LogService` + une allocation
+    /// de string à CHAQUE poll (500 ms job/status, 800 ms core/stats, bascule
+    /// bwlimit…), soit une charge CPU/énergie permanente pendant un transfert.
+    /// On saute la trace verbeuse pour elles — les erreurs restent loggées.
+    private static let quietPollingMethods: Set<String> = [
+        "job/status", "core/stats", "core/bwlimit", "core/version",
+    ]
+
     /// Send a raw RPC call. Lazily initializes the engine on first use.
     public func rpcRaw(_ method: String, _ inputJSON: String = "{}") async throws -> String {
         try await ensureInit()
         let started = Date()
-        let inputPreview = inputJSON.count > 200 ? String(inputJSON.prefix(200)) + "…" : inputJSON
-        await LogService.shared.log(
-            .debug,
-            category: "rpc",
-            message: "→ \(method) input=\(inputPreview)"
-        )
-        do {
-            let result = try await engine.rpcRaw(method: method, inputJSON: inputJSON)
-            let ms = Int(Date().timeIntervalSince(started) * 1000)
+        let verbose = !Self.quietPollingMethods.contains(method)
+        if verbose {
+            let inputPreview = inputJSON.count > 200 ? String(inputJSON.prefix(200)) + "…" : inputJSON
             await LogService.shared.log(
                 .debug,
                 category: "rpc",
-                message: "← \(method) ok in \(ms)ms (\(result.count) bytes)"
+                message: "→ \(method) input=\(inputPreview)"
             )
+        }
+        do {
+            let result = try await engine.rpcRaw(method: method, inputJSON: inputJSON)
+            if verbose {
+                let ms = Int(Date().timeIntervalSince(started) * 1000)
+                await LogService.shared.log(
+                    .debug,
+                    category: "rpc",
+                    message: "← \(method) ok in \(ms)ms (\(result.count) bytes)"
+                )
+            }
             return result
         } catch {
             let ms = Int(Date().timeIntervalSince(started) * 1000)

--- a/Rclone GUI/Services/PhotoSyncService.swift
+++ b/Rclone GUI/Services/PhotoSyncService.swift
@@ -547,6 +547,11 @@ public final class PhotoSyncService: NSObject, PHPhotoLibraryChangeObserver {
     private func heartbeatTick() async {
         guard isEnabled, configuredRemote != nil else { return }
         guard !isSyncing else { return }
+        // Rien à relancer si l'utilisateur a mis la sync en pause, ou si la
+        // politique énergie/réseau la bloque : sans ce garde, le battement (15 s)
+        // appelait quand même runSync qui ne faisait que logguer « ignorée :
+        // pause » à chaque fois — réveils + logs inutiles (ex. 18 556 en attente).
+        guard !isPausedByUser, canStartNewWork else { return }
 
         // First, recycle any asset whose Transfer counterpart is terminal or
         // missing — these would otherwise inflate `active` and block the
@@ -2156,9 +2161,14 @@ public final class PhotoSyncService: NSObject, PHPhotoLibraryChangeObserver {
     private func scheduleVerification(for localIdentifier: String, paths: [String]) {
         guard let remote = configuredRemote, !paths.isEmpty else { return }
         Task.detached(priority: .utility) { [weak self] in
+            guard let self else { return }
+            // Copie locale immuable : évite que les closures @Sendable de
+            // MainActor.run capturent la liaison `self` (vue comme mutable en
+            // Swift 6, ce qui déclenche un warning de capture concurrente).
+            let service = self
             // 1) Snapshot du localHash sur MainActor (lecture SwiftData)
             let localHash: String? = await MainActor.run {
-                guard let modelContext = self?.modelContext else { return nil }
+                guard let modelContext = service.modelContext else { return nil }
                 let descriptor = FetchDescriptor<PhotoSyncAsset>(
                     predicate: #Predicate { $0.localIdentifier == localIdentifier }
                 )
@@ -2172,7 +2182,7 @@ public final class PhotoSyncService: NSObject, PHPhotoLibraryChangeObserver {
             )
             // 3) Write SwiftData (MainActor)
             await MainActor.run {
-                guard let self, let modelContext = self.modelContext else { return }
+                guard let modelContext = service.modelContext else { return }
                 let descriptor = FetchDescriptor<PhotoSyncAsset>(
                     predicate: #Predicate { $0.localIdentifier == localIdentifier }
                 )

--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -48,6 +48,7 @@ public final class TransferQueue {
         self.modelContext = modelContext
         Task { await replayInterrupted() }
         startStatsPolling()
+        startEnergyObservers()
     }
 
     // MARK: - Enqueue API
@@ -978,18 +979,24 @@ public final class TransferQueue {
     /// d'activité change. Throttle vers 1MB/s pendant la nav, restaure
     /// le ceiling utilisateur après inactivité.
     public func applyThrottleForUserActivity(isActive: Bool, userPreferredBytes: Int64) async {
+        // Y a-t-il quelque chose à throttler ? Si AUCUN transfert ne tourne et
+        // qu'il n'y a pas de cap média, toucher au bwlimit pendant la simple
+        // navigation ne sert à rien et générait une rafale de core/bwlimit
+        // (off↔512K↔1M à chaque tap) — pur gaspillage CPU/énergie. On s'abstient.
+        let hasThrottleableWork = mediaDownloadCapBytes > 0 || anyRunningTransfer()
+
         let shouldThrottle = isActive
+            && hasThrottleableWork
             && !isPausedGlobally
             && userActivityBypassCount == 0
-            // Ne throttle que si la valeur normale est >1MB/s (sinon useless)
+            // Ne throttle que si la valeur normale est >512KB/s (sinon useless)
             && (userPreferredBytes == 0 || userPreferredBytes > Self.userActivityThrottleBytes)
 
-        // Limite effective : 512 Ko/s pendant l'interaction, sinon le ceiling
-        // utilisateur — MAIS plafonné par le cap « téléchargement vidéo » s'il est
-        // actif (sinon le download repasse plein débit à l'inactivité → fige l'app).
-        let target = shouldThrottle
-            ? Self.userActivityThrottleBytes
-            : clampToMediaCap(userPreferredBytes)
+        // Limite effective : 512 Ko/s pendant l'interaction, sinon le plafond
+        // « intelligent » (réduit sous pression thermique / mode éco) — lui-même
+        // borné par le cap « téléchargement vidéo » s'il est actif.
+        let ceiling = clampToMediaCap(smartCeiling(userPreferredBytes))
+        let target = shouldThrottle ? Self.userActivityThrottleBytes : ceiling
 
         guard target != lastAppliedBwlimit else { return }
 
@@ -1009,12 +1016,62 @@ public final class TransferQueue {
     }
 
     private func reevaluateUserActivityThrottle() async {
-        // Réajuste après changement de bypass count : on relit la prefs
-        // depuis UserDefaults et on aligne sur l'état actif courant.
+        // Réajuste après changement de bypass count / pression énergie : on relit
+        // la prefs depuis UserDefaults et on aligne sur l'état actif courant.
         let mbps = UserDefaults.standard.double(forKey: "transfer.bandwidthLimitMBps")
         let bytes = Int64(mbps * 1024 * 1024)
         let isActive = UserActivityMonitor.shared.isUserActive
         await applyThrottleForUserActivity(isActive: isActive, userPreferredBytes: bytes)
+    }
+
+    /// Y a-t-il au moins un transfert `.running` ? Borné à 1 (fetchCount) pour
+    /// rester quasi gratuit même appelé sur chaque évènement d'activité.
+    private func anyRunningTransfer() -> Bool {
+        guard let modelContext else { return false }
+        var descriptor = FetchDescriptor<Transfer>(
+            predicate: #Predicate { $0.statusRaw == "running" }
+        )
+        descriptor.fetchLimit = 1
+        return ((try? modelContext.fetchCount(descriptor)) ?? 0) > 0
+    }
+
+    /// Plafond « intelligent » du débit : réduit la limite sous pression
+    /// thermique ou en mode économie d'énergie pour rester fluide et économe.
+    /// Ne fait que BAISSER une limite (jamais l'augmenter) et seulement sous
+    /// pression réelle — au repos thermique, renvoie la préférence inchangée.
+    /// `bytes == 0` = illimité côté utilisateur ; renvoie alors le cap s'il y en a un.
+    private func smartCeiling(_ userPreferredBytes: Int64) -> Int64 {
+        let info = ProcessInfo.processInfo
+        var cap: Int64 = 0   // 0 = aucune contrainte
+        if info.isLowPowerModeEnabled { cap = 2 * 1_048_576 }              // 2 MB/s en mode éco
+        switch info.thermalState {
+        case .serious:  cap = cap == 0 ? 1_048_576 : min(cap, 1_048_576)   // 1 MB/s si ça chauffe
+        case .critical: cap = cap == 0 ? 524_288 : min(cap, 524_288)       // 0,5 MB/s si critique
+        default: break
+        }
+        guard cap > 0 else { return userPreferredBytes }
+        return userPreferredBytes == 0 ? cap : min(userPreferredBytes, cap)
+    }
+
+    /// Réagit aux changements d'état thermique / mode éco pour relever ou
+    /// rabaisser le plafond intelligent sans attendre la prochaine interaction.
+    private var energyObserversInstalled = false
+    private func startEnergyObservers() {
+        guard !energyObserversInstalled else { return }
+        energyObserversInstalled = true
+        let names: [Notification.Name] = [
+            ProcessInfo.thermalStateDidChangeNotification,
+            .NSProcessInfoPowerStateDidChange,
+        ]
+        for name in names {
+            NotificationCenter.default.addObserver(
+                forName: name, object: nil, queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    await self?.reevaluateUserActivityThrottle()
+                }
+            }
+        }
     }
 
     /// Cold-start handler: re-applies the persisted pause/bwlimit state to
@@ -1210,21 +1267,24 @@ public final class TransferQueue {
         guard statsTask == nil else { return }
         statsTask = Task { [weak self] in
             while !Task.isCancelled {
-                await self?.tickStats()
-                try? await Task.sleep(for: .milliseconds(800))
+                let hadWork = await self?.tickStats() ?? false
+                // Réveil rapide (800 ms) seulement quand un transfert tourne ;
+                // sinon backoff à 3 s → ~3,75× moins de réveils au repos (énergie).
+                try? await Task.sleep(for: hadWork ? .milliseconds(800) : .seconds(3))
             }
         }
     }
 
-    private func tickStats() async {
-        guard let modelContext else { return }
+    @discardableResult
+    private func tickStats() async -> Bool {
+        guard let modelContext else { return false }
         let descriptor = FetchDescriptor<Transfer>(
             predicate: #Predicate { $0.statusRaw == "running" }
         )
         guard let running = try? modelContext.fetch(descriptor), !running.isEmpty else {
-            return
+            return false
         }
-        guard let stats = try? await TransferService.shared.coreStats() else { return }
+        guard let stats = try? await TransferService.shared.coreStats() else { return false }
 
         // core/stats reports per-file under `transferring`, keyed by the destination basename.
         // We do best-effort matching. Dirty flag : on évite save() si rien
@@ -1247,6 +1307,7 @@ public final class TransferQueue {
         if didMutate || batchesChanged {
             try? modelContext.save()
         }
+        return true
     }
 
     private func statMatchesTransfer(_ stat: CoreStatsDTO.Transferring, transfer: Transfer) -> Bool {


### PR DESCRIPTION
## Objectif
Optimiser tout le moteur rclone iOS : **plus rapide, plus économe en énergie, anti-freeze**, avec une limite de téléchargement **intelligente**. Batch sûr & à fort impact (le driver principal du freeze — download complet — est déjà réglé en #72).

## Causes racines attaquées (lecture du code + logs device)
1. **Chaque RPC** loggait 2× via l'actor `LogService` (`→`/`←`), y compris les polls 500/800 ms → CPU/énergie permanent + logs noyés.
2. **Thrash `core/bwlimit`** : la bascule d'activité changeait le débit **même sans transfert** (simple navigation) → rafale off↔512K↔1M (jusqu'à 746 ms/appel).
3. **Heartbeat photo-sync (15 s)** appelait `runSync` **même en pause** → « relance auto » puis « ignorée : pause » en boucle (18 556 en attente).
4. **`statsTask`** réveillait toutes les 800 ms en permanence, même à vide.
5. Limite fixe 512 Ko/s **non intelligente** (ignorait thermique / mode éco).

## Changements
- **RcloneCore.rpcRaw** : plus de traces `→`/`←` pour les RPC à haute fréquence (job/status, core/stats, core/bwlimit, core/version). Erreurs toujours loggées.
- **TransferQueue** : ne touche au `core/bwlimit` que s'il y a un transfert actif ou un cap média (`anyRunningTransfer()`) → fin du thrash en navigation.
- **TransferQueue** : `smartCeiling` — plafond intelligent réduit sous pression thermique (.serious→1 MB/s, .critical→0,5 MB/s) et en mode éco (2 MB/s) ; observe `thermalStateDidChange` + `NSProcessInfoPowerStateDidChange`.
- **TransferQueue** : `statsTask` backoff 800 ms→3 s au repos (~3,75× moins de réveils).
- **PhotoSyncService.heartbeatTick** : court-circuit si en pause / politique énergie-réseau bloquante.

## Suite (à valider sur device, non incluse ici)
Exécuteur CGo **borné** (cap de concurrence sur `RclonebridgeRPC` au lieu de `DispatchQueue.global` illimité) = garantie anti-freeze en rafale. Touche le hot-path de chaque RPC → mérite sa propre validation device.

## Validation
`build_macos` : **SUCCEEDED**, 0 erreur, 0 warning.