### PR TITLE
Fix téléchargement de dossier : progression juste + anti-gel iCloud Drive

### DIFF
--- a/Rclone GUI/Services/BridgeFolderDownloader.swift
+++ b/Rclone GUI/Services/BridgeFolderDownloader.swift
@@ -57,6 +57,11 @@ public actor BridgeFolderDownloader {
     /// Progression courante du download (snapshot lu par les callers).
     private var lastSnapshot: ProgressSnapshot = .init(bytesTransferred: 0, bytesTotal: 0, filesCompleted: 0, filesTotal: 0, currentFilename: nil)
 
+    /// Erreurs des workers, collectées de façon actor-isolée (les tâches
+    /// enfants du TaskGroup y écrivent via `recordWorkerError` — jamais un
+    /// `append` concurrent sur une variable locale = plus de data race).
+    private var workerErrors: [Error] = []
+
     public func lastProgress() -> ProgressSnapshot { lastSnapshot }
 
     /// Télécharge un dossier via N workers bridge parallèles. Le callback
@@ -96,25 +101,19 @@ public actor BridgeFolderDownloader {
         // 3) Skip fichiers déjà présents avec taille identique (reprise après
         //    pause sans tout retélécharger). On calcule bytesTransferred
         //    initial pour ne pas fausser la barre de progression.
-        var todo: [(entry: RemoteEntryDTO, destURL: URL)] = []
-        var skippedBytes: Int64 = 0
-        var skippedCount = 0
         let partition = Self.partitionByExistence(
             files: sorted, sourcePath: sourcePath, destDir: destDir
         )
-        skippedBytes = partition.skippedBytes
-        skippedCount = partition.skippedCount
-        todo = partition.todo
-
+        let todo = partition.todo
         let bytesTotal = sorted.reduce(Int64(0)) { $0 + $1.size }
-        var bytesTransferred = skippedBytes
-        var filesCompleted = skippedCount
 
-        // Snapshot initial
-        var snapshot = ProgressSnapshot(
-            bytesTransferred: bytesTransferred,
+        // Snapshot initial (les octets/fichiers « skippés » comptent déjà comme
+        // faits). Ensuite tout passe par l'état actor `lastSnapshot`, jamais par
+        // une locale figée — d'où `let` : ce snapshot n'est plus muté.
+        let snapshot = ProgressSnapshot(
+            bytesTransferred: partition.skippedBytes,
             bytesTotal: bytesTotal,
-            filesCompleted: filesCompleted,
+            filesCompleted: partition.skippedCount,
             filesTotal: sorted.count,
             currentFilename: nil
         )
@@ -123,36 +122,26 @@ public actor BridgeFolderDownloader {
 
         await LogService.shared.log(
             .info, category: "transfer",
-            message: "🌉 BridgeFolderDownloader start remote=\(remote):\(sourcePath) → \(destDir.path) files=\(sorted.count) skip=\(skippedCount) concurrency=\(concurrency) bytesTotal=\(bytesTotal)"
+            message: "🌉 BridgeFolderDownloader start remote=\(remote):\(sourcePath) → \(destDir.path) files=\(sorted.count) skip=\(partition.skippedCount) concurrency=\(concurrency) bytesTotal=\(bytesTotal)"
         )
 
-        // 4) Pool de workers TaskGroup avec concurrence bornée
+        // 4) Pool de workers TaskGroup avec concurrence bornée.
+        //    Les callbacks de progression lisent l'état actor VIVANT
+        //    (`lastProgress()`) — surtout PAS la variable locale `snapshot`
+        //    figée à son état initial (sinon l'UI reste bloquée à 0 %).
         var iterator = todo.makeIterator()
         let throttledProgress = ThrottledProgress(onProgress: onProgress, intervalMs: 500)
-        var workerErrors: [Error] = []
+        workerErrors = []
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             // Seed N workers
             for _ in 0..<concurrency {
                 guard let next = iterator.next() else { break }
                 group.addTask { [self] in
-                    do {
-                        try await runWorker(
-                            remote: remote,
-                            entry: next.entry,
-                            destURL: next.destURL,
-                            onFileBytes: { writtenDelta, totalSize in
-                                Task { await self.recordFileBytes(delta: writtenDelta, currentTotal: snapshot.bytesTotal) }
-                                throttledProgress.maybeFire(snapshot)
-                            },
-                            onFileDone: { filename in
-                                Task { await self.recordFileDone(filename: filename, currentTotal: snapshot.bytesTotal) }
-                                throttledProgress.maybeFire(snapshot, force: true)
-                            }
-                        )
-                    } catch {
-                        workerErrors.append(error)
-                    }
+                    await self.runWorkerCapturingError(
+                        remote: remote, entry: next.entry, destURL: next.destURL,
+                        throttledProgress: throttledProgress
+                    )
                 }
             }
 
@@ -162,23 +151,10 @@ public actor BridgeFolderDownloader {
                 if Task.isCancelled { break }
                 while let next = iterator.next() {
                     group.addTask { [self] in
-                        do {
-                            try await runWorker(
-                                remote: remote,
-                                entry: next.entry,
-                                destURL: next.destURL,
-                                onFileBytes: { writtenDelta, _ in
-                                    Task { await self.recordFileBytes(delta: writtenDelta, currentTotal: snapshot.bytesTotal) }
-                                    throttledProgress.maybeFire(snapshot)
-                                },
-                                onFileDone: { filename in
-                                    Task { await self.recordFileDone(filename: filename, currentTotal: snapshot.bytesTotal) }
-                                    throttledProgress.maybeFire(snapshot, force: true)
-                                }
-                            )
-                        } catch {
-                            workerErrors.append(error)
-                        }
+                        await self.runWorkerCapturingError(
+                            remote: remote, entry: next.entry, destURL: next.destURL,
+                            throttledProgress: throttledProgress
+                        )
                     }
                 }
             }
@@ -197,17 +173,57 @@ public actor BridgeFolderDownloader {
         }
 
         let elapsed = Int(Date().timeIntervalSince(started))
-        let avgSpeed = elapsed > 0 ? bytesTransferred / Int64(elapsed) : 0
+        // Débit/octets lus depuis l'état actor vivant, pas les compteurs
+        // initiaux (bug de flush final : ils restaient aux valeurs de skip).
+        let doneBytes = lastSnapshot.bytesTransferred
+        let avgSpeed = elapsed > 0 ? doneBytes / Int64(elapsed) : 0
         await LogService.shared.log(
             .info, category: "transfer",
-            message: "✅ BridgeFolderDownloader DONE remote=\(remote):\(sourcePath) files=\(sorted.count) bytes=\(bytesTransferred)/\(bytesTotal) elapsed=\(elapsed)s avg=\(avgSpeed) B/s"
+            message: "✅ BridgeFolderDownloader DONE remote=\(remote):\(sourcePath) files=\(sorted.count) bytes=\(doneBytes)/\(bytesTotal) elapsed=\(elapsed)s avg=\(avgSpeed) B/s"
         )
 
-        // Flush final
-        snapshot.bytesTransferred = bytesTransferred
-        snapshot.filesCompleted = filesCompleted
-        lastSnapshot = snapshot
-        await MainActor.run { onProgress(snapshot) }
+        // Flush final : pousse l'état actor VIVANT (et non les locales figées).
+        lastSnapshot.currentFilename = nil
+        let final = lastSnapshot
+        await MainActor.run { onProgress(final) }
+    }
+
+    /// Exécute un worker et capture son éventuelle erreur dans l'état
+    /// actor-isolé (plus de `workerErrors.append` depuis des tâches enfants
+    /// concurrentes = data race). Les callbacks poussent le snapshot VIVANT.
+    private func runWorkerCapturingError(
+        remote: String,
+        entry: RemoteEntryDTO,
+        destURL: URL,
+        throttledProgress: ThrottledProgress
+    ) async {
+        do {
+            try await runWorker(
+                remote: remote,
+                entry: entry,
+                destURL: destURL,
+                onFileBytes: { [self] writtenDelta, _ in
+                    Task {
+                        await self.recordFileBytes(delta: writtenDelta)
+                        throttledProgress.maybeFire(await self.lastProgress())
+                    }
+                },
+                onFileDone: { [self] filename in
+                    Task {
+                        await self.recordFileDone(filename: filename)
+                        throttledProgress.maybeFire(await self.lastProgress(), force: true)
+                    }
+                }
+            )
+        } catch is CancellationError {
+            // Pause/annulation : pas une erreur de transfert.
+        } catch {
+            recordWorkerError(error)
+            await LogService.shared.log(
+                .error, category: "transfer",
+                message: "🌉 worker échec \(remote):\(entry.pathInRemote) — \(error.localizedDescription)"
+            )
+        }
     }
 
     // MARK: - Worker
@@ -255,20 +271,29 @@ public actor BridgeFolderDownloader {
 
     // MARK: - Progress bookkeeping (actor-isolated)
 
-    fileprivate func recordFileBytes(delta: Int64, currentTotal: Int64) {
-        var snap = lastSnapshot
-        snap.bytesTransferred += delta
-        lastSnapshot = snap
+    fileprivate func recordFileBytes(delta: Int64) {
+        lastSnapshot.bytesTransferred += delta
     }
 
-    fileprivate func recordFileDone(filename: String, currentTotal: Int64) {
-        var snap = lastSnapshot
-        snap.filesCompleted += 1
-        snap.currentFilename = filename
-        lastSnapshot = snap
+    fileprivate func recordFileDone(filename: String) {
+        lastSnapshot.filesCompleted += 1
+        lastSnapshot.currentFilename = filename
+    }
+
+    fileprivate func recordWorkerError(_ error: Error) {
+        workerErrors.append(error)
     }
 
     // MARK: - Pure helpers (testable sans HTTP ni actor)
+
+    /// Convertit un compteur d'octets CUMULATIF (celui que remonte
+    /// `URLSessionDownloadDelegate.didWriteData` via `totalBytesWritten`) en
+    /// DELTA depuis le dernier rapport. Sans ça, le cumul était ajouté comme
+    /// un delta à chaque tick → `bytesTransferred` explosait. Clampé à 0 pour
+    /// absorber un éventuel reset (relance de la même tâche).
+    nonisolated static func progressDelta(previous: Int64, cumulative: Int64) -> Int64 {
+        max(0, cumulative - previous)
+    }
 
     /// Tri large-first : sature le réseau dès les premiers octets (les gros
     /// fichiers remplissent le pipe et les petits finissent dans la queue).
@@ -336,6 +361,10 @@ private final class FileWorkerDownloader: NSObject, URLSessionDownloadDelegate, 
     private var session: URLSession?
     private var moveError: Error?
     private var lastProgressAt = Date.distantPast
+    /// Dernier cumul REPORTÉ (pas seulement reçu) : n'avance qu'aux ticks
+    /// réellement émis, pour que le delta englobe les octets des ticks sautés
+    /// par le throttle (aucune perte de progression).
+    private var lastReportedWritten: Int64 = 0
 
     init(dest: URL, onProgress: @escaping @Sendable (Int64, Int64) -> Void) {
         self.dest = dest
@@ -372,7 +401,14 @@ private final class FileWorkerDownloader: NSObject, URLSessionDownloadDelegate, 
         let now = Date()
         if now.timeIntervalSince(lastProgressAt) >= 0.25 {
             lastProgressAt = now
-            onProgress(totalBytesWritten, max(0, totalBytesExpectedToWrite))
+            // DELTA (pas le cumul) : le caller additionne ces valeurs. On
+            // n'avance lastReportedWritten qu'ici → un tick sauté par le
+            // throttle est inclus dans le prochain delta.
+            let delta = BridgeFolderDownloader.progressDelta(
+                previous: lastReportedWritten, cumulative: totalBytesWritten
+            )
+            lastReportedWritten = totalBytesWritten
+            onProgress(delta, max(0, totalBytesExpectedToWrite))
         }
     }
 
@@ -405,16 +441,22 @@ private final class FileWorkerDownloader: NSObject, URLSessionDownloadDelegate, 
     }
 }
 
-/// Helper pour throttler les callbacks de progression. Pas d'actor isolation :
-/// utilisé depuis plusieurs workers simultanément, garde son état interne.
-private final class ThrottledProgress: @unchecked Sendable {
-    private let onProgress: @Sendable (BridgeFolderDownloader.ProgressSnapshot) -> Void
+/// Helper pour throttler les callbacks de progression. `nonisolated` explicite :
+/// le projet est en SWIFT_DEFAULT_ACTOR_ISOLATION=MainActor, sans ça cette
+/// classe hériterait de @MainActor alors qu'elle est appelée depuis plusieurs
+/// workers hors main. Elle garde son état interne sous NSLock et re-hoppe
+/// elle-même sur le MainActor pour invoquer `onProgress`.
+private nonisolated final class ThrottledProgress: @unchecked Sendable {
+    // Typé @MainActor : le callback met à jour SwiftData/UI, et maybeFire
+    // re-hoppe explicitement sur le MainActor pour l'invoquer (pas de perte
+    // d'isolation à la conversion — warning Swift 6 résolu).
+    private let onProgress: @MainActor @Sendable (BridgeFolderDownloader.ProgressSnapshot) -> Void
     private let interval: TimeInterval
     private var lastFire: Date = .distantPast
     private let lock = NSLock()
 
     init(
-        onProgress: @escaping @Sendable (BridgeFolderDownloader.ProgressSnapshot) -> Void,
+        onProgress: @escaping @MainActor @Sendable (BridgeFolderDownloader.ProgressSnapshot) -> Void,
         intervalMs: Int
     ) {
         self.onProgress = onProgress

--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -1069,34 +1069,57 @@ public final class TransferQueue {
                 )
             }
             updateBatch(transfer.batchID, completedDelta: 1, failedDelta: 0)
+        } catch is CancellationError {
+            // Pause/annulation utilisateur : ni échec ni fallback.
+            if let pair = resolvedBookmark, pair.didStart {
+                pair.url.stopAccessingSecurityScopedResource()
+            }
+            return
         } catch {
-            await LogService.shared.log(
-                .info, category: "transfer",
-                message: "BridgeFolderDownloader échec \(remote):\(transfer.sourcePath) — fallback sync/copy : \(error.localizedDescription)"
-            )
-            // Fallback sync/copy : réutilise le chemin rclone historique.
-            // Le scope security-scoped est conservé pour le sync/copy.
-            do {
-                let jobID = try await relaunch(transfer)
-                guard let t = fetchTransfer(id: id), t.status == .running else { return }
-                t.jobID = jobID
-                try? modelContext?.save()
-                startPolling(t)
-                return
-            } catch {
-                if let t = fetchTransfer(id: id) {
-                    if autoPauseInsteadOfFail(t) {
-                        // Double échec parce que le réseau est tombé : pause
-                        // auto — reprise skip-existing au retour du lien.
-                    } else {
-                        t.status = .failed
-                        t.lastError = "Bridge + sync/copy ont échoué : \(error.localizedDescription)"
-                        t.finishedAt = .now
-                        try? modelContext?.save()
-                        await LogService.shared.log(
-                            .error, category: "transfer",
-                            message: "❌ Bridge + sync/copy ont échoué pour \(remote):\(transfer.sourcePath) — \(error.localizedDescription)"
-                        )
+            // GARDE-FOU ANTI-GEL : vers iCloud Drive, on NE retombe PAS sur
+            // sync/copy. C'est précisément le chemin que le bridge remplace :
+            // rclone écrivant un gros dossier dans com~apple~CloudDocs réveille
+            // le daemon `bird` et FIGE l'app (9 GB). Mieux vaut un échec clair.
+            if Self.isICloudDrivePath(transfer.destinationPath) {
+                if let t = fetchTransfer(id: id), !autoPauseInsteadOfFail(t) {
+                    t.status = .failed
+                    t.lastError = String(localized: "Téléchargement du dossier interrompu. Réessayez vers « Sur mon iPhone » : le repli iCloud Drive est désactivé car il peut figer l'app sur les gros dossiers.")
+                    t.finishedAt = .now
+                    try? modelContext?.save()
+                }
+                await LogService.shared.log(
+                    .error, category: "transfer",
+                    message: "❌ Bridge échoué + destination iCloud Drive → repli sync/copy DÉSACTIVÉ (anti-gel bird) : \(remote):\(transfer.sourcePath) — \(error.localizedDescription)"
+                )
+            } else {
+                await LogService.shared.log(
+                    .info, category: "transfer",
+                    message: "BridgeFolderDownloader échec \(remote):\(transfer.sourcePath) — fallback sync/copy : \(error.localizedDescription)"
+                )
+                // Fallback sync/copy (destination locale) : réutilise le chemin
+                // rclone historique. Le scope security-scoped est conservé.
+                do {
+                    let jobID = try await relaunch(transfer)
+                    guard let t = fetchTransfer(id: id), t.status == .running else { return }
+                    t.jobID = jobID
+                    try? modelContext?.save()
+                    startPolling(t)
+                    return
+                } catch {
+                    if let t = fetchTransfer(id: id) {
+                        if autoPauseInsteadOfFail(t) {
+                            // Double échec parce que le réseau est tombé : pause
+                            // auto — reprise skip-existing au retour du lien.
+                        } else {
+                            t.status = .failed
+                            t.lastError = "Bridge + sync/copy ont échoué : \(error.localizedDescription)"
+                            t.finishedAt = .now
+                            try? modelContext?.save()
+                            await LogService.shared.log(
+                                .error, category: "transfer",
+                                message: "❌ Bridge + sync/copy ont échoué pour \(remote):\(transfer.sourcePath) — \(error.localizedDescription)"
+                            )
+                        }
                     }
                 }
             }
@@ -2112,6 +2135,14 @@ public final class TransferQueue {
         var isDirectory: ObjCBool = false
         FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
         return isDirectory.boolValue
+    }
+
+    /// Le chemin est-il dans iCloud Drive ? Les URLs de l'espace « iCloud Drive »
+    /// (dossier Mobile Documents) contiennent le conteneur `com~apple~CloudDocs` ;
+    /// y écrire un gros dossier déclenche le daemon `bird` (upload iCloud) qui
+    /// fige l'app. `nonisolated static` → pur et testable sans le singleton.
+    nonisolated static func isICloudDrivePath(_ path: String) -> Bool {
+        path.contains("com~apple~CloudDocs") || path.contains("/Mobile Documents/")
     }
 
     private func fileSize(at url: URL) -> Int64 {

--- a/Rclone GUITests/FolderDownloadFixTests.swift
+++ b/Rclone GUITests/FolderDownloadFixTests.swift
@@ -1,0 +1,67 @@
+//
+//  FolderDownloadFixTests.swift
+//  Rclone GUITests
+//
+//  Tests des helpers purs introduits par le correctif des téléchargements de
+//  dossier : conversion cumul→delta de la progression bridge, et détection
+//  des destinations iCloud Drive (garde-fou anti-gel du daemon `bird`).
+//
+
+import Foundation
+import Testing
+@testable import Rclone_GUI
+
+@Suite("BridgeFolderDownloader — progressDelta (cumul → delta)")
+struct BridgeFolderProgressDeltaTests {
+
+    @Test("Le delta est la différence depuis le dernier cumul reporté")
+    func basicDelta() {
+        #expect(BridgeFolderDownloader.progressDelta(previous: 0, cumulative: 1_000) == 1_000)
+        #expect(BridgeFolderDownloader.progressDelta(previous: 1_000, cumulative: 2_500) == 1_500)
+    }
+
+    @Test("La somme des deltas d'une séquence cumulative croissante == dernier cumul")
+    func deltasSumToCumulative() {
+        let cumulatives: [Int64] = [0, 512, 4_096, 4_096, 1_048_576, 9_000_000]
+        var previous: Int64 = 0
+        var sum: Int64 = 0
+        for c in cumulatives {
+            sum += BridgeFolderDownloader.progressDelta(previous: previous, cumulative: c)
+            previous = c
+        }
+        #expect(sum == cumulatives.last!)
+        // Régression du bug d'origine : le cumul n'est JAMAIS compté tel quel.
+        #expect(sum != cumulatives.reduce(0, +))
+    }
+
+    @Test("Un cumul stagnant (tick sans nouveaux octets) donne un delta nul")
+    func zeroWhenNoProgress() {
+        #expect(BridgeFolderDownloader.progressDelta(previous: 5_000, cumulative: 5_000) == 0)
+    }
+
+    @Test("Un reset du cumul (relance de tâche) est clampé à 0, pas négatif")
+    func clampsRegressionToZero() {
+        #expect(BridgeFolderDownloader.progressDelta(previous: 9_000_000, cumulative: 0) == 0)
+    }
+}
+
+@Suite("TransferQueue — détection iCloud Drive (anti-gel)")
+struct ICloudDrivePathTests {
+
+    @Test("Les chemins iCloud Drive sont détectés")
+    func detectsICloud() {
+        #expect(TransferQueue.isICloudDrivePath(
+            "/private/var/mobile/Library/Mobile Documents/com~apple~CloudDocs/Downloads/daisychain") == true)
+        #expect(TransferQueue.isICloudDrivePath(
+            "/var/mobile/Library/Mobile Documents/com~apple~CloudDocs/Films") == true)
+    }
+
+    @Test("Les chemins locaux (Sur mon iPhone, sandbox) ne le sont pas")
+    func rejectsLocal() {
+        #expect(TransferQueue.isICloudDrivePath(
+            "/var/mobile/Containers/Data/Application/ABC/Documents/daisychain") == false)
+        #expect(TransferQueue.isICloudDrivePath(
+            "/private/var/mobile/Containers/Shared/AppGroup/XYZ/Downloads") == false)
+        #expect(TransferQueue.isICloudDrivePath("") == false)
+    }
+}


### PR DESCRIPTION
## Contexte
Signalé sur device : un download de dossier (9 GB vers iCloud Drive) restait bloqué à **0 %** et **figeait l'app**.

## Diagnostic
- Le `BridgeFolderDownloader` (arrivé par #105) avait 3 bugs de progression : la barre affichait 0 % **même quand les octets descendaient**.
- La destination était **iCloud Drive** (`com~apple~CloudDocs`). Quand le bridge échoue, le repli `sync/copy` réécrit 9 GB dans un dossier iCloud → le daemon `bird` sature et **fige l'app** — exactement le gel que le bridge était censé éviter.

## Corrections

### Progression (`BridgeFolderDownloader.swift`)
1. **Snapshot figé** : les callbacks poussaient la variable locale `snapshot` figée à l'état initial (0 octet). Ils lisent désormais l'état actor **vivant** (`lastProgress()`).
2. **Cumul compté comme delta** : `URLSessionDownloadDelegate` remonte `totalBytesWritten` (cumulatif), additionné comme un delta → `bytesTransferred` explosait. Conversion cumul→delta bornée à 0 (`progressDelta`, testée), le cumul reporté n'avance qu'aux ticks émis (aucune perte au throttle).
3. **Data race** : `workerErrors` était muté depuis les tâches enfants concurrentes → collecte actor-isolée (`recordWorkerError`).
4. **Flush final** lisait les compteurs initiaux figés → lit l'état actor vivant.

### Anti-gel (`TransferQueue.swift`)
- Le repli `sync/copy` est **désactivé pour les destinations iCloud Drive** (`isICloudDrivePath`, pur + testé) : au lieu de figer, on échoue clairement avec un message invitant à télécharger vers « Sur mon iPhone ».
- `CancellationError` (pause/annulation) n'est plus traité comme un échec ni un repli.

### Nettoyage
- `ThrottledProgress` marqué `nonisolated` + callback `@MainActor @Sendable` → warnings de concurrence Swift 6 résolus dans ce fichier.
- Log par worker en échec (facilite le diag device du 404 bridge résiduel).

## Tests
`Rclone GUITests` : **142 passed / 0 failed / 0 warning** (6 nouveaux : `progressDelta` cumul→delta + somme, clamp reset ; détection iCloud vs local).

## Reste à confirmer sur device (hors périmètre)
Le `FetchService` FileProvider logue un `HTTP 404 on bridge/download` au boot — probablement un fetch **stale** (fichier déplacé/renommé), file-spécifique, pas systémique. Le log par worker ajouté ici révélera si des workers de dossier 404 aussi. Si oui, ce sera un correctif séparé côté chemin bridge.