### PR TITLE
feat(fileprovider): l'extension télécharge elle-même quand l'app n'est pas active

### DIFF
--- a/RcloneFileProvider/AppGroupBridge.swift
+++ b/RcloneFileProvider/AppGroupBridge.swift
@@ -240,6 +240,17 @@ public enum FileProviderBridge {
         )
     }
 
+    /// Clé userInfo marquant l'erreur « app principale non active » (relais sans
+    /// réponse). `fetchContents` s'en sert pour basculer sur un download DIRECT
+    /// dans l'extension (bridge + URLSession) au lieu d'échouer.
+    public static let appInactiveErrorKey = "fp.appInactive"
+
+    /// True si l'erreur du relais signifie « l'app principale n'a jamais répondu »
+    /// (suspendue/fermée) — cas où l'extension peut télécharger elle-même.
+    public static func errorMeansAppInactive(_ error: NSError) -> Bool {
+        (error.userInfo[appInactiveErrorKey] as? Bool) == true
+    }
+
     /// Délègue le téléchargement à l'app principale via App Group + Darwin notification.
     /// Une .appex iOS est limitée en mémoire (~256 Mo) et le combo Go runtime + librclone
     /// + déchiffrement crypt fait jetsam. L'app principale (1.5 Go RAM) gère ça sans souci.
@@ -330,7 +341,10 @@ public enum FileProviderBridge {
                 throw NSError(
                     domain: NSFileProviderErrorDomain,
                     code: NSFileProviderError.serverUnreachable.rawValue,
-                    userInfo: [NSLocalizedDescriptionKey: "Lancez Rclone GUI puis réessayez (l'app n'est pas active)."]
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Lancez Rclone GUI puis réessayez (l'app n'est pas active).",
+                        Self.appInactiveErrorKey: true,
+                    ]
                 )
             }
 

--- a/RcloneFileProvider/RcloneFileProvider.swift
+++ b/RcloneFileProvider/RcloneFileProvider.swift
@@ -207,29 +207,47 @@ public final class RcloneFileProvider: NSObject, NSFileProviderReplicatedExtensi
 
         Task {
             do {
-                // Délégation IPC vers l'app principale (Go runtime + crypt jetsam-able
-                // dans une .appex iOS limitée à ~256 Mo).
-                try await FileProviderBridge.requestFetchViaMainApp(
-                    requestID: requestID,
-                    remote: decoded.remote,
-                    path: decoded.path,
-                    destination: sharedDestination,
-                    progress: progress
-                )
-
-                // App principale a ecrit dans sharedDestination. On bouge le fichier
-                // vers Apple-managed tempDir avant de rendre la main a iOS.
-                try FileManager.default.createDirectory(
-                    at: appleDestination.deletingLastPathComponent(),
-                    withIntermediateDirectories: true
-                )
-                try? FileManager.default.removeItem(at: appleDestination)
+                var fileAlreadyAtApple = false
                 do {
-                    try FileManager.default.moveItem(at: sharedDestination, to: appleDestination)
-                } catch {
-                    // Volumes potentiellement differents : fallback copy + remove.
-                    try FileManager.default.copyItem(at: sharedDestination, to: appleDestination)
-                    try? FileManager.default.removeItem(at: sharedDestination)
+                    // Délégation IPC vers l'app principale (Go runtime + crypt jetsam-able
+                    // dans une .appex iOS limitée à ~256 Mo) — chemin préféré.
+                    try await FileProviderBridge.requestFetchViaMainApp(
+                        requestID: requestID,
+                        remote: decoded.remote,
+                        path: decoded.path,
+                        destination: sharedDestination,
+                        progress: progress
+                    )
+                } catch let relayError as NSError where FileProviderBridge.errorMeansAppInactive(relayError) {
+                    // App suspendue/fermée : elle ne répond pas au relais. L'extension
+                    // télécharge ALORS elle-même via le bridge loopback + URLSession
+                    // (streaming, faible mémoire) → Fichiers marche sans ouvrir l'app.
+                    FileProviderBridge.appendDiagnostic("relay app inactive → direct bridge download id=\(requestID)")
+                    try await RcloneProviderClient.shared.downloadViaBridge(
+                        remote: decoded.remote,
+                        path: decoded.path,
+                        to: appleDestination,
+                        progress: progress
+                    )
+                    fileAlreadyAtApple = true
+                }
+
+                if !fileAlreadyAtApple {
+                    // Chemin relais : l'app principale a ecrit dans sharedDestination.
+                    // On bouge le fichier vers Apple-managed tempDir avant de rendre
+                    // la main a iOS.
+                    try FileManager.default.createDirectory(
+                        at: appleDestination.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    try? FileManager.default.removeItem(at: appleDestination)
+                    do {
+                        try FileManager.default.moveItem(at: sharedDestination, to: appleDestination)
+                    } catch {
+                        // Volumes potentiellement differents : fallback copy + remove.
+                        try FileManager.default.copyItem(at: sharedDestination, to: appleDestination)
+                        try? FileManager.default.removeItem(at: sharedDestination)
+                    }
                 }
 
                 let downloadedSize = (try? FileManager.default

--- a/RcloneFileProvider/RcloneProviderClient.swift
+++ b/RcloneFileProvider/RcloneProviderClient.swift
@@ -140,6 +140,37 @@ actor RcloneProviderClient {
         return result
     }
 
+    /// Téléchargement LÉGER directement dans l'extension via le bridge loopback
+    /// (`RclonebridgeStartFileHTTP`) + URLSession en streaming. Bien plus économe
+    /// en mémoire que `download(...)` (operations/copyfile + transfer manager
+    /// rclone), qui faisait jetsam dans l'.appex. Utilisé en repli quand l'app
+    /// principale n'est pas active pour assurer le relais → Fichiers fonctionne
+    /// sans avoir à ouvrir l'app.
+    func downloadViaBridge(remote: String, path: String, to localURL: URL, progress: Progress?) async throws {
+        try await ensureInitialized()
+        #if canImport(RcloneKit)
+        FileProviderBridge.appendDiagnostic("downloadViaBridge start remote=\(remote)")
+        let raw = RclonebridgeStartFileHTTP(remote, path)
+        guard let data = raw.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sessionID = object["id"] as? String,
+              let urlString = object["url"] as? String,
+              let url = URL(string: urlString),
+              !sessionID.isEmpty else {
+            throw providerError("Bridge StartFileHTTP a renvoyé une réponse invalide : \(raw)")
+        }
+        defer { RclonebridgeStopFileHTTP(sessionID) }
+        try FileManager.default.createDirectory(
+            at: localURL.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? FileManager.default.removeItem(at: localURL)
+        try await ExtensionBridgeDownloader(dest: localURL, progress: progress).download(from: url)
+        FileProviderBridge.appendDiagnostic("downloadViaBridge done remote=\(remote)")
+        #else
+        throw providerError("RcloneKit indisponible pour le download direct")
+        #endif
+    }
+
     func upload(localURL: URL, remote: String, path: String) async throws -> FPRemoteEntry? {
         let jobID = try await copyFile(
             srcFs: localURL.deletingLastPathComponent().path,
@@ -329,5 +360,76 @@ actor RcloneProviderClient {
             code: NSFileProviderError.serverUnreachable.rawValue,
             userInfo: [NSLocalizedDescriptionKey: message]
         )
+    }
+}
+
+/// Télécharge un fichier depuis le bridge loopback via `URLSession` en streaming
+/// (faible mémoire — pas de buffering du fichier entier), met à jour le `Progress`
+/// et déplace le temp vers `dest` à la fin. Pendant du `BridgeFileDownloader`
+/// côté app, dupliqué ici car l'extension est une cible séparée.
+final class ExtensionBridgeDownloader: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    private let dest: URL
+    private let progress: Progress?
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var session: URLSession?
+    private var moveError: Error?
+
+    init(dest: URL, progress: Progress?) {
+        self.dest = dest
+        self.progress = progress
+        super.init()
+    }
+
+    func download(from url: URL) async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                self.continuation = cont
+                let config = URLSessionConfiguration.default
+                config.timeoutIntervalForRequest = 60
+                config.requestCachePolicy = .reloadIgnoringLocalCacheData
+                let session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+                self.session = session
+                session.downloadTask(with: url).resume()
+            }
+        } onCancel: {
+            self.session?.invalidateAndCancel()
+        }
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didWriteData bytesWritten: Int64, totalBytesWritten: Int64,
+                    totalBytesExpectedToWrite: Int64) {
+        guard let progress, totalBytesExpectedToWrite > 0 else { return }
+        progress.totalUnitCount = totalBytesExpectedToWrite
+        progress.completedUnitCount = totalBytesWritten
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didFinishDownloadingTo location: URL) {
+        let fm = FileManager.default
+        do {
+            try fm.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? fm.removeItem(at: dest)
+            try fm.moveItem(at: location, to: dest)
+        } catch {
+            moveError = error
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        session.finishTasksAndInvalidate()
+        let cont = continuation
+        continuation = nil
+        if let moveError { cont?.resume(throwing: moveError); return }
+        if let error { cont?.resume(throwing: error); return }
+        if let http = task.response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            cont?.resume(throwing: NSError(
+                domain: NSFileProviderErrorDomain,
+                code: NSFileProviderError.serverUnreachable.rawValue,
+                userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode) (download direct extension)"]
+            ))
+            return
+        }
+        cont?.resume(returning: ())
     }
 }


### PR DESCRIPTION
## Symptôme
Depuis Fichiers, sur un device où l'app n'est pas ouverte : dialog « Lancez Rclone GUI puis réessayez (l'app n'est pas active) ». L'extension délègue le download à l'app, mais une app suspendue/fermée ne reçoit pas la notif Darwin → timeout.

## Correctif (Option A choisie par Vitaly)
Quand le relais détecte que **l'app n'est jamais devenue active**, l'extension télécharge **elle-même** via le **bridge loopback + URLSession** (streaming, faible mémoire) — bien plus léger que l'ancien `operations/copyfile` qui faisait *jetsam* dans l'.appex. → Fichiers fonctionne **sans ouvrir l'app**.

- `AppGroupBridge` : marqueur `appInactiveErrorKey` + `errorMeansAppInactive` ; le throw « app pas active » le porte.
- `RcloneProviderClient` : `downloadViaBridge(...)` + `ExtensionBridgeDownloader` (URLSessionDownloadDelegate, progress local, move atomique). L'extension init déjà librclone (`ensureInitialized`) pour le listing → le bridge y est dispo.
- `fetchContents` : relais d'abord (préféré) ; **repli download direct uniquement** sur l'erreur app-inactive.

## ⚠️ Non vérifié en local
L'extension iOS **n'est pas compilable ici** (pas de slice simulateur RcloneKit ; `build_macos` ne compile pas l'.appex). Code relu à la main, calqué sur `BridgeFileDownloader` (compilé sur macOS). **À valider au build Xcode device.** Risque résiduel : jetsam mémoire sur très gros fichiers dans l'extension.

`build_macos` (app principale) : **SUCCEEDED**, 0 erreur/warning.