### PR TITLE
fix(handoff): grille passphrase lisible + AirDrop qui s'affiche

### DIFF
--- a/Rclone GUI/InfoPlist.xcstrings
+++ b/Rclone GUI/InfoPlist.xcstrings
@@ -429,6 +429,9 @@
           }
         }
       }
+    },
+    "Sauvegarde chiffrée Rclone GUI" : {
+
     }
   },
   "version" : "1.3"

--- a/Rclone GUI/Services/HandoffSendService.swift
+++ b/Rclone GUI/Services/HandoffSendService.swift
@@ -115,7 +115,13 @@ public actor HandoffSendService {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let url = directory.appending(path: filename)
         let body = Data(payload.utf8)
-        try body.write(to: url, options: [.atomic, .completeFileProtection])
+        // .completeUntilFirstUserAuthentication (pas .completeFileProtection) :
+        // AirDrop et l'aperçu de la share sheet lisent le fichier depuis un
+        // process hors-app (sharingd). Sous .completeFileProtection ce process
+        // échoue à le lire → share sheet vide, aucune cible AirDrop. Le payload
+        // est déjà chiffré (ChaCha20-Poly1305), la protection fichier n'est que
+        // de la défense en profondeur — cette classe suffit et débloque AirDrop.
+        try body.write(to: url, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
         return url
     }
 }

--- a/Rclone GUI/Views/Settings/Handoff/HandoffSendView.swift
+++ b/Rclone GUI/Views/Settings/Handoff/HandoffSendView.swift
@@ -233,16 +233,25 @@ struct HandoffSendView: View {
                 }
 
                 if passphraseRevealed, let prepared {
-                    HStack(alignment: .top, spacing: 8) {
+                    // Grille 3×2 : un HStack de 6 colonnes donnait ~55 pt par
+                    // mot, ce qui coupait les mots Diceware longs (« nemeton »,
+                    // « flocon »…) avec césure. 3 colonnes = ~110 pt par mot,
+                    // et minimumScaleFactor gère les rares mots plus longs.
+                    LazyVGrid(
+                        columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3),
+                        spacing: 8
+                    ) {
                         ForEach(Array(prepared.passphraseWords.enumerated()), id: \.offset) { idx, word in
-                            VStack(spacing: 2) {
+                            VStack(spacing: 3) {
                                 Text("\(idx + 1)")
                                     .font(.caption2.weight(.bold))
                                     .foregroundStyle(.tertiary)
                                 Text(word)
-                                    .font(.title3.weight(.semibold).monospacedDigit())
+                                    .font(.body.weight(.semibold))
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.6)
                                     .frame(maxWidth: .infinity)
-                                    .padding(.vertical, 8)
+                                    .padding(.vertical, 10)
                                     .background(.purple.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
                             }
                         }
@@ -338,8 +347,12 @@ struct HandoffSendView: View {
         guard let prepared else { return }
         do {
             let url = try HandoffSendService.shared.materializeAirDropFile(payload: prepared.payload)
+            #if os(iOS)
+            presentActivitySheet(items: [url])
+            #else
             shareItems = [url]
             showShare = true
+            #endif
         } catch {
             self.error = "Impossible de préparer le fichier : \(error.localizedDescription)"
         }
@@ -362,12 +375,45 @@ struct HandoffSendView: View {
         guard let prepared else { return }
         do {
             let url = try HandoffSendService.shared.materializeAirDropFile(payload: prepared.payload)
+            #if os(iOS)
+            presentActivitySheet(items: [url])
+            #else
             shareItems = [url]
             showShare = true
+            #endif
         } catch {
             self.error = "Écriture impossible : \(error.localizedDescription)"
         }
     }
+
+    #if os(iOS)
+    /// Présente la share sheet directement depuis le contrôleur le plus
+    /// haut de la fenêtre clé. Encapsuler `UIActivityViewController` dans un
+    /// `.sheet` SwiftUI produit une feuille vide sur iOS récent (le VC ne
+    /// se met pas en page) — d'où « AirDrop n'affiche rien ». La présenter
+    /// en UIKit règle le problème.
+    @MainActor
+    private func presentActivitySheet(items: [Any]) {
+        guard let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+              let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController
+        else {
+            self.error = "Impossible d'ouvrir le partage : aucune fenêtre active."
+            return
+        }
+        var top = root
+        while let presented = top.presentedViewController { top = presented }
+        let vc = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        // iPad : la share sheet est un popover et exige une ancre.
+        if let pop = vc.popoverPresentationController {
+            pop.sourceView = top.view
+            pop.sourceRect = CGRect(x: top.view.bounds.midX, y: top.view.bounds.maxY - 60, width: 0, height: 0)
+            pop.permittedArrowDirections = []
+        }
+        top.present(vc, animated: true)
+    }
+    #endif
 }
 
 // MARK: - QR Display

--- a/Rclone GUITests/Rclone_GUITests.swift
+++ b/Rclone GUITests/Rclone_GUITests.swift
@@ -1160,6 +1160,37 @@ struct HandoffInboxTests {
     }
 }
 
+// MARK: - Handoff P2P : fichier AirDrop (send service → inbox)
+
+@Suite("Handoff P2P — fichier AirDrop")
+struct HandoffSendServiceFileTests {
+
+    @Test("materializeAirDropFile écrit un .rclonebackup lisible qui round-trip via l'inbox")
+    func airDropFileRoundTrips() throws {
+        let payload = "HND1:eJyrVk3PT8wvSizKUOKi5MrPSwMAF5MDtw"
+        let url = try HandoffSendService.shared.materializeAirDropFile(payload: payload)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        #expect(url.pathExtension == "rclonebackup")
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        // Le daemon de partage (sharingd) lit ce fichier hors-process : il
+        // doit être lisible (protection ≠ .completeFileProtection) et contenir
+        // exactement le payload. Ce round-trip est la garantie anti-régression
+        // du bug « AirDrop n'affiche rien ».
+        let extracted = try HandoffInbox.extractPayload(fromFileAt: url)
+        #expect(extracted == payload)
+    }
+
+    @Test("Le fichier AirDrop n'est PAS protégé en .completeFileProtection")
+    func airDropFileIsReadableByShareDaemon() throws {
+        let url = try HandoffSendService.shared.materializeAirDropFile(payload: "HND1:abcdef")
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let values = try url.resourceValues(forKeys: [.fileProtectionKey])
+        // .complete rendrait le fichier illisible pour sharingd quand l'écran
+        // se verrouille pendant le transfert AirDrop.
+        #expect(values.fileProtection != .complete)
+    }
+}
+
 // MARK: - Handoff P2P : QR payload single-fit
 
 @Suite("Handoff P2P — QR payload split")


### PR DESCRIPTION
Corrige deux bugs remontés en test sur l'écran **Envoyer** du Handoff P2P (captures utilisateur).

## 1. Les 6 mots de la passphrase s'affichaient mal
Les mots étaient dans un `HStack` de 6 colonnes égales (~55 pt chacun) : les mots Diceware français longs (« nemeton », « brique », « flocon », « diamant »…) débordaient et se coupaient avec césure. Remplacé par une **grille 3×2** (~110 pt/mot) + `lineLimit(1)` + `minimumScaleFactor(0.6)`.

## 2. « Partager via AirDrop » ouvrait une feuille vide
Deux causes cumulées :
- Le `UIActivityViewController` encapsulé dans un `.sheet` SwiftUI ne se met pas en page sur iOS récent (feuille vide, aucune cible AirDrop). → **présentation directe** depuis le contrôleur le plus haut de la fenêtre clé (avec ancre popover pour iPad).
- Le fichier temp `.rclonebackup` était écrit en `.completeFileProtection`, illisible par le daemon de partage `sharingd` qui lit hors-process. → abaissé à `.completeUntilFirstUserAuthentication` (le payload est déjà chiffré ChaCha20-Poly1305, la protection fichier n'était que de la défense en profondeur).

## Tests
Suite Handoff **21/21** sur simulateur iOS 27. 2 nouveaux cas de non-régression : `materializeAirDropFile` produit un fichier lisible qui round-trip via `HandoffInbox`, et la protection du fichier n'est pas `.complete`.

Branché sur origin/main à jour (après #106 « mode Auto »).