### PR TITLE
docs(changelog): 2.0 — connexion iCloud Drive réparée (app, site, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ and in-app under **Settings → Version history**.
   independently verifiable native build. Plus Handoff (transfer your encrypted config
   between devices via QR/AirDrop/file), Ghost Vault (encrypted config backup to a remote),
   smarter downloads (automatic network/battery/thermal management + reliable folder
-  downloads), and visible skipped photos in PhotoSync.
+  downloads), fixed iCloud Drive sign-in (regular Apple ID password + in-app 2FA prompt),
+  and visible skipped photos in PhotoSync.
 - **1.9.2** — Folder-download progress bar (folder size precomputed before the transfer).
 - **1.9.1** — Fix: first-launch “rclone catalog unavailable” error when creating your first remote.
 - **1.9** — Rebuilt video player (VLCKit 4: robust 4K MKV/HEVC, crackle-free audio),

--- a/Rclone GUI/Views/Settings/ChangelogView.swift
+++ b/Rclone GUI/Views/Settings/ChangelogView.swift
@@ -85,6 +85,7 @@ struct ChangelogView: View {
                 "Handoff : transférez votre configuration chiffrée d'un appareil à l'autre par QR code, AirDrop ou fichier.",
                 "Ghost Vault : sauvegarde chiffrée de votre configuration rclone dans l'un de vos propres remotes.",
                 "Téléchargements plus intelligents : gestion automatique selon le réseau, la batterie et la température, et téléchargements de dossiers fiabilisés (fini les gels sur iCloud Drive).",
+                "iCloud Drive réparé : l'ajout de votre compte iCloud fonctionne à nouveau — connectez-vous avec votre mot de passe Apple ID habituel, l'app vous demande ensuite votre code de vérification (2FA).",
                 "Synchro photo : les photos ignorées (supprimées, accès partiel, illisibles) sont enfin visibles, avec un bouton « Réessayer les ignorées » — fini le compteur qui plafonne sans explication.",
             ],
             itemsEN: [
@@ -92,6 +93,7 @@ struct ChangelogView: View {
                 "Handoff: move your encrypted configuration between devices via QR code, AirDrop or file.",
                 "Ghost Vault: encrypted backup of your rclone configuration into one of your own remotes.",
                 "Smarter downloads: automatic management based on network, battery and temperature, plus reliable folder downloads (no more freezes on iCloud Drive).",
+                "iCloud Drive fixed: adding your iCloud account works again — sign in with your regular Apple ID password, then the app asks for your verification code (2FA).",
                 "Photo sync: skipped photos (deleted, partial access, unreadable) are finally visible, with a \"Retry skipped\" button — no more counter stuck without explanation.",
             ]
         ),

--- a/docs/app.js
+++ b/docs/app.js
@@ -705,6 +705,7 @@
       { fr: "Handoff : transférez votre configuration chiffrée d'un appareil à l'autre par QR code, AirDrop ou fichier.", en: "Handoff: move your encrypted configuration between devices via QR code, AirDrop or file." },
       { fr: "Ghost Vault : sauvegarde chiffrée de votre configuration rclone dans l'un de vos propres remotes.", en: "Ghost Vault: encrypted backup of your rclone configuration into one of your own remotes." },
       { fr: "Téléchargements plus intelligents : gestion automatique selon le réseau, la batterie et la température, et téléchargements de dossiers fiabilisés (fini les gels sur iCloud Drive).", en: "Smarter downloads: automatic management based on network, battery and temperature, plus reliable folder downloads (no more freezes on iCloud Drive)." },
+      { fr: "iCloud Drive réparé : l'ajout de votre compte iCloud fonctionne à nouveau — connectez-vous avec votre mot de passe Apple ID habituel, l'app vous demande ensuite votre code de vérification (2FA).", en: "iCloud Drive fixed: adding your iCloud account works again — sign in with your regular Apple ID password, then the app asks for your verification code (2FA)." },
       { fr: "Synchro photo : les photos ignorées (supprimées, accès partiel, illisibles) sont enfin visibles, avec un bouton « Réessayer les ignorées ».", en: "Photo sync: skipped photos (deleted, partial access, unreadable) are finally visible, with a \"Retry skipped\" button." }
     ] },
     { v: "1.9.2", date: { fr: "Juillet 2026", en: "July 2026" }, items: [

--- a/docs/app.src.jsx
+++ b/docs/app.src.jsx
@@ -1004,6 +1004,7 @@ const VERSIONS = [
     { fr:'Handoff : transférez votre configuration chiffrée d\'un appareil à l\'autre par QR code, AirDrop ou fichier.', en:'Handoff: move your encrypted configuration between devices via QR code, AirDrop or file.' },
     { fr:'Ghost Vault : sauvegarde chiffrée de votre configuration rclone dans l\'un de vos propres remotes.', en:'Ghost Vault: encrypted backup of your rclone configuration into one of your own remotes.' },
     { fr:'Téléchargements plus intelligents : gestion automatique selon le réseau, la batterie et la température, et téléchargements de dossiers fiabilisés (fini les gels sur iCloud Drive).', en:'Smarter downloads: automatic management based on network, battery and temperature, plus reliable folder downloads (no more freezes on iCloud Drive).' },
+    { fr:'iCloud Drive réparé : l\'ajout de votre compte iCloud fonctionne à nouveau — connectez-vous avec votre mot de passe Apple ID habituel, l\'app vous demande ensuite votre code de vérification (2FA).', en:'iCloud Drive fixed: adding your iCloud account works again — sign in with your regular Apple ID password, then the app asks for your verification code (2FA).' },
     { fr:'Synchro photo : les photos ignorées (supprimées, accès partiel, illisibles) sont enfin visibles, avec un bouton « Réessayer les ignorées ».', en:'Photo sync: skipped photos (deleted, partial access, unreadable) are finally visible, with a "Retry skipped" button.' },
   ] },
   { v:'1.9.2', date:{ fr:'Juillet 2026', en:'July 2026' }, items:[


### PR DESCRIPTION
Suite du fix #122 (création de remote iCloud Drive) : les notes de version 2.0 mentionnent désormais que la connexion iCloud Drive refonctionne, sur les trois supports :

- **App** : `ChangelogView.releases` (FR/EN), ligne insérée dans l'entrée 2.0 après « Téléchargements plus intelligents ».
- **Site** : `docs/app.src.jsx` + bundle `docs/app.js` (syntaxe validée `node --check`).
- **GitHub** : puce 2.0 de la section *Version history* du README.

Contenu éditorial uniquement (littéraux statiques, aucune logique) — pas de nouveaux tests ; build simulateur : **BUILD SUCCEEDED**.