### PR TITLE
fix(wizard): création iCloud Drive — vrai mot de passe Apple ID + question 2FA

### DIFF
--- a/Rclone GUI/Core/BackendOverrides.swift
+++ b/Rclone GUI/Core/BackendOverrides.swift
@@ -468,16 +468,16 @@ enum BackendOverrides {
             usePKCE: false,
             setupURL: URL(string: "https://appleid.apple.com/account/manage"),
             setupSteps: [
-                "Active la 2FA sur ton compte iCloud si pas déjà fait (obligatoire).",
-                "Ouvre appleid.apple.com → section « Sign-In and Security ».",
-                "« App-Specific Passwords » → « Generate Password » pour « Rclone GUI ».",
-                "Copie le mot de passe au format abcd-efgh-ijkl-mnop.",
-                "Colle-le ci-dessous (champ « password »).",
+                "Active la 2FA sur ton compte Apple si pas déjà fait (obligatoire).",
+                "Utilise ton mot de passe Apple ID NORMAL — Apple refuse les mots de passe « spécifiques à une app » pour iCloud Drive.",
+                "Sur ton iPhone : Réglages → [ton nom] → iCloud → active « Accéder aux données iCloud sur le web ».",
+                "Colle ton mot de passe ci-dessous (champ « password »).",
+                "Un code 2FA te sera demandé à l'étape « Récapitulatif » (test ou création).",
                 "À l'étape précédente du wizard, remplis aussi « apple_id » avec ton email Apple ID."
             ],
-            tokenLabel: "App-specific password Apple",
+            tokenLabel: "Mot de passe Apple ID",
             tokenFieldName: "password",
-            tokenHint: "Format : 4 groupes de 4 lettres séparés par des tirets. Le champ « apple_id » est rempli dans le formulaire principal."
+            tokenHint: "Ton mot de passe Apple ID complet — PAS un mot de passe d'app (rejeté par Apple). Le champ « apple_id » est rempli dans le formulaire principal."
         ),
 
         // ───────── Dropbox / Box / pCloud ─────────

--- a/Rclone GUI/Models/Wizard/ConfigCreateFlow.swift
+++ b/Rclone GUI/Models/Wizard/ConfigCreateFlow.swift
@@ -1,0 +1,114 @@
+//
+//  ConfigCreateFlow.swift
+//  Rclone GUI — Models/Wizard
+//
+//  Drives `config/create` and the non-interactive state machine that can
+//  follow it. Most backends complete in a single call, but some come back
+//  with post-config questions — iCloud Drive notably returns `config_2fa`
+//  (the two-factor code that unlocks the session cookies + trust token).
+//  The graphical wizard used to ignore those questions, so the remote was
+//  written without trust token and stayed unusable. This flow surfaces
+//  each question through the `ask` callback and resumes rclone with
+//  `config/update { continue: true, state, result }` until completion.
+//
+//  The RPC transport is injected so the machine is unit-testable without
+//  librclone.
+//
+
+import Foundation
+
+nonisolated enum ConfigCreateFlowError: Error, Equatable, LocalizedError {
+    /// rclone asked a question without the state token needed to answer it.
+    case malformedContinuation
+    /// The user dismissed a question — the caller should clean up the
+    /// half-written remote section (config/delete).
+    case cancelled
+    /// Safety valve: more chained questions than any real backend asks.
+    case tooManyQuestions
+    /// rclone reported a fatal error while finishing the state machine.
+    case rclone(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .malformedContinuation:
+            return String(localized: "Réponse rclone inattendue pendant la configuration.")
+        case .cancelled:
+            return String(localized: "Configuration annulée — la question rclone est restée sans réponse.")
+        case .tooManyQuestions:
+            return String(localized: "Trop de questions de configuration successives — abandon.")
+        case .rclone(let message):
+            return message
+        }
+    }
+}
+
+@MainActor
+struct ConfigCreateFlow {
+
+    /// RPC transport (method, input) → response.
+    let rpc: (_ method: String, _ input: ConfigCreateInput) async throws -> ConfigCreateResponse
+
+    /// Hard cap on chained questions (config_2fa + eventual ADP approval
+    /// stay well below this).
+    static let maxQuestions = 8
+
+    /// Runs `config/create` then answers every follow-up question rclone
+    /// asks, via `ask`. `ask` receives the option describing the question
+    /// plus the soft error rclone attached to the retry (nil on the first
+    /// attempt); returning `nil` cancels the flow.
+    ///
+    /// `onRemoteWritten` fires right after the first successful RPC — from
+    /// that point a (possibly partial) section exists in rclone.conf, so
+    /// callers can arm their config/delete cleanup path.
+    func run(
+        name: String,
+        type: String,
+        parameters: [String: String],
+        obscure: Bool,
+        onRemoteWritten: () async -> Void = {},
+        ask: (_ option: RcloneOptionSchema, _ lastError: String?) async -> String?
+    ) async throws {
+        var response = try await rpc("config/create", ConfigCreateInput(
+            name: name,
+            type: type,
+            parameters: parameters,
+            opt: ConfigCreateOpt(nonInteractive: true, obscure: obscure ? true : nil)
+        ))
+        await onRemoteWritten()
+
+        var answered = 0
+        while !response.isComplete {
+            guard let option = response.option,
+                  let state = response.state, !state.isEmpty else {
+                // A soft error with no follow-up question is fatal.
+                if let err = response.error, !err.isEmpty {
+                    throw ConfigCreateFlowError.rclone(err)
+                }
+                throw ConfigCreateFlowError.malformedContinuation
+            }
+            guard answered < Self.maxQuestions else {
+                throw ConfigCreateFlowError.tooManyQuestions
+            }
+            let softError = (response.error?.isEmpty == false) ? response.error : nil
+            guard let answer = await ask(option, softError) else {
+                throw ConfigCreateFlowError.cancelled
+            }
+            answered += 1
+            response = try await rpc("config/update", ConfigCreateInput(
+                name: name,
+                type: type,
+                parameters: [:],
+                opt: ConfigCreateOpt(
+                    nonInteractive: true,
+                    obscure: option.isPassword ? true : nil,
+                    continue: true,
+                    state: state,
+                    result: answer
+                )
+            ))
+        }
+        if let err = response.error, !err.isEmpty {
+            throw ConfigCreateFlowError.rclone(err)
+        }
+    }
+}

--- a/Rclone GUI/Views/Settings/AddRemote/RecapAndTestView.swift
+++ b/Rclone GUI/Views/Settings/AddRemote/RecapAndTestView.swift
@@ -26,6 +26,19 @@ struct RecapAndTestView: View {
     @State private var isTesting = false
     @State private var isFinalizing = false
 
+    // Post-config question raised by rclone's non-interactive state machine
+    // (e.g. iCloud Drive `config_2fa`). The continuation resumes the
+    // ConfigCreateFlow loop with the user's answer (nil = cancel).
+    @State private var pendingQuestion: PendingConfigQuestion?
+    @State private var questionAnswer = ""
+
+    private struct PendingConfigQuestion: Identifiable {
+        let id = UUID()
+        let option: RcloneOptionSchema
+        let lastError: String?
+        let continuation: CheckedContinuation<String?, Never>
+    }
+
     var body: some View {
         Form {
             if let backend = state.selectedBackend {
@@ -41,6 +54,46 @@ struct RecapAndTestView: View {
             }
         }
         .scrollDismissesKeyboard(.interactively)
+        .alert(
+            questionTitle(for: pendingQuestion?.option),
+            isPresented: Binding(
+                get: { pendingQuestion != nil },
+                set: { presented in
+                    if !presented { resolveQuestion(with: nil) }
+                }
+            ),
+            presenting: pendingQuestion
+        ) { question in
+            TextField(questionTitle(for: question.option), text: $questionAnswer)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            Button("Valider") {
+                resolveQuestion(with: questionAnswer)
+            }
+            Button("Annuler", role: .cancel) {
+                resolveQuestion(with: nil)
+            }
+        } message: { question in
+            if let lastError = question.lastError, !lastError.isEmpty {
+                Text("\(lastError)\n\n\(question.option.help)")
+            } else {
+                Text(question.option.help)
+            }
+        }
+        .onDisappear {
+            // Never strand the flow's continuation if the wizard is closed
+            // while a question is on screen.
+            resolveQuestion(with: nil)
+        }
+    }
+
+    /// Resumes the suspended ConfigCreateFlow exactly once, whichever path
+    /// dismisses the alert first (button action, isPresented reset, or the
+    /// view disappearing) — a CheckedContinuation must never resume twice.
+    private func resolveQuestion(with answer: String?) {
+        guard let question = pendingQuestion else { return }
+        pendingQuestion = nil
+        question.continuation.resume(returning: answer)
     }
 
     // MARK: - Sections
@@ -292,17 +345,53 @@ struct RecapAndTestView: View {
         )
         let needsObscure = backend.name == "crypt"
             || params.keys.contains { passwordFieldNames.contains($0) }
-        let input = ConfigCreateInput(
+
+        // Some backends (iCloud Drive → config_2fa) answer config/create with
+        // follow-up questions instead of completing. ConfigCreateFlow loops on
+        // the state machine, surfacing each question via askQuestion (alert).
+        let flow = ConfigCreateFlow(rpc: { method, input in
+            try await RcloneCore.shared.rpc(method, input: input)
+        })
+        try await flow.run(
             name: state.name,
             type: backend.name,
             parameters: params,
-            opt: ConfigCreateOpt(nonInteractive: true, obscure: needsObscure ? true : nil)
-        )
-        let _: ConfigCreateResponse = try await RcloneCore.shared.rpc(
-            "config/create",
-            input: input
+            obscure: needsObscure,
+            onRemoteWritten: {
+                // A (possibly partial) section now exists in rclone.conf —
+                // arm the config/delete cleanup even if a question is
+                // cancelled or fails after this point.
+                state.remoteWasPreCreated = true
+            },
+            ask: { option, lastError in
+                await askQuestion(option, lastError: lastError)
+            }
         )
         await RcloneCore.shared.invalidateConfigCache()
+    }
+
+    /// Suspends the ConfigCreateFlow loop while the alert collects the
+    /// user's answer to a post-config question (nil = cancelled).
+    private func askQuestion(_ option: RcloneOptionSchema, lastError: String?) async -> String? {
+        await withCheckedContinuation { continuation in
+            questionAnswer = ""
+            pendingQuestion = PendingConfigQuestion(
+                option: option,
+                lastError: lastError,
+                continuation: continuation
+            )
+        }
+    }
+
+    private func questionTitle(for option: RcloneOptionSchema?) -> String {
+        switch option?.name {
+        case "config_2fa":
+            return String(localized: "Code de vérification Apple (2FA)")
+        case nil:
+            return String(localized: "Question rclone")
+        case .some(let name):
+            return name
+        }
     }
 
     private func finalizeCreation() async {

--- a/Rclone GUITests/ConfigCreateFlowTests.swift
+++ b/Rclone GUITests/ConfigCreateFlowTests.swift
@@ -1,0 +1,290 @@
+//
+//  ConfigCreateFlowTests.swift
+//  Rclone GUITests
+//
+//  Unit tests for ConfigCreateFlow — the non-interactive state machine
+//  behind config/create. Covers the iCloud Drive `config_2fa` follow-up
+//  question (answer, retry-on-wrong-code, cancel), the pass-through of
+//  obscure flags, and the safety valves (malformed continuation, question
+//  storm). The RPC transport is scripted so no librclone is involved.
+//
+
+import Testing
+import Foundation
+@testable import Rclone_GUI
+
+// MARK: - Scripted RPC transport
+
+private actor ScriptedRPC {
+    struct Call: Sendable {
+        let method: String
+        let input: ConfigCreateInput
+    }
+
+    private(set) var calls: [Call] = []
+    private var script: [ConfigCreateResponse]
+
+    init(script: [ConfigCreateResponse]) {
+        self.script = script
+    }
+
+    func invoke(_ method: String, _ input: ConfigCreateInput) throws -> ConfigCreateResponse {
+        calls.append(Call(method: method, input: input))
+        guard !script.isEmpty else {
+            throw ConfigCreateFlowError.rclone("script exhausted")
+        }
+        return script.removeFirst()
+    }
+}
+
+private actor AskRecorder {
+    struct Question: Sendable {
+        let name: String
+        let lastError: String?
+    }
+
+    private(set) var questions: [Question] = []
+    private var answers: [String?]
+
+    init(answers: [String?]) {
+        self.answers = answers
+    }
+
+    func answer(_ option: RcloneOptionSchema, _ lastError: String?) -> String? {
+        questions.append(Question(name: option.name, lastError: lastError))
+        guard !answers.isEmpty else { return nil }
+        return answers.removeFirst()
+    }
+}
+
+// MARK: - Fixtures
+
+@MainActor
+private func makeOption(name: String, help: String = "", isPassword: Bool = false) -> RcloneOptionSchema {
+    RcloneOptionSchema(
+        name: name,
+        help: help,
+        type: "string",
+        defaultStr: "",
+        valueStr: nil,
+        required: true,
+        isPassword: isPassword,
+        sensitive: false,
+        advanced: false,
+        exclusive: false,
+        hide: 0,
+        noPrefix: false,
+        examples: nil,
+        provider: nil
+    )
+}
+
+@MainActor
+private let doneResponse = ConfigCreateResponse(state: nil, option: nil, error: nil)
+
+@MainActor
+private func questionResponse(
+    _ name: String,
+    state: String,
+    error: String? = nil,
+    isPassword: Bool = false
+) -> ConfigCreateResponse {
+    ConfigCreateResponse(state: state, option: makeOption(name: name, isPassword: isPassword), error: error)
+}
+
+@MainActor
+private func makeFlow(_ rpc: ScriptedRPC) -> ConfigCreateFlow {
+    ConfigCreateFlow(rpc: { method, input in
+        try await rpc.invoke(method, input)
+    })
+}
+
+// MARK: - Tests
+
+@Suite("ConfigCreateFlow state machine")
+@MainActor
+struct ConfigCreateFlowTests {
+
+    @Test("Backend sans question : un seul config/create, pas de prompt")
+    func completesInOneCall() async throws {
+        let rpc = ScriptedRPC(script: [doneResponse])
+        let asks = AskRecorder(answers: [])
+
+        try await makeFlow(rpc).run(
+            name: "b2", type: "b2",
+            parameters: ["account": "x", "key": "y"],
+            obscure: false,
+            ask: { option, lastError in await asks.answer(option, lastError) }
+        )
+
+        let calls = await rpc.calls
+        #expect(calls.count == 1)
+        #expect(calls[0].method == "config/create")
+        #expect(calls[0].input.parameters["account"] == "x")
+        #expect(calls[0].input.opt?.nonInteractive == true)
+        #expect(calls[0].input.opt?.obscure == nil)
+        #expect(await asks.questions.isEmpty)
+    }
+
+    @Test("iCloud Drive : question config_2fa répondue via config/update continue")
+    func answersTwoFactorQuestion() async throws {
+        let rpc = ScriptedRPC(script: [
+            questionResponse("config_2fa", state: "*postconfig-2fa"),
+            doneResponse
+        ])
+        let asks = AskRecorder(answers: ["123456"])
+
+        try await makeFlow(rpc).run(
+            name: "icloud", type: "iclouddrive",
+            parameters: ["apple_id": "user@example.com", "password": "secret"],
+            obscure: true,
+            ask: { option, lastError in await asks.answer(option, lastError) }
+        )
+
+        let calls = await rpc.calls
+        #expect(calls.count == 2)
+        #expect(calls[0].method == "config/create")
+        #expect(calls[0].input.opt?.obscure == true)
+        #expect(calls[1].method == "config/update")
+        #expect(calls[1].input.opt?.continue == true)
+        #expect(calls[1].input.opt?.state == "*postconfig-2fa")
+        #expect(calls[1].input.opt?.result == "123456")
+        // config_2fa n'est pas un champ password → pas d'obscure sur la relance.
+        #expect(calls[1].input.opt?.obscure == nil)
+
+        let questions = await asks.questions
+        #expect(questions.count == 1)
+        #expect(questions[0].name == "config_2fa")
+        #expect(questions[0].lastError == nil)
+    }
+
+    @Test("Question de type password : obscure=true sur la continuation")
+    func obscuresPasswordAnswers() async throws {
+        let rpc = ScriptedRPC(script: [
+            questionResponse("password", state: "*ask-pass", isPassword: true),
+            doneResponse
+        ])
+        let asks = AskRecorder(answers: ["hunter2"])
+
+        try await makeFlow(rpc).run(
+            name: "r", type: "sftp", parameters: [:], obscure: false,
+            ask: { option, lastError in await asks.answer(option, lastError) }
+        )
+
+        let calls = await rpc.calls
+        #expect(calls.count == 2)
+        #expect(calls[1].input.opt?.obscure == true)
+    }
+
+    @Test("Mauvais code : le soft error rclone est transmis au prompt suivant")
+    func forwardsSoftErrorOnRetry() async throws {
+        let rpc = ScriptedRPC(script: [
+            questionResponse("config_2fa", state: "*try1"),
+            questionResponse("config_2fa", state: "*try2", error: "2FA code rejected"),
+            doneResponse
+        ])
+        let asks = AskRecorder(answers: ["000000", "654321"])
+
+        try await makeFlow(rpc).run(
+            name: "icloud", type: "iclouddrive", parameters: [:], obscure: false,
+            ask: { option, lastError in await asks.answer(option, lastError) }
+        )
+
+        let questions = await asks.questions
+        #expect(questions.count == 2)
+        #expect(questions[0].lastError == nil)
+        #expect(questions[1].lastError == "2FA code rejected")
+
+        let calls = await rpc.calls
+        #expect(calls.count == 3)
+        #expect(calls[2].input.opt?.state == "*try2")
+        #expect(calls[2].input.opt?.result == "654321")
+    }
+
+    @Test("Annulation du prompt : ConfigCreateFlowError.cancelled")
+    func cancelledQuestionThrows() async throws {
+        let rpc = ScriptedRPC(script: [
+            questionResponse("config_2fa", state: "*postconfig-2fa")
+        ])
+        let asks = AskRecorder(answers: [nil])
+
+        await #expect(throws: ConfigCreateFlowError.cancelled) {
+            try await makeFlow(rpc).run(
+                name: "icloud", type: "iclouddrive", parameters: [:], obscure: false,
+                ask: { option, lastError in await asks.answer(option, lastError) }
+            )
+        }
+        // Aucun config/update ne doit partir après une annulation.
+        #expect(await rpc.calls.count == 1)
+    }
+
+    @Test("Option sans state : ConfigCreateFlowError.malformedContinuation")
+    func malformedContinuationThrows() async throws {
+        let rpc = ScriptedRPC(script: [
+            ConfigCreateResponse(state: "", option: makeOption(name: "config_2fa"), error: nil)
+        ])
+
+        await #expect(throws: ConfigCreateFlowError.malformedContinuation) {
+            try await makeFlow(rpc).run(
+                name: "r", type: "iclouddrive", parameters: [:], obscure: false,
+                ask: { _, _ in "unused" }
+            )
+        }
+    }
+
+    @Test("Erreur fatale sans question : ConfigCreateFlowError.rclone")
+    func fatalErrorWithoutQuestionThrows() async throws {
+        let rpc = ScriptedRPC(script: [
+            ConfigCreateResponse(state: "", option: nil, error: "authSRPComplete: sign in failed")
+        ])
+
+        // state vide + option nil ⇒ isComplete, mais l'Error doit remonter.
+        await #expect(throws: ConfigCreateFlowError.rclone("authSRPComplete: sign in failed")) {
+            try await makeFlow(rpc).run(
+                name: "r", type: "iclouddrive", parameters: [:], obscure: false,
+                ask: { _, _ in "unused" }
+            )
+        }
+    }
+
+    @Test("Tempête de questions : coupe-circuit tooManyQuestions")
+    func questionStormThrows() async throws {
+        let storm = (0...ConfigCreateFlow.maxQuestions).map { i in
+            questionResponse("config_2fa", state: "*loop\(i)")
+        }
+        let rpc = ScriptedRPC(script: storm)
+        let asks = AskRecorder(answers: Array(repeating: "42", count: storm.count))
+
+        await #expect(throws: ConfigCreateFlowError.tooManyQuestions) {
+            try await makeFlow(rpc).run(
+                name: "r", type: "x", parameters: [:], obscure: false,
+                ask: { option, lastError in await asks.answer(option, lastError) }
+            )
+        }
+    }
+
+    @Test("onRemoteWritten déclenché après le create initial, avant la question")
+    func remoteWrittenFiresBeforeQuestions() async throws {
+        let rpc = ScriptedRPC(script: [
+            questionResponse("config_2fa", state: "*st"),
+            doneResponse
+        ])
+
+        // L'ordre est vérifiable sans horloge : le flag doit être posé au
+        // moment où le premier prompt arrive.
+        var writtenWhenAsked = false
+        var written = false
+
+        try await makeFlow(rpc).run(
+            name: "icloud", type: "iclouddrive", parameters: [:], obscure: false,
+            onRemoteWritten: { written = true },
+            ask: { _, _ in
+                writtenWhenAsked = written
+                return "123456"
+            }
+        )
+
+        #expect(written)
+        #expect(writtenWhenAsked)
+    }
+}


### PR DESCRIPTION
## Problème

La création d'un remote iCloud Drive échouait systématiquement en 401 Apple `-20101` (« Check the account information you entered ») sur `config/create`.

Deux causes :

1. **Instructions erronées** : le wizard demandait un *app-specific password* (`abcd-efgh-ijkl-mnop`), mais le backend rclone `iclouddrive` les refuse — l'auth SRP exige le mot de passe Apple ID normal (doc rclone : « App-specific passwords are not accepted »).
2. **Question 2FA ignorée** : même avec le bon mot de passe, `config/create` répond avec une question post-config `config_2fa` (State + Option). Le flow graphique ignorait cette réponse → remote écrit sans `cookies`/`trust_token`, donc inutilisable.

## Fix

- **BackendOverrides** : instructions corrigées — mot de passe Apple ID normal, activer « Accéder aux données iCloud sur le web » sur l'iPhone, code 2FA demandé au récapitulatif.
- **ConfigCreateFlow** (nouveau) : state machine `config/create` → `config/update {continue, state, result}`, transport RPC injecté (testable sans librclone). Gère les soft errors (mauvais code → retry avec message), `obscure` sur les questions de type password, coupe-circuit anti-boucle, et `onRemoteWritten` pour armer le nettoyage `config/delete` dès que la section existe.
- **RecapAndTestView** : chaque question rclone est présentée dans une alerte avec champ texte (titre dédié pour `config_2fa`). Continuation résolue exactement une fois (bouton, dismiss ou disparition de la vue).

## Tests

- 9 nouveaux tests unitaires `ConfigCreateFlowTests` (réponse 2FA, retry sur mauvais code, annulation, continuation malformée, erreur fatale, tempête de questions, obscure, ordre onRemoteWritten).
- Suite complète simulateur iOS 27 : **182 passed / 0 failed / 0 skipped**.

## Notes

- Nouvelles clés UI (« Code de vérification Apple (2FA) », « Valider », etc.) à couvrir dans la prochaine passe de localisation (`.xcstrings` non régénéré par xcodebuild CLI).
- Prérequis compte : 2FA activée ; avec ADP, Apple peut demander une approbation sur un appareil de confiance avant d'émettre les cookies PCS.