### PR TITLE
perf(swiftdata): index + anti-explosion table Transfer + dirty-flag pollLoop

### DIFF
--- a/Rclone GUI/Models/PhotoSyncAsset.swift
+++ b/Rclone GUI/Models/PhotoSyncAsset.swift
@@ -19,6 +19,12 @@ public enum PhotoSyncStatus: String, Codable, Sendable, CaseIterable {
 
 @Model
 public final class PhotoSyncAsset {
+    // Index sur statusRaw : la bibliothèque fait 18k+ assets, et de nombreux
+    // fetch/fetchCount filtrent sur statusRaw (pending/exporting/enqueued…) →
+    // sans index, full scan de 18k lignes à chaque appel. localIdentifier est
+    // déjà indexé (.unique).
+    #Index<PhotoSyncAsset>([\.statusRaw])
+
     @Attribute(.unique) public var localIdentifier: String
     public var mediaType: String
     public var creationDate: Date?

--- a/Rclone GUI/Models/Transfer.swift
+++ b/Rclone GUI/Models/Transfer.swift
@@ -82,6 +82,12 @@ public final class TransferBatch {
 
 @Model
 public final class Transfer {
+    // Index SwiftData : sans eux, chaque predicate sur statusRaw/sourceKindRaw/
+    // batchID = full table scan qui grossit avec l'historique (polling 500/800 ms,
+    // scheduleNext, updateRunningBatches, photo-sync…). Le plus gros gain perf
+    // pour le moins de code.
+    #Index<Transfer>([\.statusRaw], [\.sourceKindRaw], [\.batchID], [\.startedAt])
+
     @Attribute(.unique) public var id: String
 
     /// Stored as raw String to keep SwiftData migration simple.

--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -1165,6 +1165,7 @@ public final class TransferQueue {
                 if status.finished {
                     let finalKind = transfer.kind
                     let finalSrc = transfer.sourcePath
+                    var deleteAfterCompletion = false
                     if status.success {
                         transfer.bytesTransferred = max(transfer.bytesTransferred, transfer.bytesTotal)
                         transfer.status = .completed
@@ -1175,12 +1176,19 @@ public final class TransferQueue {
                                 success: true,
                                 error: nil
                             )
+                            // Anti-explosion SwiftData : 1 ligne Transfer par photo
+                            // (18k+) saturait la table (full scans + @Query qui
+                            // matérialise des milliers de lignes). L'état est déjà
+                            // suivi par PhotoSyncAsset → on supprime la ligne terminée.
+                            if transfer.batchID == nil { deleteAfterCompletion = true }
                         }
-                        await LogService.shared.log(
-                            .info,
-                            category: "transfer",
-                            message: "✅ \(finalKind.rawValue) terminé : \(finalSrc)"
-                        )
+                        if !deleteAfterCompletion {
+                            await LogService.shared.log(
+                                .info,
+                                category: "transfer",
+                                message: "✅ \(finalKind.rawValue) terminé : \(finalSrc)"
+                            )
+                        }
                     } else if shouldAutoRetry(transfer) {
                         // Re-enqueue auto borné (coupures réseau transitoires).
                         let key = autoRetryKey(transfer)
@@ -1224,11 +1232,18 @@ public final class TransferQueue {
                             message: "❌ \(finalKind.rawValue) échoué : \(finalSrc) — \(status.error ?? "raison inconnue")"
                         )
                     }
-                    transfer.finishedAt = .now
+                    if deleteAfterCompletion {
+                        modelContext?.delete(transfer)
+                    } else {
+                        transfer.finishedAt = .now
+                    }
                     try? modelContext?.save()
                     break
                 }
-                try? modelContext?.save()
+                // Pas de save() ici : le chemin « non terminé » ne mute RIEN dans
+                // pollLoop (la progression est persistée par tickStats, qui a son
+                // propre dirty-flag). Sauver à chaque tick (500 ms/job) invalidait
+                // inutilement tous les @Query → re-render des vues. Dirty-flag de fait.
                 try await Task.sleep(for: .milliseconds(500))
             } catch is CancellationError {
                 break


### PR DESCRIPTION
Issu de la phase Discover (/octo:discover). **Cause racine** des ralentissements résiduels : table `Transfer` **sans index** et **non bornée**, explosée par la photo-sync (1 ligne/photo → 18k+), couplée à des `@Query` gros grain re-render toutes les 500 ms.

- **`#Index`** sur `Transfer` (statusRaw, sourceKindRaw, batchID, startedAt) + `PhotoSyncAsset` (statusRaw). Avant : **zéro index** → chaque predicate = full scan. Plus gros gain perf / moindre code.
- **Anti-explosion** : une photo terminée (`photoLibrary`, sans batch) voit sa ligne `Transfer` **supprimée** (état déjà dans `PhotoSyncAsset`).
- **Dirty-flag pollLoop** : suppression du `save()` inconditionnel du chemin « non terminé » (ne mutait rien) → fini les N save/s qui invalidaient les `@Query`.

Migration : `#Index` = migration légère auto ; le `ModelContainer` a un fallback qui recrée le store si échec → pas de crash au boot.

`build_macos` : **SUCCEEDED**, 0 erreur/warning. (Runtime à confirmer device.)