### PR TITLE
fix(wizard): iCloud — retire le lien vers la page « mot de passe d'app » Apple

### DIFF
--- a/Rclone GUI/Core/BackendOverrides.swift
+++ b/Rclone GUI/Core/BackendOverrides.swift
@@ -466,7 +466,11 @@ enum BackendOverrides {
             defaultScopes: [],
             strategy: .manual,
             usePKCE: false,
-            setupURL: URL(string: "https://appleid.apple.com/account/manage"),
+            // Pas de setupURL : la page appleid.apple.com servait à générer un
+            // mot de passe d'app, inutile (et trompeur) depuis le flow 2FA —
+            // l'utilisateur saisit son mot de passe habituel, le code 2FA est
+            // demandé dans l'app.
+            setupURL: nil,
             setupSteps: [
                 "Active la 2FA sur ton compte Apple si pas déjà fait (obligatoire).",
                 "Utilise ton mot de passe Apple ID HABITUEL (celui de ton compte) — Apple refuse les mots de passe « spécifiques à une app » et les mots de passe uniques.",


### PR DESCRIPTION
L'étape Authentification iCloud affichait encore un lien « Ouvrir la page iCloud Drive et Photos » vers `appleid.apple.com/account/manage` — la page où l'on **génère les mots de passe à usage unique / d'app**. Depuis le flow 2FA (#122/#124), ce lien est inutile et trompeur : le mot de passe attendu est le mot de passe habituel du compte, et le code 2FA est demandé directement dans l'app.

- `setupURL` → `nil` pour `iclouddrive` ; la section lien disparaît via le `if let setupURL` existant d'`OAuthView`.
- Donnée pure, aucune logique nouvelle → pas de test dédié ; non-régression : **189 passed / 0 failed**.