### PR TITLE
Perf : purge automatique de l'historique des transferts (fin du ralenti)

### DIFF
--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -221,11 +221,65 @@ public final class TransferQueue {
     public func attach(modelContext: ModelContext) {
         guard self.modelContext !== modelContext else { return }
         self.modelContext = modelContext
+        pruneTerminalTransfers()
         Task { await replayInterrupted() }
         startStatsPolling()
         startEnergyObservers()
         migrateAutoModeDefaultIfNeeded()
         refreshAutoPolicy()
+    }
+
+    /// Plafond d'historique des transferts TERMINÉS (completed/failed) gardés en
+    /// base. Sans purge, la table `Transfer` grossissait indéfiniment (rien ne
+    /// supprimait les lignes terminées hors PhotoSync) : le `@Query` non borné
+    /// de l'écran Transferts matérialisait des milliers de lignes à CHAQUE
+    /// `save()` (polling, progression…) → l'app « tournait au ralenti » et
+    /// empirait avec l'usage. On garde les N plus récents.
+    static let maxTerminalHistory = 300
+
+    /// Supprime les transferts terminés au-delà du plafond (les plus anciens),
+    /// SANS toucher aux lignes d'un batch encore en cours (updateRunningBatches
+    /// resomme la progression depuis les `Transfer` → elle régresserait).
+    /// Appelé à l'attach (borne l'accumulation inter-sessions, principal vecteur
+    /// de lenteur) et après complétion d'un batch.
+    func pruneTerminalTransfers() {
+        guard let modelContext else { return }
+        let terminalDescriptor = FetchDescriptor<Transfer>(
+            predicate: #Predicate { $0.statusRaw == "completed" || $0.statusRaw == "failed" },
+            sortBy: [SortDescriptor(\.startedAt, order: .reverse)]
+        )
+        guard let terminal = try? modelContext.fetch(terminalDescriptor),
+              terminal.count > Self.maxTerminalHistory else { return }
+        let runningBatchDescriptor = FetchDescriptor<TransferBatch>(
+            predicate: #Predicate { $0.statusRaw == "running" }
+        )
+        let runningBatchIDs = Set((try? modelContext.fetch(runningBatchDescriptor))?.map(\.id) ?? [])
+        let byID = Dictionary(uniqueKeysWithValues: terminal.map { ($0.id, $0) })
+        let toDelete = Self.terminalTransfersToPrune(
+            sortedTerminal: terminal.map { (id: $0.id, batchID: $0.batchID) },
+            runningBatchIDs: runningBatchIDs,
+            keepingRecent: Self.maxTerminalHistory
+        )
+        guard !toDelete.isEmpty else { return }
+        for id in toDelete { if let t = byID[id] { modelContext.delete(t) } }
+        try? modelContext.save()
+        Task { await LogService.shared.log(.info, category: "transfer",
+            message: "🧹 Purge historique transferts : \(toDelete.count) ligne(s) terminée(s) supprimée(s) (plafond \(Self.maxTerminalHistory))") }
+    }
+
+    /// Sélection PURE des transferts terminés à supprimer : au-delà du plafond
+    /// (les plus anciens, la liste étant du plus récent au plus ancien), en
+    /// EXCLUANT ceux d'un batch encore en cours. Renvoie les ids à supprimer.
+    nonisolated static func terminalTransfersToPrune(
+        sortedTerminal: [(id: String, batchID: String?)],
+        runningBatchIDs: Set<String>,
+        keepingRecent: Int
+    ) -> [String] {
+        guard sortedTerminal.count > keepingRecent else { return [] }
+        return sortedTerminal.dropFirst(keepingRecent).compactMap { pair in
+            if let bid = pair.batchID, runningBatchIDs.contains(bid) { return nil }
+            return pair.id
+        }
     }
 
     /// Défaut ON du mode Auto réservé aux installations SANS réglage manuel
@@ -2225,11 +2279,16 @@ public final class TransferQueue {
         guard let batchID, let batch = fetchBatch(id: batchID) else { return }
         batch.completedItems += completedDelta
         batch.failedItems += failedDelta
+        var didFinish = false
         if batch.completedItems + batch.failedItems >= batch.totalItems {
             batch.status = batch.failedItems > 0 ? .failed : .completed
             batch.finishedAt = .now
+            didFinish = true
         }
         try? modelContext?.save()
+        // Un batch vient de se terminer → borne l'historique (évite que les
+        // gros batches fassent gonfler la table dans la même session).
+        if didFinish { pruneTerminalTransfers() }
     }
 
     /// Renvoie `true` si au moins un champ d'un batch a été modifié, pour

--- a/Rclone GUITests/PruneHistoryTests.swift
+++ b/Rclone GUITests/PruneHistoryTests.swift
@@ -1,0 +1,56 @@
+//
+//  PruneHistoryTests.swift
+//  Rclone GUITests
+//
+//  Tests de la sélection PURE des transferts terminés à purger (borne
+//  l'historique SwiftData → le @Query non borné ne matérialise plus des
+//  milliers de lignes = fin du « tourne au ralenti »).
+//
+
+import Foundation
+import Testing
+@testable import Rclone_GUI
+
+@Suite("TransferQueue — purge de l'historique (sélection pure)")
+struct PruneHistoryTests {
+
+    private func terminal(_ n: Int, batchID: String? = nil) -> [(id: String, batchID: String?)] {
+        // Du plus récent (index 0) au plus ancien — comme le fetch trié desc.
+        (0..<n).map { (id: "t\($0)", batchID: batchID) }
+    }
+
+    @Test("Sous le plafond : rien à supprimer")
+    func underCapKeepsAll() {
+        let ids = TransferQueue.terminalTransfersToPrune(
+            sortedTerminal: terminal(50), runningBatchIDs: [], keepingRecent: 300)
+        #expect(ids.isEmpty)
+    }
+
+    @Test("Au-delà du plafond : supprime les plus anciens uniquement")
+    func overCapDeletesOldest() {
+        let ids = TransferQueue.terminalTransfersToPrune(
+            sortedTerminal: terminal(305), runningBatchIDs: [], keepingRecent: 300)
+        // Les 5 plus anciens (indices 300..304) sont supprimés.
+        #expect(ids == ["t300", "t301", "t302", "t303", "t304"])
+    }
+
+    @Test("Ne supprime jamais une ligne d'un batch encore en cours")
+    func neverPrunesRunningBatchRows() {
+        var rows = terminal(300)  // récents, gardés
+        // 5 anciens appartenant à un batch encore running → protégés.
+        rows += (0..<5).map { (id: "old\($0)", batchID: "batchRunning") }
+        // 5 anciens d'un batch terminé → supprimables.
+        rows += (0..<5).map { (id: "dead\($0)", batchID: "batchDone") }
+        let ids = TransferQueue.terminalTransfersToPrune(
+            sortedTerminal: rows, runningBatchIDs: ["batchRunning"], keepingRecent: 300)
+        #expect(Set(ids) == Set(["dead0", "dead1", "dead2", "dead3", "dead4"]))
+        #expect(!ids.contains { $0.hasPrefix("old") })
+    }
+
+    @Test("Plafond exact : rien à supprimer")
+    func exactCapKeepsAll() {
+        let ids = TransferQueue.terminalTransfersToPrune(
+            sortedTerminal: terminal(300), runningBatchIDs: [], keepingRecent: 300)
+        #expect(ids.isEmpty)
+    }
+}


### PR DESCRIPTION
## Symptôme
L'app **tourne au ralenti** (lente, pas figée). Main thread **surchargé de travail répétitif**, pas bloqué.

## Cause
Le `@Query(sort: \Transfer.startedAt)` de l'écran Transferts est **NON BORNÉ** et **rien ne supprimait les transferts terminés** (seul PhotoSync purge ses lignes). La table `Transfer` grossissait à chaque lancement → à **chaque `save()`** (polling, progression — 41 sites), SwiftData **re-matérialise TOUTES les lignes** et re-diffe la liste SwiftUI. Avec des centaines/milliers de transferts d'historique accumulés, l'app ralentit et **empire avec l'usage**.

## Correctif
`pruneTerminalTransfers()` supprime les transferts `completed`/`failed` au-delà d'un plafond (**300 plus récents**), **SANS toucher aux lignes d'un batch encore en cours** (`updateRunningBatches` resomme la progression depuis les `Transfer` → elle régresserait). Appelé :
- à l'**attach** (borne l'accumulation inter-sessions — le principal vecteur de lenteur) ;
- après **complétion d'un batch** (borne dans la session).

La sélection est extraite en **fonction pure** `terminalTransfersToPrune` (testable).

## Tests
`Rclone GUITests` : **149 passed / 0 failed** (4 nouveaux : sous/au plafond, suppression des plus anciens, protection des batches en cours).

## Honnêteté sur le diagnostic
Le `@Query` non borné + l'absence de purge est un anti-pattern SwiftData avéré qui **explique une lenteur croissante** — mais je n'ai pas pu **mesurer** sur ton device. Si le ralenti persiste après réinstallation, il faudra un **Instruments Time Profiler** (ou un `sample` du process) sur l'appareil pour voir où le CPU part précisément.