### PR TITLE
fix(ios): retire « picture-in-picture » de UIBackgroundModes (rejet App Store 90112)

### DIFF
--- a/Rclone GUI/Info.plist
+++ b/Rclone GUI/Info.plist
@@ -5,7 +5,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
-		<string>picture-in-picture</string>
 		<string>remote-notification</string>
 		<string>fetch</string>
 		<string>processing</string>


### PR DESCRIPTION
Tous les uploads iOS échouaient à la validation App Store (erreur **90112** : *UIBackgroundModes contains an invalid value: 'picture-in-picture'*). Cette valeur n'existe pas dans UIBackgroundModes — le PiP s'appuie sur le mode **audio** (déjà présent). Retirée → le PiP fonctionne toujours, et l'upload iOS passe. Diagnostiqué via altool --validate-app (clé API) sur l'IPA exporté par Xcode Cloud (build 120).