### PR TITLE
fix(player): « Ouvrir dans une autre app » télécharge en local puis partage

### DIFF
--- a/Rclone GUI/Views/Folders/EntryActionsMenu.swift
+++ b/Rclone GUI/Views/Folders/EntryActionsMenu.swift
@@ -47,23 +47,6 @@ struct EntryActionsMenu: View {
                           systemImage: Self.isMediaFile(entry.name) ? "play.circle" : "doc.viewfinder")
                 }
 
-                if Self.isVideoFile(entry.name) {
-                    Menu {
-                        Button {
-                            Task { await streamInExternalPlayer(scheme: .infuse) }
-                        } label: {
-                            Label("Infuse", systemImage: "play.tv")
-                        }
-                        Button {
-                            Task { await streamInExternalPlayer(scheme: .vlc) }
-                        } label: {
-                            Label("VLC", systemImage: "play.tv.fill")
-                        }
-                    } label: {
-                        Label("Lire dans une app externe", systemImage: "play.rectangle.on.rectangle")
-                    }
-                }
-
                 Button {
                     externalOpenTarget = entry
                 } label: {
@@ -199,65 +182,6 @@ struct EntryActionsMenu: View {
     // aussi le routage AVPlayer ↔ VLC du lecteur embarqué).
     static func isMediaFile(_ name: String) -> Bool { MediaFormat.isMedia(name) }
     static func isVideoFile(_ name: String) -> Bool { MediaFormat.isVideo(name) }
-
-    enum ExternalPlayerScheme {
-        case infuse
-        case vlc
-
-        func callbackURL(for streamURL: URL) -> URL? {
-            // Encode l'URL HTTP locale dans le scheme x-callback-url propre à
-            // chaque player. Infuse : infuse://x-callback-url/play?url=...
-            // VLC : vlc-x-callback://x-callback-url/stream?url=...
-            var components = URLComponents()
-            switch self {
-            case .infuse:
-                components.scheme = "infuse"
-                components.host = "x-callback-url"
-                components.path = "/play"
-            case .vlc:
-                components.scheme = "vlc-x-callback"
-                components.host = "x-callback-url"
-                components.path = "/stream"
-            }
-            components.queryItems = [URLQueryItem(name: "url", value: streamURL.absoluteString)]
-            return components.url
-        }
-    }
-
-    @MainActor
-    private func streamInExternalPlayer(scheme: ExternalPlayerScheme) async {
-        do {
-            let session = try await RcloneStreamingService.shared.session(
-                remote: remote,
-                path: entry.pathInRemote,
-                sizeHint: entry.size
-            )
-            guard let callbackURL = scheme.callbackURL(for: session.url) else {
-                await LogService.shared.log(
-                    .error,
-                    category: "streaming",
-                    message: "Impossible de construire l'URL callback pour \(entry.name)"
-                )
-                return
-            }
-            #if canImport(UIKit)
-            await UIApplication.shared.open(callbackURL)
-            #elseif canImport(AppKit)
-            NSWorkspace.shared.open(callbackURL)
-            #endif
-            await LogService.shared.log(
-                .info,
-                category: "streaming",
-                message: "Stream → \(callbackURL.scheme ?? "?") : \(remote):\(entry.pathInRemote)"
-            )
-        } catch {
-            await LogService.shared.log(
-                .error,
-                category: "streaming",
-                message: "Streaming externe échoué (\(remote):\(entry.pathInRemote)) : \(error.localizedDescription)"
-            )
-        }
-    }
 }
 
 // MARK: - Rename Sheet

--- a/Rclone GUI/Views/Player/MediaPlayerView.swift
+++ b/Rclone GUI/Views/Player/MediaPlayerView.swift
@@ -279,6 +279,9 @@ struct MediaPlayerHost: View {
     @State private var preparing = true
     @State private var error: String?
     @State private var engine: PlaybackEngine = .avFoundation
+    /// Cible d'« Ouvrir dans une autre app » : déclenche le download-then-share
+    /// fiable (cf. openExternal). Présenté en sheet par-dessus le lecteur.
+    @State private var externalOpenEntry: RemoteEntryDTO?
     @Environment(\.dismiss) private var dismiss
 
     init(remote: String, entry: RemoteEntryDTO, playlist: [RemoteEntryDTO]? = nil) {
@@ -317,6 +320,9 @@ struct MediaPlayerHost: View {
             stopCurrentSession()
             NowPlayingService.shared.endPlaybackSession()
         }
+        .sheet(item: $externalOpenEntry) { entry in
+            RemoteExternalOpenHost(remote: remote, entry: entry)
+        }
     }
 
     @ViewBuilder
@@ -334,7 +340,7 @@ struct MediaPlayerHost: View {
                 hasPrevious: hasPrevious,
                 onNext: hasNext ? { advance(by: 1) } : nil,
                 onPrevious: hasPrevious ? { advance(by: -1) } : nil,
-                onOpenExternal: { openExternal(session) },
+                onOpenExternal: { openExternal() },
                 onClose: { dismiss() }
             )
             .ignoresSafeArea()
@@ -405,13 +411,16 @@ struct MediaPlayerHost: View {
         }
     }
 
-    private func openExternal(_ session: StreamingSession) {
-        guard let callbackURL = EntryActionsMenu.ExternalPlayerScheme.vlc.callbackURL(for: session.url) else { return }
-        #if canImport(UIKit)
-        UIApplication.shared.open(callbackURL)
-        #elseif canImport(AppKit)
-        NSWorkspace.shared.open(callbackURL)
-        #endif
+    /// Ouverture dans une app tierce (Infuse, VLC, nPlayer…). On NE passe PLUS
+    /// par un handoff loopback `infuse://…?url=http://127.0.0.1:PORT/…` : dès
+    /// qu'iOS bascule vers l'app cible, rclone-gui est suspendu en arrière-plan
+    /// et son serveur HTTP local devient injoignable → l'app cible affiche
+    /// « Failed to open input stream in demuxing stream ». À la place on
+    /// télécharge le fichier en local PUIS on présente le partage iOS /
+    /// « Ouvrir dans » (RemoteExternalOpenHost) : l'app cible importe un vrai
+    /// fichier local et le lit. Fiable, sans dépendre du process de fond.
+    private func openExternal() {
+        externalOpenEntry = entry
     }
 
     // MARK: États de chargement / erreur


### PR DESCRIPTION
## Problème

« Ouvrir dans une autre app » (ex. Infuse) échouait avec **« Failed to open input stream in demuxing stream »**.

Cause : le handoff passait par une URL loopback `infuse://x-callback-url/play?url=http://127.0.0.1:PORT/file?token=…` pointant vers le serveur HTTP interne de rclone-gui. Dès qu'iOS basculait vers l'app cible, rclone-gui passait en arrière-plan (suspendu) → son serveur local devenait injoignable → échec d'ouverture du flux. Défaut structurel, aucun réglage ne le corrige.

## Correctif

L'ouverture externe **télécharge d'abord le fichier en local** (`MediaCacheService`) **puis présente le partage iOS / « Ouvrir dans »** (`RemoteExternalOpenHost`). L'app cible importe un vrai fichier local et le lit — sans dépendre du process de fond. Fiable.

- **EntryActionsMenu** : suppression du sous-menu loopback « Lire dans une app externe » (Infuse/VLC) + enum/fonction associés. Le bouton générique « Ouvrir dans une autre app » (déjà fiable) reste seul.
- **MediaPlayerHost** : le bouton « Externe » du lecteur présente le même `RemoteExternalOpenHost` au lieu d'ouvrir l'URL loopback.

## Validation

- `build_macos` ✅ (seul warning préexistant `humanize` FieldSpec.swift:56).
- Runtime à valider sur device (pas de slice simulateur en local).