### PR TITLE
chore(fastlane): épingle build 141 pour la 2.0 (ship + submit_mac)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -88,11 +88,12 @@ platform :ios do
     deliver(
       api_key: asc_key,
       app_version: "2.0",
-      build_number: "139",
+      build_number: "141",
       skip_binary_upload: true,
       skip_screenshots: true,
       skip_metadata: false,
       submit_for_review: true,
+      reject_if_possible: true,   # annule la revue 2.0 en cours pour attacher 141
       automatic_release: true,
       force: true,
       precheck_include_in_app_purchases: false,
@@ -214,8 +215,9 @@ platform :mac do
       api_key: asc_key,
       platform: "osx",
       app_version: "2.0",
-      build_number: "139",
+      build_number: "141",
       submit_for_review: true,
+      reject_if_possible: true,   # annule la revue macOS 2.0 en cours pour attacher 141
       automatic_release: true,
       skip_binary_upload: true,
       skip_screenshots: true,


### PR DESCRIPTION
Soumission de la **2.0 build 141** (iOS + macOS), qui remplace le build 139 en revue.

- Build 141 est **VALID** sur ASC pour iOS et macOS (uploadé par Xcode Cloud).
- Contient les correctifs iCloud (#122/#124/#125) et le fix d'archive macOS (#126) qui faisait échouer le build 140.
- Lanes `ship` et `submit_mac` : `build_number` 139 → 141 + `reject_if_possible: true` pour annuler la revue 2.0 en cours et rattacher 141.

Syntaxe Ruby vérifiée (`ruby -c`).