### PR TITLE
chore(fastlane): épingler resubmit/submit_mac sur le build 134

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,6 +61,7 @@ platform :ios do
   lane :resubmit do
     deliver(
       api_key: asc_key,
+      build_number: "134",
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: true,
@@ -213,7 +214,7 @@ platform :mac do
       api_key: asc_key,
       platform: "osx",
       app_version: "1.9.1",
-      build_number: "128",
+      build_number: "134",
       submit_for_review: true,
       automatic_release: false,
       skip_binary_upload: true,


### PR DESCRIPTION
## Summary
- Épingle `build_number: "134"` sur les lanes `resubmit` (iOS) et `submit_mac` (macOS), déjà utilisé pour resoumettre 1.9.1 sur les deux plateformes (WAITING_FOR_REVIEW confirmé via l'API ASC).
- Évite la dérive silencieuse observée (`resubmit` sans build_number sélectionnait le dernier build disponible, 128→132).