### PR TITLE
fix(photosync): rendre les photos ignorées visibles (fin du « bloqué à N »)

### DIFF
--- a/Rclone GUI/Services/PhotoSyncService.swift
+++ b/Rclone GUI/Services/PhotoSyncService.swift
@@ -201,6 +201,11 @@ public struct PhotoSyncRunSummary: Sendable, Equatable {
     public let activeCount: Int
     public let completedCount: Int
     public let failedCount: Int
+    /// Photos en état terminal `.skipped` (asset supprimé/déplacé dans Photos,
+    /// accès perdu, ou illisible). Jamais uploadées et jamais réessayées
+    /// automatiquement — surfacées ici pour ne plus être un « trou » invisible
+    /// qui laisse la barre plafonner sans explication.
+    public let skippedCount: Int
     public let totalBytes: Int64
     public let transferredBytes: Int64
     public let averageBytesPerSecond: Double
@@ -238,7 +243,14 @@ public struct PhotoSyncRunSummary: Sendable, Equatable {
     /// below by the discovered library size (`indexedCount`). Failed are
     /// included so the user doesn't "lose" them visually.
     public var effectiveTotal: Int {
-        max(completedCount + activeCount + pendingCount + failedCount, indexedCount)
+        max(completedCount + activeCount + pendingCount + failedCount + skippedCount, indexedCount)
+    }
+
+    /// Travail réellement en cours ou à faire (hors `.skipped`, terminal). Sert
+    /// à afficher « N restantes » de façon honnête : atteint 0 quand il ne reste
+    /// que des ignorées, au lieu de rester bloqué à `total - completed`.
+    public var outstandingCount: Int {
+        pendingCount + activeCount + failedCount
     }
 
     /// Monotonic 0..1 progress ratio. Combined with the service-side ratchet,
@@ -256,8 +268,16 @@ public struct PhotoSyncRunSummary: Sendable, Equatable {
     public var displayLabel: String {
         let total = effectiveTotal
         if total > 0 {
-            let remaining = max(0, total - completedCount)
-            return String(localized: "\(completedCount) / \(total) photos uploadées · \(remaining) restantes")
+            var label = String(localized: "\(completedCount) / \(total) photos uploadées")
+            if outstandingCount > 0 {
+                label += String(localized: " · \(outstandingCount) restantes")
+            }
+            // Explique le plateau : les ignorées ne sont ni terminées ni en
+            // attente, elles n'apparaissaient nulle part avant ce correctif.
+            if skippedCount > 0 {
+                label += String(localized: " · \(skippedCount) ignorées")
+            }
+            return label
         }
         if indexedCount > 0 {
             return String(localized: "\(indexedCount) élément(s) indexé(s)")
@@ -321,6 +341,10 @@ private struct PhotoSyncCounts {
     let active: Int
     let completed: Int
     let failed: Int
+    /// Assets en état terminal `.skipped` (asset supprimé/déplacé, accès Photos
+    /// perdu, ou illisible) — jamais uploadés, jamais réessayés automatiquement.
+    /// Comptés à part pour ne plus les faire passer pour « en attente ».
+    let skipped: Int
     let totalBytes: Int64
     let transferredBytes: Int64
 }
@@ -967,6 +991,37 @@ public final class PhotoSyncService: NSObject, PHPhotoLibraryChangeObserver {
             )
         }
         return failed.count
+    }
+
+    /// Recycle les assets `.skipped` (asset supprimé/déplacé, accès Photos perdu,
+    /// illisible) en `.pending` puis relance une sync. Utile après avoir re-accordé
+    /// « Toutes les photos » (les skips 3303 « accès refusé » redeviennent valides).
+    /// Les skips définitifs (asset réellement disparu) repasseront en `.skipped`
+    /// en une passe — pas de boucle. Renvoie le nombre d'assets recyclés.
+    @discardableResult
+    public func retrySkippedAssets() async -> Int {
+        guard let modelContext else { return 0 }
+        let descriptor = FetchDescriptor<PhotoSyncAsset>(
+            predicate: #Predicate { $0.statusRaw == "skipped" }
+        )
+        let skipped = (try? modelContext.fetch(descriptor)) ?? []
+        guard !skipped.isEmpty else { return 0 }
+        for asset in skipped {
+            asset.status = .pending
+            asset.retryCount = 0
+            asset.lastError = nil
+        }
+        try? modelContext.save()
+        await LogService.shared.log(.info, category: "photos", message: "Reprise de \(skipped.count) asset(s) ignoré(s).")
+        if isEnabled, configuredRemote != nil, !isPausedByUser {
+            shouldContinueUntilEmpty = true
+            _ = await runSync(
+                requestedLimit: limits.enqueueBatchSize,
+                continueUntilEmpty: true,
+                includeFailedRetries: true
+            )
+        }
+        return skipped.count
     }
 
     /// Permanently drop every `.failed` asset row so the historique stops
@@ -2687,7 +2742,7 @@ public final class PhotoSyncService: NSObject, PHPhotoLibraryChangeObserver {
         // de photos uploadées ne peuvent descendre pendant une session.
         // Reset (à 0) déjà fait par resetSessionCounters au début du
         // pipeline runPipeline.
-        let candidateTotal = max(counts.completed + counts.active + counts.pending + counts.failed, counts.indexed)
+        let candidateTotal = max(counts.completed + counts.active + counts.pending + counts.failed + counts.skipped, counts.indexed)
         ratchetTotal = max(ratchetTotal, candidateTotal)
         ratchetCompleted = max(ratchetCompleted, counts.completed)
         // Calcul des valeurs "affichables" qui respectent le ratchet,
@@ -2698,7 +2753,10 @@ public final class PhotoSyncService: NSObject, PHPhotoLibraryChangeObserver {
         // Recalcule pending pour que `effectiveTotal` du summary corresponde
         // à `displayTotal` (sans changer les compteurs réels affichés sur
         // les pastilles individuelles).
-        let displayPending = max(0, displayTotal - displayCompleted - counts.active - counts.failed)
+        // Les ignorées (.skipped) sont terminales : on les retire du « pending »
+        // affiché, sinon elles apparaissaient comme des restantes qui ne
+        // drainent jamais (cause du « bloqué à N photos »).
+        let displayPending = max(0, displayTotal - displayCompleted - counts.active - counts.failed - counts.skipped)
 
         let summary = PhotoSyncRunSummary(
             authorization: authorization,
@@ -2710,6 +2768,7 @@ public final class PhotoSyncService: NSObject, PHPhotoLibraryChangeObserver {
             activeCount: counts.active,
             completedCount: displayCompleted,
             failedCount: counts.failed,
+            skippedCount: counts.skipped,
             totalBytes: total,
             transferredBytes: transferred,
             averageBytesPerSecond: bps,
@@ -2811,6 +2870,7 @@ public final class PhotoSyncService: NSObject, PHPhotoLibraryChangeObserver {
             active: fetchPhotoSyncCount(.exporting) + fetchPhotoSyncCount(.enqueued),
             completed: fetchPhotoSyncCount(.completed),
             failed: fetchPhotoSyncCount(.failed),
+            skipped: fetchPhotoSyncCount(.skipped),
             totalBytes: byteTotals.total,
             transferredBytes: byteTotals.transferred
         )

--- a/Rclone GUI/Views/Settings/PhotoSyncSettingsView.swift
+++ b/Rclone GUI/Views/Settings/PhotoSyncSettingsView.swift
@@ -47,6 +47,9 @@ struct PhotoSyncSettingsView: View {
                         AppMetricPill(value: "\(stats.pending)", label: "attente", systemImage: "clock", tint: .orange)
                         AppMetricPill(value: "\(stats.active)", label: "actifs", systemImage: "bolt.fill", tint: .blue)
                         AppMetricPill(value: "\(stats.completed)", label: "terminés", systemImage: "checkmark.circle", tint: .green)
+                        if stats.skipped > 0 {
+                            AppMetricPill(value: "\(stats.skipped)", label: "ignorées", systemImage: "minus.circle", tint: .gray)
+                        }
                     }
 
                     if shouldShowProgressBar {
@@ -200,6 +203,15 @@ struct PhotoSyncSettingsView: View {
                     }
                 }
 
+                if stats.skipped > 0 {
+                    Button {
+                        Task { await retrySkipped() }
+                    } label: {
+                        Label("Réessayer les ignorées (\(stats.skipped))", systemImage: "arrow.clockwise.circle")
+                    }
+                    .disabled(stats.pausedByUser || selectedRemote.isEmpty)
+                }
+
                 Button {
                     Task { await verifyIntegrity() }
                 } label: {
@@ -244,6 +256,8 @@ struct PhotoSyncSettingsView: View {
                     Text("La synchro est en pause. Aucun nouveau transfert ne sera lancé jusqu'à la reprise manuelle.")
                 } else if stats.failed > 0 {
                     Text("\(stats.failed) photo(s) en échec. Réessayer remet à zéro le compteur de tentatives.")
+                } else if stats.skipped > 0 {
+                    Text("\(stats.skipped) photo(s) ignorée(s) : supprimées/déplacées dans Photos, accès partiel, ou originaux illisibles. « Réessayer les ignorées » les recycle — utile après avoir re-accordé « Toutes les photos ».")
                 }
             }
 
@@ -266,6 +280,9 @@ struct PhotoSyncSettingsView: View {
                 LabeledContent("En cours/en file", value: "\(stats.active)")
                 LabeledContent("Terminés", value: "\(stats.completed)")
                 LabeledContent("Échecs", value: "\(stats.failed)")
+                if stats.skipped > 0 {
+                    LabeledContent("Ignorées", value: "\(stats.skipped)")
+                }
             } header: {
                 Text("État")
             }
@@ -401,6 +418,7 @@ struct PhotoSyncSettingsView: View {
             active: summary.activeCount,
             completed: summary.completedCount,
             failed: summary.failedCount,
+            skipped: summary.skippedCount,
             totalBytes: summary.totalBytes,
             transferredBytes: summary.transferredBytes,
             averageBytesPerSecond: summary.averageBytesPerSecond,
@@ -422,6 +440,14 @@ struct PhotoSyncSettingsView: View {
         let recycled = await PhotoSyncService.shared.retryFailedAssets()
         if recycled > 0 {
             message = "\(recycled) photo(s) remise(s) en file."
+        }
+        await reloadStats()
+    }
+
+    private func retrySkipped() async {
+        let recycled = await PhotoSyncService.shared.retrySkippedAssets()
+        if recycled > 0 {
+            message = "\(recycled) photo(s) ignorée(s) remise(s) en file."
         }
         await reloadStats()
     }
@@ -599,6 +625,7 @@ private struct PhotoSyncStats {
     var active = 0
     var completed = 0
     var failed = 0
+    var skipped = 0
     var totalBytes: Int64 = 0
     var transferredBytes: Int64 = 0
     var averageBytesPerSecond: Double = 0
@@ -609,7 +636,7 @@ private struct PhotoSyncStats {
     /// `PhotoSyncRunSummary.effectiveTotal` so both screens agree on
     /// the denominator (includes failed, ratchet-aware).
     var effectiveTotal: Int {
-        max(completed + active + pending + failed, indexed)
+        max(completed + active + pending + failed + skipped, indexed)
     }
 
     /// Monotonic 0..1 ratio sourced from the service-side ratchet.

--- a/Rclone GUI/Views/Settings/PhotoSyncStatsView.swift
+++ b/Rclone GUI/Views/Settings/PhotoSyncStatsView.swift
@@ -86,6 +86,11 @@ struct PhotoSyncStatsView: View {
                             y: .value("Count", summary.failedCount)
                         )
                         .foregroundStyle(.red)
+                        BarMark(
+                            x: .value("État", "Ignorés"),
+                            y: .value("Count", summary.skippedCount)
+                        )
+                        .foregroundStyle(.gray)
                     }
                     .frame(height: 180)
                 } header: {

--- a/Rclone GUITests/PhotoSyncSkippedTests.swift
+++ b/Rclone GUITests/PhotoSyncSkippedTests.swift
@@ -1,0 +1,89 @@
+//
+//  PhotoSyncSkippedTests.swift
+//  Rclone GUITests
+//
+//  Régression du « bloqué à N photos » : les assets .skipped (asset supprimé/
+//  déplacé, accès Photos perdu, illisible) étaient comptés dans le total mais
+//  invisibles, laissant « N restantes » plafonner sans explication. On vérifie
+//  que le résumé les surface (skippedCount), les exclut des « restantes »
+//  (outstandingCount) et les affiche dans le libellé.
+//
+
+import Foundation
+import Testing
+@testable import Rclone_GUI
+
+@Suite("PhotoSync — visibilité des .skipped")
+struct PhotoSyncSkippedTests {
+
+    private func summary(
+        indexed: Int, pending: Int, active: Int,
+        completed: Int, failed: Int, skipped: Int
+    ) -> PhotoSyncRunSummary {
+        PhotoSyncRunSummary(
+            authorization: .authorized,
+            visibleAssetCount: indexed,
+            indexedCount: indexed,
+            newlyIndexedCount: 0,
+            enqueuedCount: 0,
+            pendingCount: pending,
+            activeCount: active,
+            completedCount: completed,
+            failedCount: failed,
+            skippedCount: skipped,
+            totalBytes: 0,
+            transferredBytes: 0,
+            averageBytesPerSecond: 0,
+            estimatedTimeRemaining: nil,
+            pausedByUser: false,
+            sessionUploaded: 0,
+            sessionInitialPending: 0,
+            sessionEstimatedRemaining: nil
+        )
+    }
+
+    @Test("effectiveTotal inclut les ignorées")
+    func effectiveTotalIncludesSkipped() {
+        let s = summary(indexed: 3000, pending: 0, active: 0, completed: 2600, failed: 0, skipped: 400)
+        #expect(s.effectiveTotal == 3000)
+    }
+
+    @Test("outstandingCount = pending + active + failed (exclut les ignorées)")
+    func outstandingExcludesSkipped() {
+        let s = summary(indexed: 3000, pending: 5, active: 2, completed: 2600, failed: 3, skipped: 390)
+        #expect(s.outstandingCount == 10)
+    }
+
+    @Test("Régression « bloqué à 2600 » : que des ignorées → 0 restantes, libellé explicite")
+    func stuckAt2600IsExplained() {
+        let s = summary(indexed: 3000, pending: 0, active: 0, completed: 2600, failed: 0, skipped: 400)
+        // Avant : remaining = total - completed = 400 « restantes » fantômes qui
+        // ne drainaient jamais. Après : outstanding = 0, et 400 « ignorées ».
+        #expect(s.effectiveTotal == 3000)
+        #expect(s.skippedCount == 400)
+        #expect(s.outstandingCount == 0)
+        // NB : on n'assert pas le « 2600 / 3000 » littéral — String(localized:)
+        // insère un séparateur de milliers dépendant de la locale (« 2 600 »).
+        let label = s.displayLabel
+        #expect(label.contains("ignorées"))
+        #expect(!label.contains("restantes"))
+    }
+
+    @Test("Sans ignorées, libellé inchangé (pas de bruit)")
+    func noSkippedNoClutter() {
+        let s = summary(indexed: 100, pending: 10, active: 0, completed: 90, failed: 0, skipped: 0)
+        let label = s.displayLabel
+        #expect(label.contains("90 / 100"))
+        #expect(label.contains("10 restantes"))
+        #expect(!label.contains("ignorées"))
+    }
+
+    @Test("Échecs comptés dans les restantes (récupérables), pas les ignorées")
+    func failedCountsAsOutstanding() {
+        let s = summary(indexed: 100, pending: 0, active: 0, completed: 80, failed: 15, skipped: 5)
+        #expect(s.outstandingCount == 15)
+        let label = s.displayLabel
+        #expect(label.contains("15 restantes"))
+        #expect(label.contains("5 ignorées"))
+    }
+}


### PR DESCRIPTION
## Symptôme
« Mon upload photo est bloqué à ~2600 » sans message d'erreur, alors que ce n'est **pas** une limite d'essai.

## Cause
Les assets **`.skipped`** (asset supprimé/déplacé dans Photos → PHPhotos 3169, accès perdu 3303, ou illisible 2498) sont un état **terminal** jamais réessayé. Or ils étaient comptés dans le total (`indexedCount`) mais **absents** des compteurs `pending/active/completed/failed`. Résultat : `displayPending = total − completed − active − failed` les comptait comme « en attente », et « N restantes » plafonnait sans jamais drainer, sans explication.

## Correctif
- `PhotoSyncCounts` / `PhotoSyncRunSummary` / `PhotoSyncStats` : nouveau **`skippedCount`** (`fetchPhotoSyncCount(.skipped)`).
- `effectiveTotal` inclut les ignorées ; nouveau **`outstandingCount = pending + active + failed`** → « N restantes » atteint 0 quand il ne reste que des ignorées.
- `displayPending` **soustrait** les ignorées (fini le faux « en attente »).
- `displayLabel` affiche **« N ignorées »**.
- UI : pastille « ignorées », ligne détail, barre du graphe (StatsView), et bouton **« Réessayer les ignorées »** (`retrySkippedAssets`) — utile après avoir re-accordé « Toutes les photos » (les skips 3303 redeviennent valides).

## Tests
`PhotoSyncSkippedTests` (non-régression « bloqué à 2600 » : que des ignorées → `outstandingCount == 0`, libellé sans « restantes » + « ignorées »).
Suite `Rclone GUITests` : **173 passed / 0 failed / 0 skipped** (simulateur iOS 27).