### PR TITLE
fix(fileprovider): auto-répare un domaine orphelin au boot (réapparaît dans Fichiers)

### DIFF
--- a/Rclone GUI/Services/FileProviderManager.swift
+++ b/Rclone GUI/Services/FileProviderManager.swift
@@ -57,11 +57,35 @@ public final class FileProviderManager {
                 message: "Domaine FileProvider enregistré : \(Self.domainIdentifier.rawValue)"
             )
         } catch {
+            // L'ajout a échoué — typiquement un domaine ORPHELIN laissé par une
+            // réinstallation Xcode (⇧⌘K + réinstall) : iOS garde une entrée
+            // incohérente et le domaine n'apparaît PLUS dans Fichiers, tandis que
+            // `add` est rejeté. On s'auto-répare : remove puis add, puis on
+            // réécrit le manifest + signale la racine pour que Fichiers ré-énumère.
             await LogService.shared.log(
-                .debug,
+                .error,
                 category: "fileprovider",
-                message: "Enregistrement FileProvider ignoré/échoué : \(error.localizedDescription)"
+                message: "Enregistrement FileProvider échoué (\(error.localizedDescription)) → récupération remove+add"
             )
+            do {
+                try? await NSFileProviderManager.remove(domain)
+                try await NSFileProviderManager.add(domain)
+                if let remotes = try? await RemoteService.shared.listRemoteSummaries() {
+                    await writeRemotesManifest(remotes)
+                }
+                signalRefresh(remote: "", path: "")
+                await LogService.shared.log(
+                    .info,
+                    category: "fileprovider",
+                    message: "Domaine FileProvider récupéré (remove+add) : \(Self.domainIdentifier.rawValue)"
+                )
+            } catch {
+                await LogService.shared.log(
+                    .error,
+                    category: "fileprovider",
+                    message: "Récupération FileProvider échouée : \(error.localizedDescription). Essaie : Réglages → Logs → « Réinitialiser Fichiers », ou supprime+réinstalle l'app."
+                )
+            }
         }
         #endif
     }


### PR DESCRIPTION
## Symptôme
« rclone gui n'apparaît plus dans Fichiers d'Apple. »

## Diagnostic
- **Pas une régression de mes commits récents** : aucun de #72–76 ne touche `RcloneFileProvider/` ni `FileProviderManager`. L'app tourne → l'extension compile (Xcode build l'extension embarquée avec l'app).
- Cause probable : **domaine FileProvider orphelin** côté iOS après réinstallations Xcode répétées (⇧⌘K + réinstall). `NSFileProviderManager.add` est alors rejeté et l'ancien `catch` se contentait d'un log `.debug` → domaine invisible.

## Correctif
`registerDomain()` s'**auto-répare** : si `add` échoue → `remove` puis `add`, réécriture du manifest des remotes + `signalRefresh` racine pour forcer Fichiers à ré-énumérer. Échec persistant → message d'aide.

## Remèdes immédiats (sans attendre ce build)
1. **Réglages → Logs → ⋯ → « Réinitialiser Fichiers »** (déjà présent : `resetDomain`).
2. Sinon : **supprimer l'app** du device puis réinstaller depuis Xcode.
3. Sinon : **redémarrer l'iPhone** (Fichiers re-scanne les providers).

## Validation
`build_macos` : **SUCCEEDED**, 0 erreur, 0 warning. (Extension iOS non compilable en local — pas de slice simulateur RcloneKit.)