### PR TITLE
perf(thumbnails): décodage eager + annulation au scroll + cache version()

### DIFF
--- a/Rclone GUI/Core/RcloneCore.swift
+++ b/Rclone GUI/Core/RcloneCore.swift
@@ -116,10 +116,16 @@ public actor RcloneCore {
 
     // MARK: - Convenience
 
-    /// `core/version` → `version` field.
+    /// `core/version` → `version` field. Mis en cache : la version ne change
+    /// JAMAIS pendant un run, et `liveSession` l'appelle comme sonde de vivacité
+    /// avant CHAQUE vignette → c'était un RPC CGo par miniature (rafale au scroll
+    /// d'une grille). Une fois connue, on la renvoie sans appel.
+    private var cachedVersion: String?
     public func version() async throws -> String {
+        if let cachedVersion { return cachedVersion }
         struct Response: Decodable { let version: String }
         let resp: Response = try await rpc("core/version")
+        cachedVersion = resp.version
         return resp.version
     }
 

--- a/Rclone GUI/Services/ThumbnailService.swift
+++ b/Rclone GUI/Services/ThumbnailService.swift
@@ -29,7 +29,7 @@ public enum ThumbnailPolicy: String, CaseIterable, Sendable {
     case wifiOnly
     case never
 
-    public static let defaultsKey = "thumbnails.policy"
+    nonisolated public static let defaultsKey = "thumbnails.policy"
 
     public var label: String {
         switch self {
@@ -98,14 +98,21 @@ public actor ThumbnailService {
         switch Self.policy {
         case .never:
             return nil
-        case .wifiOnly where NetworkReachability.shared.isExpensive:
-            return nil
-        default:
+        case .wifiOnly:
+            if await NetworkReachability.shared.isExpensive { return nil }
+        case .always:
             break
         }
 
         await limiter.wait()
         defer { Task { await limiter.signal() } }
+
+        // ANNULATION AU SCROLL : SwiftUI annule la `.task` d'une cellule sortie de
+        // l'écran. Si on a attendu un permis du limiteur (3 max) pendant ce temps,
+        // on abandonne immédiatement → le permis repart aussitôt vers une cellule
+        // VISIBLE, au lieu de générer une vignette hors écran qui bouchait le
+        // limiteur et affamait les cellules regardées.
+        if Task.isCancelled { return nil }
 
         // Re-vérifie après l'attente (réentrance : une autre tâche a pu générer).
         if let cached = memCache[key] { return cached }
@@ -204,8 +211,21 @@ public actor ThumbnailService {
     nonisolated static func loadFromDisk(key: String) -> CGImageBox? {
         let url = cacheFileURL(key: key)
         guard FileManager.default.fileExists(atPath: url.path),
-              let source = CGImageSourceCreateWithURL(url as CFURL, nil),
-              let cg = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+              let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            return nil
+        }
+        // DÉCODAGE EAGER, hors render thread. CGImageSourceCreateImageAtIndex(nil)
+        // renvoie un CGImage PARESSEUX : Core Animation le décode au 1er affichage
+        // SUR LE RENDER THREAD → à-coups au scroll. On force le décodage immédiat
+        // ici (on est déjà off-main) via Thumbnail + ShouldCacheImmediately. Le JPEG
+        // disque fait déjà ≤400 px, donc « thumbnail » renvoie l'image pleine décodée.
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ]
+        guard let cg = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
             return nil
         }
         return CGImageBox(image: cg)


### PR DESCRIPTION
Issu de Discover (/octo:discover). Fluidité scroll des grilles média :

- **`loadFromDisk` décodage eager** : `CGImageSourceCreateThumbnailAtIndex` + `kCGImageSourceShouldCacheImmediately` au lieu de `CreateImageAtIndex` (CGImage paresseux décodé sur le render thread → à-coups).
- **Annulation au scroll** : `Task.isCancelled` après `limiter.wait()` → une cellule hors écran libère son permis (3 max) au lieu d'affamer les cellules visibles.
- **`RcloneCore.version()` en cache** : `liveSession` l'appelait avant CHAQUE vignette (1 RPC CGo/miniature). La version ne change jamais pendant un run.

`build_macos` : **SUCCEEDED**, 0 erreur/warning. (Fluidité à confirmer device.)