### PR TITLE
feat(player): download-ahead progressif (précharge 1 min, lit en local, continue de télécharger)

### DIFF
--- a/Rclone GUI/Services/MediaCacheService.swift
+++ b/Rclone GUI/Services/MediaCacheService.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 import AVFoundation
+import Network
 
 public actor MediaCacheService {
     public static let shared = MediaCacheService()
@@ -246,5 +247,259 @@ public actor MediaCacheService {
             url = url.appendingPathExtension(ext)
         }
         return url
+    }
+}
+
+// MARK: - Cache progressif (download-ahead)
+
+/// Télécharge un média distant SÉQUENTIELLEMENT dans un fichier de cache local
+/// et le sert simultanément via un petit proxy HTTP loopback. Le lecteur (VLC)
+/// lit le proxy comme un fichier complet (`Content-Length` = taille totale) ;
+/// les octets pas encore téléchargés font patienter la connexion jusqu'à leur
+/// arrivée (avec un plafond de 10 s pour ne pas bloquer un seek hors-zone).
+///
+/// But : « précharge ~1 min puis lit en LOCAL pendant que le reste continue de
+/// se télécharger ». Comme le download est SÉQUENTIEL depuis le bridge (zéro
+/// re-seek SFTP) et plus rapide que la lecture temps-réel, le buffer ne se vide
+/// plus → fini les saccades, et les seeks dans la zone téléchargée sont
+/// instantanés (données locales). À la fin, le `.partial` devient le fichier de
+/// cache final (lecture instantanée à la prochaine ouverture).
+final class ProgressiveMediaCache: NSObject, @unchecked Sendable {
+    private let sourceURL: URL      // bridge loopback servant le fichier distant
+    private let partialURL: URL     // fichier local en cours de remplissage
+    private let finalURL: URL       // destination cache une fois complet
+    private let fileName: String    // pour donner l'extension au lecteur
+
+    private let lock = NSLock()
+    private var _available: Int64 = 0
+    private var _total: Int64 = -1
+    private enum DLState { case downloading, complete, failed }
+    private var _state: DLState = .downloading
+
+    private var session: URLSession?
+    private var task: URLSessionDataTask?
+    private var writeHandle: FileHandle?
+    private var listener: NWListener?
+    private let serverQueue = DispatchQueue(label: "rclone.progressivecache.server", attributes: .concurrent)
+    private var stopped = false
+
+    var available: Int64 { lock.lock(); defer { lock.unlock() }; return _available }
+    var total: Int64 { lock.lock(); defer { lock.unlock() }; return _total }
+    var isComplete: Bool { lock.lock(); defer { lock.unlock() }; return _state == .complete }
+    var isFailed: Bool { lock.lock(); defer { lock.unlock() }; return _state == .failed }
+
+    init(sourceURL: URL, finalURL: URL, fileName: String) {
+        self.sourceURL = sourceURL
+        self.finalURL = finalURL
+        self.partialURL = finalURL.appendingPathExtension("partial")
+        self.fileName = fileName
+        super.init()
+    }
+
+    /// Démarre le proxy + le téléchargement. Renvoie l'URL loopback à donner au
+    /// lecteur. Lève si le proxy ne peut pas démarrer (→ repli streaming direct).
+    func start() throws -> URL {
+        let fm = FileManager.default
+        try fm.createDirectory(at: partialURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if fm.fileExists(atPath: partialURL.path) { try? fm.removeItem(at: partialURL) }
+        fm.createFile(atPath: partialURL.path, contents: nil)
+        writeHandle = try FileHandle(forWritingTo: partialURL)
+
+        // Proxy HTTP loopback (port éphémère)
+        let params = NWParameters.tcp
+        params.requiredInterfaceType = .loopback
+        let listener = try NWListener(using: params, on: .any)
+        self.listener = listener
+        listener.newConnectionHandler = { [weak self] conn in
+            conn.start(queue: self?.serverQueue ?? .global())
+            self?.receiveRequest(conn, buffer: Data())
+        }
+        let ready = DispatchSemaphore(value: 0)
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready, .failed, .cancelled: ready.signal()
+            default: break
+            }
+        }
+        listener.start(queue: serverQueue)
+        _ = ready.wait(timeout: .now() + 5)
+        guard let port = listener.port?.rawValue else {
+            listener.cancel()
+            throw RcloneError.rcloneError(code: -1, method: "progressivecache", message: "proxy loopback indisponible")
+        }
+
+        // Téléchargement séquentiel depuis le bridge (un seul GET, pas de re-seek)
+        let config = URLSessionConfiguration.default
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.timeoutIntervalForRequest = 60
+        let session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+        self.session = session
+        var req = URLRequest(url: sourceURL)
+        req.setValue("bytes=0-", forHTTPHeaderField: "Range")
+        let task = session.dataTask(with: req)
+        self.task = task
+        task.resume()
+
+        let encodedName = fileName.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? "media"
+        return URL(string: "http://127.0.0.1:\(port)/\(encodedName)")!
+    }
+
+    /// Attend que `bytes` octets soient disponibles (précharge), ou que le
+    /// téléchargement se termine/échoue.
+    func waitForPrefill(bytes: Int64) async {
+        while !Task.isCancelled {
+            if isFailed || isComplete { return }
+            let avail = available
+            if avail >= bytes { return }
+            let t = total
+            if t >= 0 && avail >= t { return }
+            try? await Task.sleep(for: .milliseconds(150))
+        }
+    }
+
+    func stop() {
+        lock.lock(); let wasStopped = stopped; stopped = true; let complete = _state == .complete; lock.unlock()
+        guard !wasStopped else { return }
+        task?.cancel(); task = nil
+        session?.invalidateAndCancel(); session = nil
+        listener?.cancel(); listener = nil
+        try? writeHandle?.close(); writeHandle = nil
+        let fm = FileManager.default
+        if complete {
+            // partial → final : cache hit à la prochaine ouverture.
+            try? fm.removeItem(at: finalURL)
+            try? fm.moveItem(at: partialURL, to: finalURL)
+        } else {
+            // Incomplet : NE PAS le laisser passer pour un cache complet.
+            try? fm.removeItem(at: partialURL)
+        }
+    }
+
+    // MARK: Serveur HTTP loopback
+
+    private func receiveRequest(_ conn: NWConnection, buffer: Data) {
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { conn.cancel(); return }
+            var buf = buffer
+            if let data { buf.append(data) }
+            if let r = buf.range(of: Data("\r\n\r\n".utf8)) {
+                let head = String(decoding: buf.subdata(in: buf.startIndex..<r.lowerBound), as: UTF8.self)
+                self.respond(conn, head: head, attempt: 0)
+                return
+            }
+            if error != nil || isComplete || buf.count > 64 * 1024 { conn.cancel(); return }
+            self.receiveRequest(conn, buffer: buf)
+        }
+    }
+
+    private func respond(_ conn: NWConnection, head: String, attempt: Int) {
+        // La taille totale n'est connue qu'après la 1re réponse du bridge :
+        // on patiente brièvement (non bloquant) si besoin.
+        if total < 0 {
+            if isFailed || attempt > 200 { sendStatus(conn, "503 Service Unavailable"); return }
+            serverQueue.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.respond(conn, head: head, attempt: attempt + 1)
+            }
+            return
+        }
+        let totalBytes = total
+        guard totalBytes > 0 else { sendStatus(conn, "503 Service Unavailable"); return }
+
+        var start: Int64 = 0
+        var end: Int64 = totalBytes - 1
+        for line in head.split(separator: "\r\n") where line.lowercased().hasPrefix("range:") {
+            let spec = line.drop(while: { $0 != "=" }).dropFirst()
+            let parts = spec.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+            if let s = parts.first, let v = Int64(s.trimmingCharacters(in: .whitespaces)) { start = v }
+            if parts.count > 1, let e = Int64(parts[1].trimmingCharacters(in: .whitespaces)) { end = min(e, totalBytes - 1) }
+        }
+        start = max(0, min(start, totalBytes - 1))
+        if end < start { end = totalBytes - 1 }
+        let length = end - start + 1
+
+        var header = "HTTP/1.1 206 Partial Content\r\n"
+        header += "Content-Type: application/octet-stream\r\n"
+        header += "Accept-Ranges: bytes\r\n"
+        header += "Content-Length: \(length)\r\n"
+        header += "Content-Range: bytes \(start)-\(end)/\(totalBytes)\r\n"
+        header += "Connection: close\r\n\r\n"
+        conn.send(content: Data(header.utf8), completion: .contentProcessed { [weak self] err in
+            guard let self, err == nil else { conn.cancel(); return }
+            guard let readHandle = try? FileHandle(forReadingFrom: self.partialURL) else { conn.cancel(); return }
+            self.pump(conn, readHandle, pos: start, end: end, waited: 0)
+        })
+    }
+
+    /// Envoie les octets [pos, end] par chunks, en patientant (non bloquant) que
+    /// le téléchargement atteigne `pos`. Plafond d'attente 10 s → un seek dans une
+    /// zone pas encore téléchargée échoue proprement au lieu de bloquer.
+    private func pump(_ conn: NWConnection, _ readHandle: FileHandle, pos: Int64, end: Int64, waited: Double) {
+        if pos > end { try? readHandle.close(); conn.cancel(); return }
+        let avail = available
+        if avail <= pos {
+            if isFailed || isComplete || waited > 10 { try? readHandle.close(); conn.cancel(); return }
+            serverQueue.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.pump(conn, readHandle, pos: pos, end: end, waited: waited + 0.05)
+            }
+            return
+        }
+        let chunkEnd = min(end, avail - 1)
+        let want = Int(min(chunkEnd - pos + 1, 256 * 1024))
+        try? readHandle.seek(toOffset: UInt64(pos))
+        let data = (try? readHandle.read(upToCount: want)) ?? Data()
+        if data.isEmpty {
+            serverQueue.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.pump(conn, readHandle, pos: pos, end: end, waited: waited + 0.05)
+            }
+            return
+        }
+        conn.send(content: data, completion: .contentProcessed { [weak self] err in
+            guard let self, err == nil else { try? readHandle.close(); conn.cancel(); return }
+            self.pump(conn, readHandle, pos: pos + Int64(data.count), end: end, waited: 0)
+        })
+    }
+
+    private func sendStatus(_ conn: NWConnection, _ status: String) {
+        let header = "HTTP/1.1 \(status)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        conn.send(content: Data(header.utf8), completion: .contentProcessed { _ in conn.cancel() })
+    }
+}
+
+extension ProgressiveMediaCache: URLSessionDataDelegate {
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        let len = response.expectedContentLength
+        lock.lock(); if _total < 0, len > 0 { _total = len }; lock.unlock()
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        lock.lock()
+        let stopped = stopped
+        lock.unlock()
+        guard !stopped else { return }
+        // Écrit sur disque PUIS publie le nouveau disponible (les lecteurs ne
+        // lisent jamais au-delà de `_available` = octets garantis écrits).
+        do {
+            try writeHandle?.write(contentsOf: data)
+        } catch {
+            lock.lock(); _state = .failed; lock.unlock()
+            return
+        }
+        lock.lock(); _available += Int64(data.count); lock.unlock()
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        try? writeHandle?.synchronize()
+        lock.lock()
+        if let error {
+            // L'annulation volontaire (stop) n'est pas un échec à reporter.
+            if (error as NSError).code != NSURLErrorCancelled { _state = .failed }
+        } else {
+            _state = .complete
+            if _total < 0 { _total = _available }
+        }
+        lock.unlock()
     }
 }

--- a/Rclone GUI/Views/Player/VLCPlayerView.swift
+++ b/Rclone GUI/Views/Player/VLCPlayerView.swift
@@ -435,6 +435,10 @@ struct EmbeddedVLCPlayerView: View {
     @State private var playingLocal = false
     @State private var bufferingSince: Date?
     @State private var offerLocalDownload = false
+    // Cache progressif (download-ahead) : précharge ~1 min puis lit en LOCAL
+    // pendant que le reste se télécharge → fini les saccades SFTP, seeks instantanés.
+    @State private var progressive: ProgressiveMediaCache?
+    private static let prefillBytes: Int64 = 24 * 1024 * 1024   // ~1 min à ~3,2 Mbit/s
 
     private let speeds: [Float] = [0.5, 1.0, 1.25, 1.5, 2.0]
 
@@ -493,12 +497,9 @@ struct EmbeddedVLCPlayerView: View {
                 playingLocal = true
                 model.load(url: cached, startAtSeconds: resume)
             } else {
-                // Streaming : on surveille la santé du flux. S'il ne tient pas le
-                // débit de façon soutenue (SFTP qui dip → saccade), bascule AUTO
-                // vers le téléchargement local capé (lecture parfaite, pas de freeze).
-                model.monitorsStreamHealth = true
-                model.onSustainedUnderrun = { downloadAndPlayLocal() }
-                model.load(url: streamURL, startAtSeconds: resume)
+                // Download-ahead : précharge ~1 min puis lit en LOCAL pendant que
+                // le reste se télécharge. Élimine la saccade SFTP (données locales).
+                await startProgressiveAndPlay(resume: resume)
             }
         }
         .onChange(of: model.positionSeconds) { _, newValue in
@@ -537,6 +538,11 @@ struct EmbeddedVLCPlayerView: View {
                 position: model.positionSeconds, duration: model.durationSeconds
             )
             model.stop()
+            // Arrête le proxy de cache progressif : si le fichier est complet, le
+            // .partial devient le cache final (lecture instantanée la prochaine
+            // fois) ; sinon il est supprimé (jamais pris pour un cache complet).
+            progressive?.stop()
+            progressive = nil
             // La session audio (et les commandes distantes) sont fermées par
             // MediaPlayerHost à la sortie complète, pas ici.
         }
@@ -610,6 +616,45 @@ struct EmbeddedVLCPlayerView: View {
     /// la lecture sur le fichier local — zéro seek, démux fluide. Réutilise le
     /// même VLCPlayerModel (la session de streaming est lâchée au changement de
     /// média). Le cache LRU MediaCache gère la rétention.
+    /// Download-ahead : démarre le proxy de cache progressif, précharge ~1 min,
+    /// puis lit en LOCAL (depuis le proxy loopback) pendant que le téléchargement
+    /// continue → seeks instantanés dans la zone téléchargée, zéro saccade SFTP.
+    /// Repli sur le streaming direct (+ moniteur de santé) si le proxy échoue.
+    private func startProgressiveAndPlay(resume: Double?) async {
+        let cacheURL = MediaCacheService.cacheURL(remote: remote, path: path)
+        let fileName = (path as NSString).lastPathComponent
+        let cache = ProgressiveMediaCache(sourceURL: streamURL, finalURL: cacheURL, fileName: fileName)
+        do {
+            let proxyURL = try cache.start()
+            progressive = cache
+            downloading = true   // overlay « préchargement »
+            await cache.waitForPrefill(bytes: Self.prefillBytes)
+            if Task.isCancelled { return }   // vue fermée pendant le préchargement
+            if cache.isFailed {
+                cache.stop()
+                progressive = nil
+                downloading = false
+                fallbackToStreaming(resume: resume)
+                return
+            }
+            downloading = false
+            playingLocal = true   // on lit en local (proxy) → pas de moniteur stream
+            model.load(url: proxyURL, startAtSeconds: resume)
+        } catch {
+            progressive = nil
+            downloading = false
+            fallbackToStreaming(resume: resume)
+        }
+    }
+
+    /// Repli : streaming direct depuis le bridge + moniteur qui bascule au
+    /// téléchargement complet si le débit ne tient pas.
+    private func fallbackToStreaming(resume: Double?) {
+        model.monitorsStreamHealth = true
+        model.onSustainedUnderrun = { downloadAndPlayLocal() }
+        model.load(url: streamURL, startAtSeconds: resume)
+    }
+
     private func downloadAndPlayLocal() {
         guard !downloading else { return }
         downloading = true


### PR DESCRIPTION
## Demande de Vitaly
« Télécharge 1 minute de vidéo puis lis et continue le téléchargement pendant la lecture » (modèle Infuse/Plex).

## Pourquoi
Le streaming pur sur SFTP a un **plafond** : après un seek, la livraison par à-coups ne tient pas le débit → buffer VLC vide → saccade. La seule façon d'avoir des **seeks instantanés + débit garanti**, c'est que les données soient **locales**.

## Implémentation — `ProgressiveMediaCache` (dans MediaCacheService)
- **Télécharge séquentiellement** depuis le bridge loopback (un seul GET, **zéro re-seek SFTP**) vers un `.partial` local, via URLSession (chemin sans freeze, cf. #71).
- **Sert en parallèle** via un proxy HTTP loopback (`NWListener`) : le lecteur voit un fichier **complet** (`Content-Length` = taille totale) ; les octets pas encore téléchargés font **patienter** la connexion (plafond 10 s → un seek hors-zone échoue proprement au lieu de bloquer).
- À la fin, le `.partial` devient le **cache final** (lecture instantanée ensuite). Incomplet → supprimé (jamais pris pour un cache complet).

## `VLCPlayerView`
- `startProgressiveAndPlay` : précharge `prefillBytes` (~24 Mo ≈ 1 min) → overlay « préchargement » → charge VLC sur l'URL du proxy ; le download **continue pendant la lecture**.
- Le download (séquentiel, plein débit) **dépasse** la lecture temps-réel → le buffer ne se vide plus, seeks instantanés dans la zone téléchargée.
- Repli sur streaming direct + moniteur de santé (#75) si le proxy ne démarre pas.
- Proxy arrêté à la fermeture (`.onDisappear`).

## Validation
`build_macos` : **SUCCEEDED**, 0 erreur, 0 warning. (Comportement runtime du proxy/NWListener à valider sur device.)