### PR TITLE
fix(macos): archive Xcode Cloud — modifier cross-platform sur le champ 2FA

### DIFF
--- a/Rclone GUI/Views/Settings/AddRemote/RecapAndTestView.swift
+++ b/Rclone GUI/Views/Settings/AddRemote/RecapAndTestView.swift
@@ -65,7 +65,7 @@ struct RecapAndTestView: View {
             presenting: pendingQuestion
         ) { question in
             TextField(questionTitle(for: question.option), text: $questionAnswer)
-                .textInputAutocapitalization(.never)
+                .rgNoAutocap()
                 .autocorrectionDisabled()
             Button("Valider") {
                 resolveQuestion(with: questionAnswer)


### PR DESCRIPTION
L'archive macOS du build Xcode Cloud 140 échouait (exit 65) : l'alerte 2FA iCloud (#122) utilisait `.textInputAutocapitalization(.never)`, une API iOS-only absente de macOS — le seul usage non protégé du repo (tous les autres passent par `#if os(iOS)` ou `rgNoAutocap()`).

- Remplacé par `rgNoAutocap()` (no-op sur macOS), pattern maison existant.
- Vérifié localement : `xcodebuild build -configuration Release` sur `generic/platform=macOS` **et** `generic/platform=iOS` → BUILD SUCCEEDED.
- Aucune logique changée — pas de nouveau test (les 189 tests existants couvrent le flow 2FA).

NB : le workflow GitHub « iOS CI » est rouge sur ses 12 derniers runs pour des raisons d'infra (RcloneKit.xcframework absent du runner, destination simulateur introuvable) — il n'aurait pas attrapé cette régression ; à réparer séparément.