### PR TITLE
feat(debug): bypass Face ID/passcode en mode --seed-demo

### DIFF
--- a/Rclone GUI/Core/BiometricGate.swift
+++ b/Rclone GUI/Core/BiometricGate.swift
@@ -52,6 +52,16 @@ public actor BiometricGate {
 
     /// Trigger a biometric prompt. Falls back to passcode if biometrics fail or are unavailable.
     public func authenticate(reason: BiometricReason) async -> BiometricResult {
+        #if DEBUG
+        // Simulators used for App Store screenshot automation have no enrolled
+        // Face ID / passcode, which would otherwise block every launch behind
+        // the system auth sheet. Skip only when the same --seed-demo flag that
+        // seeds fixture data (DemoSeeder.isRequested) is present.
+        if DemoSeeder.isRequested {
+            return .authenticated
+        }
+        #endif
+
         let context = LAContext()
         var nsError: NSError?
 


### PR DESCRIPTION
Les simulateurs utilisés pour générer les captures App Store n'ont ni Face ID ni code enrôlé, ce qui bloquait chaque lancement derrière la feuille d'authentification système (LAContext.deviceOwnerAuthentication). Bypass `#if DEBUG` uniquement, gardé par le même flag `DemoSeeder.isRequested` (`--seed-demo` / `SEED_DEMO=1`) — ne peut jamais s'activer en Release.