### PR TITLE
chore(fastlane): lanes ship/submit_mac sur 1.9 (build 122) [ci skip]

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,12 +82,12 @@ platform :ios do
     )
   end
 
-  desc "Create version 1.1, attach already-uploaded build, push metadata, submit for review"
+  desc "Create the iOS version, attach already-uploaded build, push metadata, submit for review"
   lane :ship do
     deliver(
       api_key: asc_key,
-      app_version: "1.1",
-      build_number: "6",
+      app_version: "1.9",
+      build_number: "122",
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: false,
@@ -207,17 +207,18 @@ platform :mac do
     )
   end
 
-  desc "Submit the macOS 1.4 version for review (build already uploaded)"
+  desc "Submit the macOS version for review (build already uploaded)"
   lane :submit_mac do
     deliver(
       api_key: asc_key,
       platform: "osx",
       app_version: "1.9",
+      build_number: "122",
       submit_for_review: true,
       automatic_release: false,
       skip_binary_upload: true,
       skip_screenshots: true,
-      skip_metadata: true,
+      skip_metadata: false,
       force: true,
       run_precheck_before_submit: false,
       submission_information: {


### PR DESCRIPTION
Aligne les lanes de soumission sur la version publiée (1.9, build 122). [ci skip] — pas de rebuild Xcode Cloud nécessaire.