### PR TITLE
Perf : concurrence dédiée aux fichiers de dossier (vitesse de download)

### DIFF
--- a/Rclone GUI/Services/AutoTransferPolicy.swift
+++ b/Rclone GUI/Services/AutoTransferPolicy.swift
@@ -129,7 +129,11 @@ nonisolated public enum AutoTransferPolicy {
             // multiplier les connexions radio coûteuses en énergie.
             decision = Decision(queueConcurrency: 2, bridgeConcurrency: 3, reason: .cellular)
         } else {
-            decision = Decision(queueConcurrency: 4, bridgeConcurrency: 6, reason: .nominal)
+            // Wi-Fi + froid + non facturé : on pousse la concurrence des
+            // fichiers de dossier (8) pour saturer le lien — chaque fichier
+            // est un copyfile async léger. queueConcurrency (transferts
+            // séparés) reste à 4, plus conservateur.
+            decision = Decision(queueConcurrency: 4, bridgeConcurrency: 8, reason: .nominal)
         }
         return Decision(
             queueConcurrency: min(max(decision.queueConcurrency, 1), 8),

--- a/Rclone GUI/Services/TransferQueue.swift
+++ b/Rclone GUI/Services/TransferQueue.swift
@@ -958,6 +958,12 @@ public final class TransferQueue {
     static let pauseOnCellularKey = "transfer.pauseOnCellular"
     static let cellularLimitKey = "transfer.cellularLimitMBps"
     static let wifiLimitKey = "transfer.bandwidthLimitMBps"
+    /// Concurrence INTERNE d'un download de dossier (nb de fichiers copiés en
+    /// parallèle), distincte de `maxConcurrent` (qui borne les transferts
+    /// SÉPARÉS). Un dossier = 1 transfert de la file, mais N fichiers en vol
+    /// en interne → cette concurrence-là doit être plus généreuse pour saturer
+    /// le lien (défaut manuel 6, borné 1…16).
+    static let folderConcurrencyKey = "transfer.bridgeFolderConcurrency"
 
     /// Nombre max de transferts download/upload simultanés. Mode Auto ON →
     /// valeur décidée par AutoTransferPolicy (réseau + énergie) ; OFF →
@@ -966,6 +972,18 @@ public final class TransferQueue {
         if isAutoModeEnabled { return currentAutoDecision.queueConcurrency }
         let v = UserDefaults.standard.integer(forKey: Self.maxConcurrentKey)
         return v <= 0 ? 3 : min(v, 8)
+    }
+
+    /// Concurrence des fichiers d'un download de DOSSIER. Mode Auto →
+    /// `bridgeConcurrency` contextuel (Wi-Fi 8, cellulaire 3, chauffe/éco 2,
+    /// critique 1) ; OFF → réglage manuel `transfer.bridgeFolderConcurrency`
+    /// (défaut 6, borné 1…16). Plus haut que `maxConcurrent` pour la vitesse :
+    /// dans un dossier, chaque fichier est un transfert léger (copyfile async)
+    /// et on veut remplir le tuyau.
+    public var folderDownloadConcurrency: Int {
+        if isAutoModeEnabled { return min(max(currentAutoDecision.bridgeConcurrency, 1), 16) }
+        let v = UserDefaults.standard.integer(forKey: Self.folderConcurrencyKey)
+        return v <= 0 ? 6 : min(v, 16)
     }
 
     /// Seuls les transferts « lourds » (download/upload) passent par la file
@@ -1189,12 +1207,12 @@ public final class TransferQueue {
         }
 
         await LogService.shared.log(.info, category: "transfer",
-            message: "📁 Download dossier (par fichiers\(stagingDir != nil ? ", staging iCloud" : "")) \(remote):\(sourcePath) files=\(files.count) skip=\(partition.skippedCount) concurrency=\(min(max(maxConcurrent,1),8)) bytesTotal=\(bytesTotal)")
+            message: "📁 Download dossier (par fichiers\(stagingDir != nil ? ", staging iCloud" : "")) \(remote):\(sourcePath) files=\(files.count) skip=\(partition.skippedCount) concurrency=\(folderDownloadConcurrency) bytesTotal=\(bytesTotal)")
 
         // 3) File bornée de copyfile+poll. maxConcurrent respecte le mode Auto
         //    / le réglage manuel, borné 1…8. Chaque copyfile passe par le
         //    bouclier cgoQueue → jamais d'épuisement du pool GCD → pas de gel.
-        let concurrency = min(max(maxConcurrent, 1), 8)
+        let concurrency = folderDownloadConcurrency
         var iterator = partition.todo.makeIterator()
         var firstError: Error?
 

--- a/Rclone GUITests/AutoTransferPolicyTests.swift
+++ b/Rclone GUITests/AutoTransferPolicyTests.swift
@@ -33,10 +33,10 @@ struct AutoTransferPolicyDecideTests {
         )
     }
 
-    @Test("Wi-Fi nominal → 4 en file, 6 en bridge")
+    @Test("Wi-Fi nominal → 4 en file, 8 en bridge")
     func nominalWiFi() {
         let d = AutoTransferPolicy.decide(inputs())
-        #expect(d == AutoTransferPolicy.Decision(queueConcurrency: 4, bridgeConcurrency: 6, reason: .nominal))
+        #expect(d == AutoTransferPolicy.Decision(queueConcurrency: 4, bridgeConcurrency: 8, reason: .nominal))
     }
 
     @Test("Cellulaire → 2 en file, 3 en bridge")


### PR DESCRIPTION
## Symptôme
Le téléchargement de dossier marche mais **pas à pleine vitesse**.

## Cause (régression que j'avais introduite)
Depuis la réécriture en `downloadFolderViaFiles` (#109), le **pool interne de fichiers** utilisait `maxConcurrent` — la borne des transferts **SÉPARÉS** (Auto : Wi-Fi 4, cellulaire 2, chauffe 2). Or un dossier = **1 seul** transfert de la file, mais N fichiers en vol en interne. L'ancien moteur avait une concurrence dossier **dédiée et plus élevée** (jusqu'à 16), que j'avais cessé d'utiliser. Résultat : seulement 4 fichiers en parallèle sur Wi-Fi au lieu de saturer le lien.

## Correctif
- **`folderDownloadConcurrency`** : concurrence dédiée aux fichiers d'un dossier.
  - Mode Auto → `bridgeConcurrency` contextuel (déjà calculé par `AutoTransferPolicy`, mais plus branché).
  - Manuel → clé `transfer.bridgeFolderConcurrency` (défaut **6**, borné 1…16).
- `downloadFolderViaFiles` l'utilise à la place de `maxConcurrent`.
- `AutoTransferPolicy` : `bridgeConcurrency` Wi-Fi nominal **6 → 8** (Wi-Fi + froid + non facturé = on pousse ; chaque fichier est un `copyfile` async léger). `queueConcurrency` (transferts séparés) inchangé à 4. **Cellulaire / chauffe / éco / critique inchangés** (protection thermique/énergie conservée).

Sur Wi-Fi frais : **8 fichiers en parallèle** au lieu de 4.

## Tests
`Rclone GUITests` : **154 passed / 0 failed** (assertion nominale mise à jour 6 → 8).

## Note
Si le device est en `thermalSerious` (chaud), Auto plafonne toujours à 2 (protection). Pour forcer la vitesse max quelle que soit la chauffe : désactiver « Gestion automatique » dans Réglages → Performance (le manuel utilise alors 6, réglable via la clé).