### PR TITLE
feat(lens): socle Remote Lens — détection PDF, plan de lecture, lecteur de plage (RG-17)

### DIFF
--- a/Rclone GUI/Core/MediaFormat.swift
+++ b/Rclone GUI/Core/MediaFormat.swift
@@ -103,6 +103,26 @@ public nonisolated enum MediaFormat {
         isImage(name) || isVideo(name)
     }
 
+    // Documents dont on sait rendre un aperçu (1re page). Pour l'instant PDF ;
+    // extensible plus tard (pages, docx…) si un moteur de rendu est ajouté.
+    static let documentExtensions: Set<String> = ["pdf"]
+
+    /// Vrai pour un PDF (détection par extension, avec repli sur le type système).
+    public static func isPDF(_ name: String) -> Bool {
+        let e = ext(name)
+        if documentExtensions.contains(e) { return true }
+        if let type = UTType(filenameExtension: e), type.conforms(to: .pdf) {
+            return true
+        }
+        return false
+    }
+
+    /// Fichiers éligibles à un aperçu « Remote Lens » (vignette + métadonnées
+    /// par range requests) : images et PDF. La vidéo garde son chemin galerie.
+    public static func hasLens(_ name: String) -> Bool {
+        isImage(name) || isPDF(name)
+    }
+
     /// Extensions de sous-titres « sidecar » qu'on cherche à côté du média.
     static let subtitleExtensions: Set<String> = [
         "srt", "ass", "ssa", "vtt", "sub", "idx"

--- a/Rclone GUI/Core/RemoteLensPlan.swift
+++ b/Rclone GUI/Core/RemoteLensPlan.swift
@@ -1,0 +1,114 @@
+//
+//  RemoteLensPlan.swift
+//  Rclone GUI — Core
+//
+//  Logique PURE de la feature « Remote Lens » (aperçus par range requests) :
+//  décision de stratégie de lecture (combien d'octets rapatrier) et formatage
+//  des métadonnées EXIF. Aucune I/O, aucun UIKit → 100 % testable sans réseau
+//  ni fichier. Le service `RemoteLensService` consomme ces décisions.
+//
+
+import Foundation
+
+public nonisolated enum RemoteLensPlan {
+
+    // MARK: - Stratégie de lecture
+
+    /// Comment rapatrier les octets d'un fichier distant pour son aperçu.
+    public enum FetchStrategy: Equatable, Sendable {
+        /// Fichier assez petit : GET complet borné (le transport reste range-capable,
+        /// mais on tire tout l'objet).
+        case fullBounded
+        /// Lire seulement les `N` premiers octets, puis tenter un décodage incrémental
+        /// (vignette EXIF embarquée + métadonnées, souvent en tête de fichier).
+        case headRange(Int64)
+        /// Accès aléatoire par plages piloté par le consommateur (PDF : xref en fin +
+        /// objets de la 1re page) — quelle que soit la taille.
+        case randomAccess
+        /// Trop volumineux pour un aperçu raisonnable → icône de repli.
+        case skip
+    }
+
+    // Aligné sur `ThumbnailService.imageSizeCap` (80 Mo) : au-delà, pas de vignette.
+    public static let imageFullCap: Int64 = 80 * 1024 * 1024
+    // Fenêtre de tête pour EXIF + vignette embarquée (JPEG/HEIC/RAW la placent tôt).
+    public static let imageHeadWindow: Int64 = 512 * 1024
+    // En dessous de ce seuil, un GET complet borné est plus simple qu'un range de tête.
+    public static let imageInlineCap: Int64 = 256 * 1024
+
+    /// Stratégie pour une image selon sa taille.
+    /// - `size <= 0` (inconnue) → tenter la fenêtre de tête.
+    public static func imageStrategy(size: Int64) -> FetchStrategy {
+        if size > imageFullCap { return .skip }
+        if size > 0, size <= imageInlineCap { return .fullBounded }
+        return .headRange(imageHeadWindow)
+    }
+
+    /// Stratégie pour un PDF : toujours l'accès aléatoire (lecture ciblée xref +
+    /// 1re page), sans plafond de taille.
+    public static func pdfStrategy(size: Int64) -> FetchStrategy {
+        .randomAccess
+    }
+
+    // MARK: - Arithmétique de plage
+
+    /// Plage `[start, start+window-1]` bornée à l'octet final du fichier, pour ne
+    /// jamais déclencher un `416 Range Not Satisfiable`.
+    /// - Retourne `nil` si `start` est hors du fichier (≥ taille) ou paramètres invalides.
+    public static func clampedRange(start: Int64, window: Int64, totalSize: Int64) -> ClosedRange<Int64>? {
+        guard window > 0, start >= 0 else { return nil }
+        // Taille inconnue : on fait confiance à la fenêtre demandée.
+        if totalSize <= 0 {
+            return start...(start + window - 1)
+        }
+        guard start < totalSize else { return nil }
+        let end = min(start + window - 1, totalSize - 1)
+        return start...end
+    }
+
+    // MARK: - Formatage EXIF (pur)
+
+    /// Temps de pose : « 1/250 s » sous 1 s, « 2 s » au-dessus.
+    public static func formatExposureTime(_ seconds: Double) -> String {
+        guard seconds > 0 else { return "—" }
+        if seconds >= 1 {
+            // Retire un « .0 » superflu.
+            let rounded = (seconds * 10).rounded() / 10
+            let s = rounded == rounded.rounded() ? String(Int(rounded)) : String(rounded)
+            return "\(s) s"
+        }
+        let denom = Int((1.0 / seconds).rounded())
+        return "1/\(denom) s"
+    }
+
+    /// Ouverture : « f/2.8 ».
+    public static func formatFNumber(_ f: Double) -> String {
+        guard f > 0 else { return "—" }
+        let rounded = (f * 10).rounded() / 10
+        let s = rounded == rounded.rounded() ? String(Int(rounded)) : String(rounded)
+        return "f/\(s)"
+    }
+
+    /// Focale : « 50 mm ».
+    public static func formatFocalLength(_ mm: Double) -> String {
+        guard mm > 0 else { return "—" }
+        return "\(Int(mm.rounded())) mm"
+    }
+
+    /// Sensibilité : « ISO 100 ».
+    public static func formatISO(_ iso: Int) -> String {
+        guard iso > 0 else { return "—" }
+        return "ISO \(iso)"
+    }
+
+    /// Applique le signe hémisphère (réf « S » ou « W » → valeur négative).
+    public static func gpsDecimal(_ value: Double, ref: String?) -> Double {
+        guard let ref = ref?.uppercased() else { return value }
+        return (ref == "S" || ref == "W") ? -abs(value) : abs(value)
+    }
+
+    /// Coordonnées lisibles : « 48.8566, 2.3522 » (déjà signées).
+    public static func formatCoordinate(lat: Double, lon: Double) -> String {
+        String(format: "%.5f, %.5f", lat, lon)
+    }
+}

--- a/Rclone GUI/Services/RemoteRangeReader.swift
+++ b/Rclone GUI/Services/RemoteRangeReader.swift
@@ -1,0 +1,102 @@
+//
+//  RemoteRangeReader.swift
+//  Rclone GUI — Services
+//
+//  Primitive de lecture PARTIELLE d'un fichier distant via le bridge loopback
+//  range-capable (`RcloneStreamingService.liveSession` → serveur Go
+//  `StartFileHTTP`, qui gère HEAD + `Range: bytes=` + 206). Une seule session
+//  loopback est ouverte pour toute la durée de `withSession` (jamais un serveur
+//  par plage), puis arrêtée en `defer`.
+//
+//  `RangeByteSource` est une petite abstraction Sendable (closures) avec deux
+//  fabriques : `.loopback` (réseau) et `.inMemory` (tests, sans réseau).
+//
+
+import Foundation
+
+/// Source d'octets adressable par plage. Type-erased (closures) pour rester
+/// Sendable et testable sans réseau via `.inMemory`.
+public nonisolated struct RangeByteSource: Sendable {
+    private let _size: @Sendable () async -> Int64?
+    private let _read: @Sendable (ClosedRange<Int64>) async -> Data?
+
+    public init(
+        size: @escaping @Sendable () async -> Int64?,
+        read: @escaping @Sendable (ClosedRange<Int64>) async -> Data?
+    ) {
+        self._size = size
+        self._read = read
+    }
+
+    /// Taille totale du fichier en octets (nil si inconnue/erreur).
+    public func size() async -> Int64? { await _size() }
+
+    /// Lit la plage `[a, b]` (bornes incluses). Renvoie nil sur erreur.
+    public func read(_ range: ClosedRange<Int64>) async -> Data? { await _read(range) }
+
+    // MARK: - Fabriques
+
+    /// Source réseau : HEAD pour la taille, GET `Range: bytes=a-b` pour les plages.
+    public static func loopback(baseURL: URL, urlSession: URLSession = .shared) -> RangeByteSource {
+        RangeByteSource(
+            size: {
+                var req = URLRequest(url: baseURL)
+                req.httpMethod = "HEAD"
+                req.cachePolicy = .reloadIgnoringLocalCacheData
+                guard let (_, resp) = try? await urlSession.data(for: req),
+                      let http = resp as? HTTPURLResponse else { return nil }
+                if let len = http.value(forHTTPHeaderField: "Content-Length"),
+                   let n = Int64(len), n >= 0 { return n }
+                let expected = http.expectedContentLength
+                return expected >= 0 ? expected : nil
+            },
+            read: { range in
+                var req = URLRequest(url: baseURL)
+                req.httpMethod = "GET"
+                req.setValue("bytes=\(range.lowerBound)-\(range.upperBound)",
+                             forHTTPHeaderField: "Range")
+                req.cachePolicy = .reloadIgnoringLocalCacheData
+                guard let (data, _) = try? await urlSession.data(for: req) else { return nil }
+                // Défensif : si le serveur ignore le Range et renvoie tout (200),
+                // on ne garde que la plage demandée.
+                let want = range.upperBound - range.lowerBound + 1
+                if Int64(data.count) > want, want > 0, want <= Int64(Int.max) {
+                    return data.prefix(Int(want))
+                }
+                return data
+            }
+        )
+    }
+
+    /// Source en mémoire (tests, aperçu depuis des octets déjà en main).
+    public static func inMemory(_ data: Data) -> RangeByteSource {
+        let total = Int64(data.count)
+        return RangeByteSource(
+            size: { total },
+            read: { range in
+                guard range.lowerBound >= 0, range.lowerBound < total else { return nil }
+                let end = min(range.upperBound, total - 1)
+                let lo = Int(range.lowerBound)
+                let hi = Int(end)
+                return data.subdata(in: lo..<(hi + 1))
+            }
+        )
+    }
+}
+
+/// Ouvre une session loopback pour `remote:path`, exécute `body` avec une
+/// `RangeByteSource` réseau, puis arrête la session. Renvoie nil si le bridge
+/// est indisponible.
+public nonisolated enum RemoteRangeReader {
+    public static func withSession<T>(
+        remote: String,
+        path: String,
+        _ body: (RangeByteSource) async throws -> T
+    ) async rethrows -> T? {
+        guard let session = await RcloneStreamingService.shared.liveSession(
+            remote: remote, path: path
+        ) else { return nil }
+        defer { Task { await RcloneStreamingService.shared.stop(session) } }
+        return try await body(.loopback(baseURL: session.url))
+    }
+}

--- a/Rclone GUITests/RemoteLensCoreTests.swift
+++ b/Rclone GUITests/RemoteLensCoreTests.swift
@@ -1,0 +1,136 @@
+//
+//  RemoteLensCoreTests.swift
+//  Rclone GUITests
+//
+//  Tests unitaires du socle « Remote Lens » (PR1) : détection PDF/lens
+//  (MediaFormat), décisions de stratégie + formatage EXIF (RemoteLensPlan),
+//  et lecture de plage sur source mémoire (RangeByteSource). Zéro réseau.
+//
+
+import Testing
+import Foundation
+@testable import Rclone_GUI
+
+@Suite("MediaFormat — PDF & lens")
+struct MediaFormatLensTests {
+
+    @Test("isPDF reconnaît .pdf quelle que soit la casse, pas les autres")
+    func isPDF() {
+        #expect(MediaFormat.isPDF("rapport.pdf"))
+        #expect(MediaFormat.isPDF("RAPPORT.PDF"))
+        #expect(MediaFormat.isPDF("dossier/sous/a.Pdf"))
+        #expect(!MediaFormat.isPDF("photo.png"))
+        #expect(!MediaFormat.isPDF("archive.zip"))
+        #expect(!MediaFormat.isPDF("sans-extension"))
+    }
+
+    @Test("hasLens = images + PDF, pas vidéo/audio/autre")
+    func hasLens() {
+        #expect(MediaFormat.hasLens("photo.jpg"))
+        #expect(MediaFormat.hasLens("raw.dng"))
+        #expect(MediaFormat.hasLens("scan.pdf"))
+        #expect(!MediaFormat.hasLens("film.mp4"))
+        #expect(!MediaFormat.hasLens("son.mp3"))
+        #expect(!MediaFormat.hasLens("archive.zip"))
+    }
+}
+
+@Suite("RemoteLensPlan — stratégie & formatage")
+struct RemoteLensPlanTests {
+
+    @Test("imageStrategy : skip au-delà du plafond, inline si petit, sinon range de tête")
+    func imageStrategy() {
+        #expect(RemoteLensPlan.imageStrategy(size: 200 * 1024 * 1024) == .skip)
+        #expect(RemoteLensPlan.imageStrategy(size: 100 * 1024) == .fullBounded)      // 100 Ko
+        #expect(RemoteLensPlan.imageStrategy(size: 5 * 1024 * 1024)
+                == .headRange(RemoteLensPlan.imageHeadWindow))                       // 5 Mo
+        // Taille inconnue → on tente la fenêtre de tête.
+        #expect(RemoteLensPlan.imageStrategy(size: 0)
+                == .headRange(RemoteLensPlan.imageHeadWindow))
+    }
+
+    @Test("imageStrategy : bornes exactes autour des seuils")
+    func imageStrategyBoundaries() {
+        #expect(RemoteLensPlan.imageStrategy(size: RemoteLensPlan.imageInlineCap) == .fullBounded)
+        #expect(RemoteLensPlan.imageStrategy(size: RemoteLensPlan.imageInlineCap + 1)
+                == .headRange(RemoteLensPlan.imageHeadWindow))
+        #expect(RemoteLensPlan.imageStrategy(size: RemoteLensPlan.imageFullCap)
+                == .headRange(RemoteLensPlan.imageHeadWindow))
+        #expect(RemoteLensPlan.imageStrategy(size: RemoteLensPlan.imageFullCap + 1) == .skip)
+    }
+
+    @Test("pdfStrategy : toujours accès aléatoire")
+    func pdfStrategy() {
+        #expect(RemoteLensPlan.pdfStrategy(size: 1_000) == .randomAccess)
+        #expect(RemoteLensPlan.pdfStrategy(size: 500 * 1024 * 1024) == .randomAccess)
+    }
+
+    @Test("clampedRange : borne à EOF, refuse au-delà de la taille")
+    func clampedRange() {
+        // Fenêtre entièrement dans le fichier.
+        #expect(RemoteLensPlan.clampedRange(start: 0, window: 100, totalSize: 1_000) == 0...99)
+        // Fenêtre qui dépasse EOF → bornée au dernier octet.
+        #expect(RemoteLensPlan.clampedRange(start: 950, window: 100, totalSize: 1_000) == 950...999)
+        // start == taille → hors fichier → nil.
+        #expect(RemoteLensPlan.clampedRange(start: 1_000, window: 10, totalSize: 1_000) == nil)
+        // Taille inconnue → on fait confiance à la fenêtre.
+        #expect(RemoteLensPlan.clampedRange(start: 0, window: 512, totalSize: 0) == 0...511)
+        // Paramètres invalides.
+        #expect(RemoteLensPlan.clampedRange(start: -1, window: 10, totalSize: 100) == nil)
+        #expect(RemoteLensPlan.clampedRange(start: 0, window: 0, totalSize: 100) == nil)
+    }
+
+    @Test("formatExposureTime : fractions sous 1 s, secondes au-dessus")
+    func exposureTime() {
+        #expect(RemoteLensPlan.formatExposureTime(0.004) == "1/250 s")
+        #expect(RemoteLensPlan.formatExposureTime(0.5) == "1/2 s")
+        #expect(RemoteLensPlan.formatExposureTime(2.0) == "2 s")
+        #expect(RemoteLensPlan.formatExposureTime(0) == "—")
+    }
+
+    @Test("formatFNumber / focale / ISO")
+    func numericFormats() {
+        #expect(RemoteLensPlan.formatFNumber(2.8) == "f/2.8")
+        #expect(RemoteLensPlan.formatFNumber(8.0) == "f/8")
+        #expect(RemoteLensPlan.formatFocalLength(50) == "50 mm")
+        #expect(RemoteLensPlan.formatFocalLength(35.4) == "35 mm")
+        #expect(RemoteLensPlan.formatISO(100) == "ISO 100")
+        #expect(RemoteLensPlan.formatISO(0) == "—")
+    }
+
+    @Test("gpsDecimal : réfs S/W négatives, N/E positives")
+    func gps() {
+        #expect(RemoteLensPlan.gpsDecimal(48.8566, ref: "N") == 48.8566)
+        #expect(RemoteLensPlan.gpsDecimal(48.8566, ref: "S") == -48.8566)
+        #expect(RemoteLensPlan.gpsDecimal(2.3522, ref: "W") == -2.3522)
+        #expect(RemoteLensPlan.gpsDecimal(2.3522, ref: nil) == 2.3522)
+        #expect(RemoteLensPlan.formatCoordinate(lat: 48.8566, lon: 2.3522) == "48.85660, 2.35220")
+    }
+}
+
+@Suite("RangeByteSource — source mémoire")
+struct RangeByteSourceTests {
+
+    @Test("inMemory : size et lecture de plage exacte")
+    func inMemoryReads() async {
+        let bytes = Data((0..<256).map { UInt8($0) })
+        let src = RangeByteSource.inMemory(bytes)
+
+        #expect(await src.size() == 256)
+        let head = await src.read(0...15)
+        #expect(head == Data((0...15).map { UInt8($0) }))
+        let mid = await src.read(100...103)
+        #expect(mid == Data([100, 101, 102, 103]))
+    }
+
+    @Test("inMemory : plage dépassant EOF tronquée, hors fichier → nil")
+    func inMemoryClamp() async {
+        let bytes = Data((0..<10).map { UInt8($0) })
+        let src = RangeByteSource.inMemory(bytes)
+
+        let tail = await src.read(8...20)     // dépasse EOF → 8,9
+        #expect(tail == Data([8, 9]))
+        let beyond = await src.read(10...20)  // entièrement hors fichier
+        #expect(beyond == nil)
+    }
+}


### PR DESCRIPTION
PR 1/4 de **Remote Lens** (RG-17 : aperçus vignette/EXIF/1re page PDF par range requests, sans tout télécharger).

Le socle, sans UI ni décodage :
- `MediaFormat.isPDF` / `hasLens` : détection PDF centralisée + éligibilité aperçu (images + PDF).
- `RemoteLensPlan` (pur) : `FetchStrategy` (fullBounded / headRange / randomAccess / skip) selon la taille, `clampedRange` bornée à EOF (anti-416), formatage EXIF (pose, ouverture, focale, ISO, GPS + signe hémisphère).
- `RemoteRangeReader` + `RangeByteSource` : lecture partielle sur **une** session loopback range-capable (`RcloneStreamingService.liveSession`), fabriques `.loopback` (HEAD + `Range: bytes=`, porte le patron éprouvé de `RcloneFileProvider.swift`) et `.inMemory` (tests).

Tests : 11 nouveaux (Swift Testing, zéro réseau). Suite complète : **200 passed / 0 failed**. Build Release iOS **et** macOS : SUCCEEDED.