### PR TITLE
feat(player): upgrade VLCKit 3.6 → 4.0 (base du PiP) + migration API

### DIFF
--- a/Rclone GUI.xcodeproj/project.pbxproj
+++ b/Rclone GUI.xcodeproj/project.pbxproj
@@ -412,7 +412,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 2650;
-				LastUpgradeCheck = 2650;
+				LastUpgradeCheck = 2700;
 				TargetAttributes = {
 					278FAAAB2FAF741D0019F255 = {
 						CreatedOnToolsVersion = 26.4.1;
@@ -631,6 +631,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.rougetet.rclone-gui.fileprovider";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -678,6 +679,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.rougetet.rclone-gui.fileprovider";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -907,6 +909,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -971,6 +974,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1268,10 +1272,10 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		27FFEE0100000000000F0001 /* XCRemoteSwiftPackageReference "vlckit-spm" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/tylerjonesio/vlckit-spm";
+			repositoryURL = "https://github.com/virtualox/vlckit-spm";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.6.0;
+				kind = exactVersion;
+				version = "4.0.0-alpha.19";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Rclone GUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Rclone GUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "294b5443f2fd75dbed7a00528cc25cb27baf812b2346df53611fbd2af4f2803d",
+  "originHash" : "bd7b71cbb99159d545e54e854dec007a7b2145c792a1ccc4ed2f510f30308e6b",
   "pins" : [
     {
       "identity" : "vlckit-spm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tylerjonesio/vlckit-spm",
+      "location" : "https://github.com/virtualox/vlckit-spm",
       "state" : {
-        "revision" : "e932bbd488872fdb74f6654d28c2f291eae03daf",
-        "version" : "3.6.0"
+        "revision" : "1d19105c52515a1d52813923d88515947cdeb3d8",
+        "version" : "4.0.0-alpha.19"
       }
     }
   ],

--- a/Rclone GUI/Views/Player/VLCPlayerView.swift
+++ b/Rclone GUI/Views/Player/VLCPlayerView.swift
@@ -57,13 +57,16 @@ final class VLCPlayerModel: NSObject, ObservableObject {
     @Published var rate: Float = 1.0
 
     struct Track: Identifiable, Hashable {
-        let id: Int32
+        // VLCKit 4.0 : les pistes sont identifiées par un trackId String
+        // (ex. "audio/0"), plus par un index Int32 comme en 3.x.
+        let id: String
         let name: String
     }
     @Published var subtitleTracks: [Track] = []
     @Published var audioTracks: [Track] = []
-    @Published var currentSubtitleID: Int32 = -1
-    @Published var currentAudioID: Int32 = -1
+    /// trackId de la piste sélectionnée, nil = aucune (sous-titres désactivés).
+    @Published var currentSubtitleID: String?
+    @Published var currentAudioID: String?
 
     /// Appelé quand la lecture atteint la fin (pour enchaîner la playlist).
     var onEnded: (() -> Void)?
@@ -139,13 +142,12 @@ final class VLCPlayerModel: NSObject, ObservableObject {
     private func stateName(_ s: VLCMediaPlayerState) -> String {
         switch s {
         case .stopped: return "stopped"
+        case .stopping: return "stopping"
         case .opening: return "opening"
         case .buffering: return "buffering"
-        case .ended: return "ended"
         case .error: return "error"
         case .playing: return "playing"
         case .paused: return "paused"
-        case .esAdded: return "esAdded"
         @unknown default: return "?"
         }
     }
@@ -178,14 +180,21 @@ final class VLCPlayerModel: NSObject, ObservableObject {
         rate = newRate
     }
 
-    func selectSubtitle(id: Int32) {
-        player.currentVideoSubTitleIndex = id
-        currentSubtitleID = id
+    func selectSubtitle(id: String?) {
+        if let id, let track = player.textTracks.first(where: { $0.trackId == id }) {
+            track.isSelectedExclusively = true
+            currentSubtitleID = id
+        } else {
+            player.deselectAllTextTracks()   // id nil = sous-titres désactivés
+            currentSubtitleID = nil
+        }
     }
 
-    func selectAudio(id: Int32) {
-        player.currentAudioTrackIndex = id
-        currentAudioID = id
+    func selectAudio(id: String) {
+        if let track = player.audioTracks.first(where: { $0.trackId == id }) {
+            track.isSelectedExclusively = true
+            currentAudioID = id
+        }
     }
 
     /// Ajoute un sous-titre externe (fichier local) et le sélectionne.
@@ -207,15 +216,15 @@ final class VLCPlayerModel: NSObject, ObservableObject {
     }
 
     private func refreshTracks() {
-        let subIDs = (player.videoSubTitlesIndexes as? [NSNumber])?.map { $0.int32Value } ?? []
-        let subNames = player.videoSubTitlesNames.map { String(describing: $0) }
-        subtitleTracks = zip(subIDs, subNames).map { Track(id: $0.0, name: $0.1) }
-        currentSubtitleID = player.currentVideoSubTitleIndex
+        // VLCKit 4.0 : pistes via player.textTracks / audioTracks (VLCMediaPlayerTrack
+        // avec trackId/trackName/isSelected), au lieu des index 3.x.
+        let subs = player.textTracks
+        subtitleTracks = subs.map { Track(id: $0.trackId, name: $0.trackName) }
+        currentSubtitleID = subs.first(where: { $0.isSelected })?.trackId
 
-        let audIDs = (player.audioTrackIndexes as? [NSNumber])?.map { $0.int32Value } ?? []
-        let audNames = player.audioTrackNames.map { String(describing: $0) }
-        audioTracks = zip(audIDs, audNames).map { Track(id: $0.0, name: $0.1) }
-        currentAudioID = player.currentAudioTrackIndex
+        let auds = player.audioTracks
+        audioTracks = auds.map { Track(id: $0.trackId, name: $0.trackName) }
+        currentAudioID = auds.first(where: { $0.isSelected })?.trackId
     }
 
     private func refreshTime() {
@@ -326,8 +335,9 @@ final class VLCPlayerModel: NSObject, ObservableObject {
 // MARK: VLCMediaPlayerDelegate
 
 extension VLCPlayerModel: VLCMediaPlayerDelegate {
-    func mediaPlayerStateChanged(_ aNotification: Notification) {
-        let state = player.state
+    func mediaPlayerStateChanged(_ newState: VLCMediaPlayerState) {
+        // VLCKit 4.0 : le delegate reçoit l'état directement (avant : une Notification).
+        let state = newState
         plog("VLC état → \(stateName(state)) @\(Int(positionSeconds))s (stalls=\(stallCount), totalStall=\(String(format: "%.1f", totalStallSeconds))s)")
         switch state {
         case .buffering, .opening:
@@ -358,15 +368,19 @@ extension VLCPlayerModel: VLCMediaPlayerDelegate {
                 plog("VLC ⚠️ fin re-buffering après \(String(format: "%.1f", dur))s (stall #\(stallCount))")
             }
             refreshTracks()
-            plog("🔊 audio: \(audioTracks.count) piste(s) sél=id\(currentAudioID) · sous-titres: \(subtitleTracks.count) — VLC=[caching=\(Self.networkCachingMs)ms, hw=videotoolbox, clock-jitter=0, no-drop-late-frames, no-audio-time-stretch]")
+            plog("🔊 audio: \(audioTracks.count) piste(s) sél=\(currentAudioID ?? "-") · sous-titres: \(subtitleTracks.count) — VLC=[caching=\(Self.networkCachingMs)ms, hw=videotoolbox, clock-jitter=0, no-drop-late-frames, no-audio-time-stretch]")
         case .paused:
+            isPlaying = false
+        case .stopping:
             isPlaying = false
         case .stopped:
             isPlaying = false
             plog("VLC ⏹️ stop — bilan : stalls=\(stallCount), tempsBuffering=\(String(format: "%.1f", totalStallSeconds))s")
-        case .ended:
-            isPlaying = false
-            onEnded?()
+            // VLCKit 4.0 n'a plus d'état .ended : fin de média = .stopped en étant
+            // proche de la fin → on enchaîne la playlist.
+            if durationSeconds > 0, positionSeconds >= durationSeconds - 2 {
+                onEnded?()
+            }
         case .error:
             failed = true
             isBuffering = false
@@ -788,19 +802,17 @@ struct EmbeddedVLCPlayerView: View {
             // Sous-titres : sidecar + intégrés.
             Menu {
                 Button {
-                    model.selectSubtitle(id: -1)
+                    model.selectSubtitle(id: nil)
                 } label: {
-                    Label("Désactivés", systemImage: model.currentSubtitleID == -1 ? "checkmark" : "")
+                    Label("Désactivés", systemImage: model.currentSubtitleID == nil ? "checkmark" : "")
                 }
                 if !model.subtitleTracks.isEmpty {
                     Section("Pistes intégrées") {
                         ForEach(model.subtitleTracks) { track in
-                            if track.id != -1 {
-                                Button {
-                                    model.selectSubtitle(id: track.id)
-                                } label: {
-                                    Label(track.name, systemImage: model.currentSubtitleID == track.id ? "checkmark" : "")
-                                }
+                            Button {
+                                model.selectSubtitle(id: track.id)
+                            } label: {
+                                Label(track.name, systemImage: model.currentSubtitleID == track.id ? "checkmark" : "")
                             }
                         }
                     }
@@ -819,7 +831,7 @@ struct EmbeddedVLCPlayerView: View {
             } label: {
                 Image(systemName: "captions.bubble")
                     .font(.system(size: 17, weight: .medium))
-                    .foregroundStyle(model.currentSubtitleID != -1 ? Color.accentColor : .white)
+                    .foregroundStyle(model.currentSubtitleID != nil ? Color.accentColor : .white)
                     .frame(width: 38, height: 38)
                     .background(.black.opacity(0.35), in: .circle)
             }


### PR DESCRIPTION
**Prérequis du Picture-in-Picture** : VLCKit 4.0 a ajouté le PiP iOS natif (la 3.6 ne l'a pas). Dépendance SPM **tylerjonesio/vlckit-spm 3.6.0 → virtualox/vlckit-spm 4.0.0-alpha.19** (même produit `import VLCKitSPM`, LGPL ✅ App Store).

### Migration API VLCKit 3→4 (guidée par le build)
- **Pistes** : `player.textTracks/audioTracks` (`[VLCMediaPlayerTrack]` : `trackId:String`, `trackName`, `isSelected/isSelectedExclusively`) au lieu des index Int32. `Track.id:String`, `currentSubtitleID/AudioID:String?`.
- **Delegate** : `mediaPlayerStateChanged(_ newState: VLCMediaPlayerState)` (avant : Notification → le callback ne se déclenchait plus).
- **États** : `.ended`/`.esAdded` supprimés → `.stopping` ajouté ; fin de média via `.stopped` proche de la fin.

### Statut
`build_macos` : **SUCCEEDED** (résout + télécharge + compile VLCKit 4.0). **PiP PAS encore câblé.**

### ⚠️ À valider AVANT le PiP
VLCKit 4.0 est **alpha**. **Étape 1 = device-test que la lecture marche toujours** (streaming MKV 4K, sous-titres, pistes audio, vitesse). Si OK → je câble le PiP. Si régression → `git revert` (retour 3.6 sans PiP).