### PR TITLE
Download iOS-optimisé : staging Caches → iCloud (anti-gel bird)

### DIFF
--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -1052,8 +1052,23 @@ public final class TransferQueue {
         transfer.bytesTransferred = doneBytes
         try? modelContext?.save()
 
+        // Staging Caches quand la destination est iCloud Drive : on télécharge
+        // en local (pas de `bird`) puis on publie chaque fichier terminé. Un
+        // sous-dossier par transfert, nettoyé à la fin.
+        let stagingDir: URL? = Self.isICloudDrivePath(destinationURL.path)
+            ? FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("folder-dl", isDirectory: true)
+                .appendingPathComponent(id, isDirectory: true)
+            : nil
+        if let stagingDir {
+            try? FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+        }
+        func cleanupStaging() {
+            if let stagingDir { try? FileManager.default.removeItem(at: stagingDir) }
+        }
+
         await LogService.shared.log(.info, category: "transfer",
-            message: "📁 Download dossier (par fichiers) \(remote):\(sourcePath) files=\(files.count) skip=\(partition.skippedCount) concurrency=\(min(max(maxConcurrent,1),8)) bytesTotal=\(bytesTotal)")
+            message: "📁 Download dossier (par fichiers\(stagingDir != nil ? ", staging iCloud" : "")) \(remote):\(sourcePath) files=\(files.count) skip=\(partition.skippedCount) concurrency=\(min(max(maxConcurrent,1),8)) bytesTotal=\(bytesTotal)")
 
         // 3) File bornée de copyfile+poll. maxConcurrent respecte le mode Auto
         //    / le réglage manuel, borné 1…8. Chaque copyfile passe par le
@@ -1072,7 +1087,7 @@ public final class TransferQueue {
                 let name = next.entry.name
                 group.addTask { [self] in
                     do {
-                        try await self.copyFileAndWait(remote: remote, srcPath: srcPath, destURL: destURL)
+                        try await self.copyFileAndWait(remote: remote, srcPath: srcPath, destURL: destURL, stagingDir: stagingDir)
                         return (name, size, nil)
                     } catch {
                         return (name, size, error)
@@ -1101,6 +1116,9 @@ public final class TransferQueue {
         }
 
         releaseScope()
+        // Nettoyage du staging (fichiers publiés = déplacés ; restes partiels
+        // sur erreur/annulation = à jeter, re-téléchargés à la reprise).
+        cleanupStaging()
 
         // 4) Finalisation.
         if Task.isCancelled {
@@ -1135,27 +1153,82 @@ public final class TransferQueue {
     /// instantanément (jobID) → la lane du bouclier est libérée aussitôt, seul
     /// le poll — léger — reste. `Task.checkCancellation()` stoppe le poll sur
     /// pause/annulation (le fichier partiel sera re-téléchargé au skip-existing).
-    private func copyFileAndWait(remote: String, srcPath: String, destURL: URL) async throws {
-        let parent = destURL.deletingLastPathComponent()
+    ///
+    /// OPTIMISATION iOS (anti-gel iCloud) : si `stagingDir` est fourni
+    /// (destination iCloud Drive), on télécharge d'abord dans le sandbox
+    /// (`Caches`) — écriture locale rapide qui ne réveille PAS le daemon
+    /// `bird` — puis on publie le fichier TERMINÉ vers iCloud via
+    /// `NSFileCoordinator`. Écrire chaque chunk directement dans
+    /// `com~apple~CloudDocs` faisait thrasher `bird` (coordination + hash +
+    /// upload permanents) → gel. Destination locale (`stagingDir == nil`) :
+    /// écriture directe, inchangée.
+    private func copyFileAndWait(
+        remote: String,
+        srcPath: String,
+        destURL: URL,
+        stagingDir: URL?
+    ) async throws {
+        let writeURL = stagingDir?.appendingPathComponent(UUID().uuidString) ?? destURL
+        let parent = writeURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+
         let jobID = try await TransferService.shared.copyFileAsync(
             srcFs: "\(remote):", srcPath: srcPath,
-            dstFs: parent.path, dstPath: destURL.lastPathComponent
+            dstFs: parent.path, dstPath: writeURL.lastPathComponent
         )
-        while true {
-            try Task.checkCancellation()
-            let status = try await TransferService.shared.jobStatus(jobID: jobID)
-            if status.finished {
-                if !status.success {
-                    throw RcloneError.rcloneError(
-                        code: 0, method: "operations/copyfile",
-                        message: status.error ?? "échec du téléchargement de \(destURL.lastPathComponent)"
-                    )
+        do {
+            while true {
+                try Task.checkCancellation()
+                let status = try await TransferService.shared.jobStatus(jobID: jobID)
+                if status.finished {
+                    if !status.success {
+                        throw RcloneError.rcloneError(
+                            code: 0, method: "operations/copyfile",
+                            message: status.error ?? "échec du téléchargement de \(destURL.lastPathComponent)"
+                        )
+                    }
+                    break
                 }
-                return
+                try await Task.sleep(for: .milliseconds(500))
             }
-            try await Task.sleep(for: .milliseconds(500))
+        } catch {
+            if stagingDir != nil { try? FileManager.default.removeItem(at: writeURL) }
+            throw error
         }
+
+        // Publication du fichier TERMINÉ vers iCloud, hors MainActor (le move
+        // coordonné peut bloquer). Le scope security-scoped est actif au niveau
+        // process pour toute la durée du dossier → le move de fond y a accès.
+        if stagingDir != nil {
+            let staged = writeURL
+            let final = destURL
+            try await Task.detached(priority: .utility) {
+                try Self.publishFileCoordinated(from: staged, to: final)
+            }.value
+        }
+    }
+
+    /// Déplace un fichier TERMINÉ du staging vers sa destination finale iCloud,
+    /// sous `NSFileCoordinator` (writing/`.forReplacing`) pour éviter les
+    /// conflits avec le daemon `bird`. `nonisolated static` → appelable depuis
+    /// une tâche de fond. On ne publie qu'un fichier FERMÉ (plus d'écriture) →
+    /// une seule passe de synchro iCloud au lieu d'un thrash continu.
+    nonisolated static func publishFileCoordinated(from src: URL, to dest: URL) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let coordinator = NSFileCoordinator(filePresenter: nil)
+        var coordError: NSError?
+        var opError: Error?
+        coordinator.coordinate(writingItemAt: dest, options: .forReplacing, error: &coordError) { url in
+            do {
+                if fm.fileExists(atPath: url.path) { try fm.removeItem(at: url) }
+                try fm.moveItem(at: src, to: url)
+            } catch {
+                opError = error
+            }
+        }
+        if let coordError { throw coordError }
+        if let opError { throw opError }
     }
 
     /// Crée le transfert EN FILE D'ATTENTE (.enqueued) puis tente de démarrer.

--- a/Rclone GUITests/ICloudStagingTests.swift
+++ b/Rclone GUITests/ICloudStagingTests.swift
@@ -1,0 +1,71 @@
+//
+//  ICloudStagingTests.swift
+//  Rclone GUITests
+//
+//  Tests du move coordonné staging→destination (optimisation iOS anti-gel
+//  iCloud : télécharger en Caches puis publier via NSFileCoordinator).
+//
+
+import Foundation
+import Testing
+@testable import Rclone_GUI
+
+@Suite("TransferQueue — publication coordonnée (staging → destination)")
+struct ICloudStagingTests {
+
+    private func tempDir() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("staging-test-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    @Test("Déplace le fichier staged vers la destination et supprime la source")
+    func movesStagedFileToDestination() throws {
+        let fm = FileManager.default
+        let root = tempDir()
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let staged = root.appendingPathComponent("staged.bin")
+        let payload = Data("bonjour daisychain".utf8)
+        try payload.write(to: staged)
+
+        // Destination dans un sous-dossier encore inexistant (créé par le helper).
+        let dest = root.appendingPathComponent("sub/dir/final.bin")
+
+        try TransferQueue.publishFileCoordinated(from: staged, to: dest)
+
+        #expect(fm.fileExists(atPath: dest.path))
+        #expect(!fm.fileExists(atPath: staged.path))
+        #expect(try Data(contentsOf: dest) == payload)
+    }
+
+    @Test("Remplace un fichier existant à la destination (.forReplacing)")
+    func replacesExistingDestination() throws {
+        let fm = FileManager.default
+        let root = tempDir()
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let dest = root.appendingPathComponent("final.bin")
+        try Data("ancien".utf8).write(to: dest)
+
+        let staged = root.appendingPathComponent("staged.bin")
+        let fresh = Data("nouveau contenu".utf8)
+        try fresh.write(to: staged)
+
+        try TransferQueue.publishFileCoordinated(from: staged, to: dest)
+
+        #expect(try Data(contentsOf: dest) == fresh)
+        #expect(!fm.fileExists(atPath: staged.path))
+    }
+
+    @Test("Les chemins iCloud déclenchent le staging, les locaux non")
+    func icloudDetectionGatesStaging() {
+        // La décision de stager repose sur isICloudDrivePath (déjà testé) —
+        // on revérifie le contrat exact utilisé par downloadFolderViaFiles.
+        #expect(TransferQueue.isICloudDrivePath(
+            "/var/mobile/Library/Mobile Documents/com~apple~CloudDocs/Downloads/x") == true)
+        #expect(TransferQueue.isICloudDrivePath(
+            "/var/mobile/Containers/Data/Application/A/Documents/x") == false)
+    }
+}


### PR DESCRIPTION
## Contexte
Malgré #106/#108/#109, l'app peut encore figer pendant les téléchargements. Sur demande de Vitaly (« revois tout le système, prend un autre moteur, optimisé iOS »), recherche + refonte iOS-native.

## Recherche (Perplexity + best practices Apple)
- **Pas de meilleur moteur que rclone** pour 70+ backends sur iOS — il reste le moteur. Les alternatives (SDK par provider) perdent la couverture multi-backend ; rclone côté serveur n'est pas applicable à une app standalone.
- **URLSession background** est l'idéal iOS mais **ne peut pas parler à un serveur `127.0.0.1` rclone** (il meurt quand l'app est suspendue) → non viable ici. Pour un download foreground, le transfert reste in-process quel que soit le mécanisme.
- **LA cause du gel** (doc Apple) : écrire un gros download **directement dans iCloud Drive** (`com~apple~CloudDocs`) fait thrasher le daemon `bird` (coordination + hash + upload à chaque écriture). Solution documentée : **télécharger dans le sandbox (`Caches`), puis publier via `NSFileCoordinator`**.

Le levier n'était donc pas le moteur mais **la façon d'écrire dans iCloud**.

## Changement
Pour les destinations **iCloud Drive** (détectées par `isICloudDrivePath`) :
1. chaque fichier est téléchargé dans un staging `Library/Caches/folder-dl/<id>/` — **écriture locale rapide, `bird` au repos** ;
2. le fichier **terminé** est publié vers iCloud via `NSFileCoordinator(writingItemAt:.forReplacing)`, **hors MainActor** (`Task.detached`) car le move peut bloquer ;
3. `bird` ne fait qu'**une passe par fichier fermé, en arrière-plan**, au lieu d'un thrash continu ;
4. nettoyage du staging à la fin (publiés = déplacés ; restes partiels jetés → re-téléchargés au skip-existing à la reprise).

**Destinations locales** (Sur mon iPhone, sandbox) : écriture directe, **inchangée** (déjà sans `bird`).

Le moteur reste rclone (copyfile par fichier, borné, à travers le bouclier `cgoQueue` — établi en #109).

## Tests
`Rclone GUITests` : **145 passed / 0 failed** (3 nouveaux : `publishFileCoordinated` déplace le fichier + supprime la source, remplace un existant, et le gating iCloud vs local).

## Suite possible (hors périmètre)
Appliquer le même staging aux downloads de **fichier unique** vers iCloud (aujourd'hui écriture directe via `relaunch`/`pollLoop`) — un seul fichier = un seul évènement `bird`, moins critique que les dossiers.