### PR TITLE
fix(wizard): iCloud — libellés explicites, choix Drive/Photos, warning durée du test

### DIFF
--- a/Rclone GUI/Core/BackendOverrides.swift
+++ b/Rclone GUI/Core/BackendOverrides.swift
@@ -469,15 +469,16 @@ enum BackendOverrides {
             setupURL: URL(string: "https://appleid.apple.com/account/manage"),
             setupSteps: [
                 "Active la 2FA sur ton compte Apple si pas déjà fait (obligatoire).",
-                "Utilise ton mot de passe Apple ID NORMAL — Apple refuse les mots de passe « spécifiques à une app » pour iCloud Drive.",
+                "Utilise ton mot de passe Apple ID HABITUEL (celui de ton compte) — Apple refuse les mots de passe « spécifiques à une app » et les mots de passe uniques.",
                 "Sur ton iPhone : Réglages → [ton nom] → iCloud → active « Accéder aux données iCloud sur le web ».",
-                "Colle ton mot de passe ci-dessous (champ « password »).",
+                "Colle ton mot de passe ci-dessous.",
                 "Un code 2FA te sera demandé à l'étape « Récapitulatif » (test ou création).",
-                "À l'étape précédente du wizard, remplis aussi « apple_id » avec ton email Apple ID."
+                "L'obtention du jeton de session Apple après le code 2FA peut prendre plusieurs minutes — laisse l'écran ouvert.",
+                "À l'étape précédente du wizard, remplis aussi « Email Apple ID » et choisis le service (iCloud Drive ou iCloud Photos)."
             ],
-            tokenLabel: "Mot de passe Apple ID",
+            tokenLabel: "Mot de passe Apple ID (habituel)",
             tokenFieldName: "password",
-            tokenHint: "Ton mot de passe Apple ID complet — PAS un mot de passe d'app (rejeté par Apple). Le champ « apple_id » est rempli dans le formulaire principal."
+            tokenHint: "Le mot de passe normal de ton compte Apple — PAS un mot de passe d'app ni un mot de passe unique (rejetés par Apple). L'email Apple ID se remplit dans le formulaire principal."
         ),
 
         // ───────── Dropbox / Box / pCloud ─────────
@@ -831,6 +832,35 @@ enum BackendOverrides {
             tokenHint: "⚠️ La clé API s'obtient seulement via le CLI Filen sur ordinateur. Email + mot de passe se saisissent à l'étape Formulaire."
         ),
     ]
+
+    // MARK: - Field-level overrides (labels + rendu)
+
+    /// Labels par backend/champ quand le nom rclone humanisé est trompeur —
+    /// ex. iCloud attend le mot de passe HABITUEL du compte (pas un mot de
+    /// passe d'app) et `service` choisit entre Drive et Photos. Chaînes FR
+    /// sources, résolues via le String Catalog.
+    nonisolated static func fieldLabel(backend: String, field: String) -> String? {
+        switch (backend, field) {
+        case ("iclouddrive", "apple_id"):
+            return String(localized: "Email Apple ID")
+        case ("iclouddrive", "password"):
+            return String(localized: "Mot de passe Apple ID (habituel)")
+        case ("iclouddrive", "service"):
+            return String(localized: "Service iCloud (Drive ou Photos)")
+        default:
+            return nil
+        }
+    }
+
+    /// Champs à présenter en sélecteur exclusif même quand rclone ne marque
+    /// pas l'option `Exclusive` (une valeur libre n'aurait aucun sens).
+    private nonisolated static let forcedPickerFields: [String: Set<String>] = [
+        "iclouddrive": ["service"],
+    ]
+
+    nonisolated static func forcesPicker(backend: String, field: String) -> Bool {
+        forcedPickerFields[backend]?.contains(field) ?? false
+    }
 
     // MARK: - Backends to hide on iOS
 

--- a/Rclone GUI/Models/Wizard/FieldSpec.swift
+++ b/Rclone GUI/Models/Wizard/FieldSpec.swift
@@ -48,9 +48,18 @@ struct FieldSpec: Identifiable, Hashable, Sendable {
     /// currently-selected provider is not in the list.
     let providerFilter: String?
 
+    /// Product-side override: render the examples as an exclusive picker
+    /// even when rclone doesn't flag the option `Exclusive` (e.g. iCloud
+    /// `service` where drive/photos are the only meaningful values).
+    let forcedPicker: Bool
+
     // MARK: - Lifting from rclone schema
 
-    nonisolated init(from option: RcloneOptionSchema, label overrideLabel: String? = nil) {
+    nonisolated init(
+        from option: RcloneOptionSchema,
+        label overrideLabel: String? = nil,
+        forcePicker: Bool = false
+    ) {
         self.id = option.name
         self.name = option.name
         self.label = overrideLabel ?? Self.humanize(option.name)
@@ -65,6 +74,7 @@ struct FieldSpec: Identifiable, Hashable, Sendable {
         self.hide = option.hide
         self.examples = option.examples ?? []
         self.providerFilter = option.provider
+        self.forcedPicker = forcePicker
     }
 
     private nonisolated static func humanize(_ raw: String) -> String {
@@ -163,7 +173,7 @@ struct FieldSpec: Identifiable, Hashable, Sendable {
         if sensitive || isPassword { return .secureInput }
 
         if !examples.isEmpty {
-            return exclusive ? .picker : .combobox
+            return (exclusive || forcedPicker) ? .picker : .combobox
         }
 
         switch type {

--- a/Rclone GUI/Services/RemoteCatalogService.swift
+++ b/Rclone GUI/Services/RemoteCatalogService.swift
@@ -82,7 +82,13 @@ actor RemoteCatalogService {
                         .map { NSLocalizedString($0, comment: "Backend description") }
                         ?? rclone.description
                     let oauth = BackendOverrides.oauthConfigs[rclone.name]
-                    let fields = rclone.options.map { FieldSpec(from: $0) }
+                    let fields = rclone.options.map { option in
+                        FieldSpec(
+                            from: option,
+                            label: BackendOverrides.fieldLabel(backend: rclone.name, field: option.name),
+                            forcePicker: BackendOverrides.forcesPicker(backend: rclone.name, field: option.name)
+                        )
+                    }
                     return BackendSchema(
                         name: rclone.name,
                         prefix: rclone.prefix,

--- a/Rclone GUI/Views/Settings/AddRemote/RecapAndTestView.swift
+++ b/Rclone GUI/Views/Settings/AddRemote/RecapAndTestView.swift
@@ -149,6 +149,12 @@ struct RecapAndTestView: View {
 
     private var testSection: some View {
         Section {
+            if state.selectedBackend?.name == "iclouddrive" {
+                Label("iCloud : après le code 2FA, l'obtention du jeton de session Apple peut prendre plusieurs minutes. Laisse l'écran ouvert pendant le test.",
+                      systemImage: "clock.badge.exclamationmark")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
             Button {
                 Task { await runTest() }
             } label: {
@@ -281,9 +287,15 @@ struct RecapAndTestView: View {
             return
         }
 
-        // 2. Run operations/list with timeout.
+        // 2. Run operations/list with timeout. iCloud gets a much longer
+        // window: right after 2FA, Apple can take minutes to mint the
+        // session token before the first listing answers.
+        let timeoutSeconds = backend.name == "iclouddrive" ? 180 : 10
         do {
-            let result = try await RemoteConnectionTester.test(remote: state.name)
+            let result = try await RemoteConnectionTester.test(
+                remote: state.name,
+                timeoutSeconds: timeoutSeconds
+            )
             state.testResult = .success(itemCount: result.itemCount, sample: result.sample)
         } catch RemoteConnectionTester.TestError.timeout(let secs) {
             state.testResult = .timeout

--- a/Rclone GUITests/ICloudWizardFieldTests.swift
+++ b/Rclone GUITests/ICloudWizardFieldTests.swift
@@ -1,0 +1,101 @@
+//
+//  ICloudWizardFieldTests.swift
+//  Rclone GUITests
+//
+//  Unit tests for the iCloud Drive wizard field overrides: French labels
+//  that state the real expected value (regular Apple ID password, not an
+//  app-specific one), and the forced-picker rendering of `service`
+//  (drive/photos) even though rclone doesn't flag the option Exclusive.
+//
+
+import Testing
+import Foundation
+@testable import Rclone_GUI
+
+// MARK: - Fixtures
+
+private func makeOption(
+    name: String,
+    exclusive: Bool = false,
+    examples: [RcloneExampleValue]? = nil
+) -> RcloneOptionSchema {
+    RcloneOptionSchema(
+        name: name,
+        help: "",
+        type: "string",
+        defaultStr: "",
+        valueStr: nil,
+        required: true,
+        isPassword: false,
+        sensitive: false,
+        advanced: false,
+        exclusive: exclusive,
+        hide: 0,
+        noPrefix: false,
+        examples: examples,
+        provider: nil
+    )
+}
+
+private let serviceExamples = [
+    RcloneExampleValue(value: "drive", help: "iCloud Drive", provider: nil),
+    RcloneExampleValue(value: "photos", help: "iCloud Photos", provider: nil),
+]
+
+// MARK: - Tests
+
+@Suite("Overrides des champs du wizard iCloud")
+struct ICloudWizardFieldTests {
+
+    @Test("Labels iCloud : la vraie valeur attendue est nommée")
+    func icloudFieldLabels() {
+        #expect(BackendOverrides.fieldLabel(backend: "iclouddrive", field: "apple_id") == "Email Apple ID")
+        #expect(BackendOverrides.fieldLabel(backend: "iclouddrive", field: "password") == "Mot de passe Apple ID (habituel)")
+        #expect(BackendOverrides.fieldLabel(backend: "iclouddrive", field: "service") == "Service iCloud (Drive ou Photos)")
+    }
+
+    @Test("Pas d'override de label pour les autres backends/champs")
+    func noLabelOverrideElsewhere() {
+        #expect(BackendOverrides.fieldLabel(backend: "iclouddrive", field: "client_id") == nil)
+        #expect(BackendOverrides.fieldLabel(backend: "s3", field: "apple_id") == nil)
+        #expect(BackendOverrides.fieldLabel(backend: "drive", field: "service") == nil)
+    }
+
+    @Test("service iCloud est forcé en sélecteur exclusif")
+    func icloudServiceForcesPicker() {
+        #expect(BackendOverrides.forcesPicker(backend: "iclouddrive", field: "service"))
+        #expect(!BackendOverrides.forcesPicker(backend: "iclouddrive", field: "apple_id"))
+        #expect(!BackendOverrides.forcesPicker(backend: "s3", field: "service"))
+    }
+
+    @Test("FieldSpec : forcePicker rend un picker malgré exclusive=false")
+    func forcePickerYieldsPickerUI() {
+        let option = makeOption(name: "service", exclusive: false, examples: serviceExamples)
+
+        let forced = FieldSpec(from: option, forcePicker: true)
+        #expect(forced.uiKind == .picker)
+
+        // Sans le forçage, le même schéma rclone donne le combobox flou.
+        let plain = FieldSpec(from: option)
+        #expect(plain.uiKind == .combobox)
+    }
+
+    @Test("FieldSpec : exclusive=true donne un picker sans forçage")
+    func exclusiveStillYieldsPicker() {
+        let option = makeOption(name: "region", exclusive: true, examples: serviceExamples)
+        #expect(FieldSpec(from: option).uiKind == .picker)
+    }
+
+    @Test("FieldSpec : forcePicker sans examples reste un champ texte")
+    func forcePickerWithoutExamplesFallsBack() {
+        let option = makeOption(name: "service", exclusive: false, examples: nil)
+        #expect(FieldSpec(from: option, forcePicker: true).uiKind == .textInput)
+    }
+
+    @Test("FieldSpec : le label override remplace le nom humanisé")
+    func labelOverrideApplied() {
+        let option = makeOption(name: "apple_id")
+        #expect(FieldSpec(from: option).label == "Apple Id")
+        #expect(FieldSpec(from: option, label: "Email Apple ID").label == "Email Apple ID")
+    }
+}


### PR DESCRIPTION
Suite UX du fix #122, sur retour terrain :

## Changements

1. **Libellés qui disent la vraie valeur attendue** — nouveau `BackendOverrides.fieldLabel(backend:field:)` appliqué par `RemoteCatalogService` :
   - `apple_id` → « Email Apple ID »
   - `password` → « Mot de passe Apple ID (habituel) » (étape Authentification : tokenLabel/hint précisent que les mots de passe d'app et « uniques » sont rejetés par Apple)
   - `service` → « Service iCloud (Drive ou Photos) »
2. **Choix iCloud Drive / iCloud Photos visible** — rclone ne marque pas `service` comme `Exclusive`, donc le formulaire affichait un combobox confus (champ texte + suggestions). Nouveau `FieldSpec.forcedPicker` (opt-in par backend) → vrai sélecteur « drive — iCloud Drive » / « photos — iCloud Photos », défaut Drive.
3. **Warning durée au test** — encart orange à l'étape Récapitulatif : après le code 2FA, l'obtention du jeton de session Apple peut prendre plusieurs minutes ; laisser l'écran ouvert. Timeout du test 10 s → **180 s** pour `iclouddrive`.
4. Le flow 2FA (mot de passe → alerte code) reste celui de #122.

## Tests

- 7 nouveaux tests `ICloudWizardFieldTests` (labels, `forcesPicker`, `uiKind` picker forcé/exclusive/fallback, override de label).
- Suite complète simulateur : **189 passed / 0 failed / 0 skipped**.

Nouvelles clés FR à couvrir dans la prochaine passe de localisation.