### PR TITLE
fix(handoff): compile macOS — débloque l'archive 2.0

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -101,6 +101,38 @@ jobs:
           echo "Archive structure OK"
           du -sh "build/RcloneGUI-CI.xcarchive"
 
+  build-macos:
+    name: Build (macOS, unsigned)
+    # Garde de non-régression : l'app cible aussi macOS, mais seul le simulateur
+    # iOS était vérifié en CI. Des API iOS-only non gardées (ex. Handoff :
+    # textInputAutocapitalization, UIPasteboard, UIActivityViewController) ne
+    # cassaient donc qu'à l'archive macOS Xcode Cloud. Ce job compile la cible
+    # macOS à chaque PR pour attraper ces régressions plus tôt.
+    runs-on: macos-15
+    timeout-minutes: 25
+
+    env:
+      PROJECT: Rclone GUI.xcodeproj
+      SCHEME: Rclone GUI
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build for macOS (compile check, no signing)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Release \
+            -destination 'generic/platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            DEVELOPMENT_TEAM="" \
+            PROVISIONING_PROFILE_SPECIFIER=""
+
   transparency-guard:
     name: Glass Engine — garde « 0 appel maison »
     runs-on: macos-15

--- a/Rclone GUI/Views/Settings/Handoff/HandoffReceiveView.swift
+++ b/Rclone GUI/Views/Settings/Handoff/HandoffReceiveView.swift
@@ -15,6 +15,8 @@ import UniformTypeIdentifiers
 
 #if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
 #endif
 
 struct HandoffReceiveView: View {
@@ -188,7 +190,9 @@ struct HandoffReceiveView: View {
                 TextEditor(text: $payload)
                     .frame(minHeight: 100)
                     .font(.system(size: 12, design: .monospaced))
+                    #if os(iOS)
                     .textInputAutocapitalization(.never)
+                    #endif
                     .autocorrectionDisabled()
                     .overlay {
                         if payload.isEmpty {
@@ -232,7 +236,9 @@ struct HandoffReceiveView: View {
                             .foregroundStyle(.tertiary)
                             .frame(width: 22, alignment: .trailing)
                         TextField("Mot \(idx + 1)", text: bindingForWord(at: idx))
+                            #if os(iOS)
                             .textInputAutocapitalization(.never)
+                            #endif
                             .autocorrectionDisabled()
                             .padding(.horizontal, 10)
                             .padding(.vertical, 8)
@@ -401,7 +407,14 @@ struct HandoffReceiveView: View {
         case .file:
             showFilePicker = true
         case .clipboard:
-            if let text = UIPasteboard.general.string, let extracted = HandoffEnvelope.extract(from: text) {
+            #if os(iOS)
+            let clip = UIPasteboard.general.string
+            #elseif os(macOS)
+            let clip = NSPasteboard.general.string(forType: .string)
+            #else
+            let clip: String? = nil
+            #endif
+            if let text = clip, let extracted = HandoffEnvelope.extract(from: text) {
                 payload = extracted
                 Task { await inspect() }
             } else {

--- a/Rclone GUI/Views/Settings/Handoff/HandoffSendView.swift
+++ b/Rclone GUI/Views/Settings/Handoff/HandoffSendView.swift
@@ -76,9 +76,11 @@ struct HandoffSendView: View {
                     .disabled(preparing)
             }
         }
+        #if canImport(UIKit)
         .sheet(isPresented: $showShare) {
             HandoffShareSheet(items: shareItems)
         }
+        #endif
         .confirmationDialog(
             "As-tu noté les 6 mots ?",
             isPresented: $showPassphraseConfirm,


### PR DESCRIPTION
## Symptôme
Build **138 (v2.0) — Archive macOS échoue** sur Xcode Cloud (`xcodebuild archive … generic/platform=macOS`, exit 65).

## Cause
Les vues Handoff (livrées en #105/#107) utilisent des API **iOS-only non gardées**, qui ne cassent qu'à la compilation macOS :
- `HandoffReceiveView.swift` : `.textInputAutocapitalization(.never)` (×2), `UIPasteboard.general` (case presse-papiers).
- `HandoffSendView.swift` : `HandoffShareSheet` (UIActivityViewController, défini sous `#if canImport(UIKit)`).

La CI ne buildait que le **simulateur iOS** → jamais macOS → la régression est passée jusqu'à l'archive Xcode Cloud.

## Correctif
- Guards `#if os(iOS)` autour de `textInputAutocapitalization` ; `#if canImport(UIKit)` autour du `.sheet` AirDrop.
- Presse-papiers cross-platform : `UIPasteboard` (iOS) / `NSPasteboard` (macOS) — le collage de payload marche maintenant aussi sur Mac.
- **Non-régression** : nouveau job CI `build-macos` (compile Release macOS à chaque PR).

Comportement iOS **inchangé** (tout est derrière des guards).

## Vérifié localement
`xcodebuild build -configuration Release` : **iOS device = BUILD SUCCEEDED** · **macOS = BUILD SUCCEEDED**.