### PR TITLE
feat(lens): aperçu PDF — 1re page par CGDataProvider random-access (RG-17)

### DIFF
--- a/Rclone GUI/Services/RemoteLensService.swift
+++ b/Rclone GUI/Services/RemoteLensService.swift
@@ -115,15 +115,12 @@ public actor RemoteLensService {
 
         let result: RemoteLensPreview?
         if MediaFormat.isPDF(entry.name) {
-            // Chemin PDF branché en PR3 (RemoteRangePDFProvider).
-            result = RemoteLensPreview(kind: .pdf, pdf: RemotePDFMetadata(
-                pageCount: nil, title: nil, author: nil, firstPageAvailable: false
-            ))
+            result = await Self.buildPDFPreview(remote: remote, entry: entry)
         } else {
             result = await Self.buildImagePreview(remote: remote, entry: entry)
         }
 
-        if let result, result.thumbnail != nil || result.image != nil {
+        if let result, result.thumbnail != nil || result.image != nil || result.pdf != nil {
             store(result, key: key)
         }
         return result
@@ -183,6 +180,40 @@ public actor RemoteLensService {
 
         // withSession renvoie nil si le bridge est indisponible.
         return built ?? RemoteLensPreview(kind: .image,
+                                          note: String(localized: "Aperçu indisponible (pont hors ligne)."))
+    }
+
+    // MARK: - PDF (hors acteur)
+
+    nonisolated static func buildPDFPreview(remote: String, entry: RemoteEntryDTO) async -> RemoteLensPreview? {
+        let built: RemoteLensPreview? = await RemoteRangeReader.withSession(
+            remote: remote, path: entry.pathInRemote
+        ) { source in
+            let total = await source.size() ?? entry.size
+            guard total > 0 else {
+                return RemoteLensPreview(kind: .pdf,
+                                         note: String(localized: "Aperçu indisponible."))
+            }
+            guard let render = await RemoteRangePDFProvider.render(source: source, totalSize: total) else {
+                return RemoteLensPreview(
+                    kind: .pdf,
+                    pdf: RemotePDFMetadata(pageCount: nil, title: nil, author: nil, firstPageAvailable: false),
+                    note: String(localized: "Aperçu PDF indisponible.")
+                )
+            }
+            let box = render.firstPage
+            persistThumbnail(box, remote: remote, entry: entry)
+            return RemoteLensPreview(
+                kind: .pdf,
+                thumbnail: box,
+                pdf: RemotePDFMetadata(
+                    pageCount: render.pageCount, title: nil, author: nil,
+                    firstPageAvailable: box != nil
+                ),
+                note: box == nil ? String(localized: "Première page non rendue.") : nil
+            )
+        }
+        return built ?? RemoteLensPreview(kind: .pdf,
                                           note: String(localized: "Aperçu indisponible (pont hors ligne)."))
     }
 

--- a/Rclone GUI/Services/RemoteRangePDFProvider.swift
+++ b/Rclone GUI/Services/RemoteRangePDFProvider.swift
@@ -1,0 +1,188 @@
+//
+//  RemoteRangePDFProvider.swift
+//  Rclone GUI — Services
+//
+//  Rendu de la 1re page d'un PDF distant SANS le télécharger en entier.
+//  CoreGraphics lit un PDF via un `CGDataProvider` à accès aléatoire : son
+//  callback `getBytesAtPosition` demande des plages arbitraires (la table xref
+//  est en fin de fichier, puis les objets de la 1re page). On adosse ce
+//  callback à une `RangeByteSource` (bridge loopback range) → CG ne lit que le
+//  xref + la 1re page, quelle que soit la taille du PDF.
+//
+//  Contrainte : le callback CG est SYNCHRONE alors que les lectures range sont
+//  async. On exécute donc tout le rendu sur un thread OS dédié (jamais le main
+//  ni le pool coopératif) et on attend chaque plage via un DispatchSemaphore
+//  (URLSession complète sur ses propres threads → pas de deadlock). Un plafond
+//  d'octets distincts protège contre un PDF pathologique qui forcerait la
+//  lecture de tout le fichier.
+//
+
+import Foundation
+import CoreGraphics
+
+public struct PDFRenderResult: Sendable {
+    public let pageCount: Int
+    public let firstPage: CGImageBox?
+}
+
+/// Lecteur adossé à une `RangeByteSource`, exposé à CoreGraphics via un
+/// `CGDataProvider` direct. Manipulé séquentiellement sur le thread de rendu
+/// dédié → `@unchecked Sendable` assumé.
+nonisolated final class RangeBackedPDFReader: @unchecked Sendable {
+    let source: RangeByteSource
+    let totalSize: Int64
+    let blockSize: Int64
+    let maxBytes: Int64
+    private var blocks: [Int64: Data] = [:]
+    private var distinctBytesRead: Int64 = 0
+
+    init(source: RangeByteSource, totalSize: Int64, maxBytes: Int64, blockSize: Int64 = 64 * 1024) {
+        self.source = source
+        self.totalSize = totalSize
+        self.maxBytes = maxBytes
+        self.blockSize = blockSize
+    }
+
+    /// Sert `count` octets à partir de `position` depuis les blocs (lus à la
+    /// demande, alignés, cachés). Renvoie le nombre d'octets réellement copiés.
+    func getBytes(at position: off_t, count: Int, into buffer: UnsafeMutableRawPointer) -> Int {
+        let pos = Int64(position)
+        guard pos >= 0, pos < totalSize, count > 0 else { return 0 }
+        let end = min(pos + Int64(count), totalSize)
+        var written = 0
+        var cursor = pos
+        while cursor < end {
+            let blockIndex = cursor / blockSize
+            guard let block = ensureBlock(blockIndex) else { break }
+            let blockStart = blockIndex * blockSize
+            let offsetInBlock = Int(cursor - blockStart)
+            if offsetInBlock >= block.count { break }
+            let avail = block.count - offsetInBlock
+            let need = Int(min(end - cursor, Int64(avail)))
+            if need <= 0 { break }
+            block.withUnsafeBytes { raw in
+                if let base = raw.baseAddress {
+                    memcpy(buffer.advanced(by: written), base.advanced(by: offsetInBlock), need)
+                }
+            }
+            written += need
+            cursor += Int64(need)
+        }
+        return written
+    }
+
+    private func ensureBlock(_ index: Int64) -> Data? {
+        if let cached = blocks[index] { return cached }
+        let start = index * blockSize
+        guard start >= 0, start < totalSize else { return nil }
+        if distinctBytesRead >= maxBytes { return nil }   // plafond anti lecture-totale
+        let endInclusive = min(start + blockSize - 1, totalSize - 1)
+        guard let data = readSync(start...endInclusive) else { return nil }
+        blocks[index] = data
+        distinctBytesRead += Int64(data.count)
+        return data
+    }
+
+    /// Pont synchrone → async : lit une plage en bloquant le thread dédié.
+    private func readSync(_ range: ClosedRange<Int64>) -> Data? {
+        let semaphore = DispatchSemaphore(value: 0)
+        let box = ByteResultBox()
+        let src = source
+        Task.detached {
+            box.data = await src.read(range)
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return box.data
+    }
+}
+
+/// Transporte le résultat d'une lecture async vers le thread synchrone.
+private final class ByteResultBox: @unchecked Sendable {
+    var data: Data?
+}
+
+public nonisolated enum RemoteRangePDFProvider {
+
+    /// Plafond d'octets DISTINCTS lus avant abandon (PDF pathologique).
+    public static let maxDistinctBytes: Int64 = 16 * 1024 * 1024
+
+    /// Rend la 1re page + compte les pages en lisant par plages. nil si le PDF
+    /// est illisible ou la taille inconnue.
+    public static func render(source: RangeByteSource, totalSize: Int64, maxPixel: Int = 400) async -> PDFRenderResult? {
+        guard totalSize > 0 else { return nil }
+        return await withCheckedContinuation { (continuation: CheckedContinuation<PDFRenderResult?, Never>) in
+            let thread = Thread {
+                let result = renderSync(source: source, totalSize: totalSize, maxPixel: maxPixel)
+                continuation.resume(returning: result)
+            }
+            thread.name = "RemoteLens.PDF"
+            thread.stackSize = 4 << 20
+            thread.start()
+        }
+    }
+
+    private static func renderSync(source: RangeByteSource, totalSize: Int64, maxPixel: Int) -> PDFRenderResult? {
+        autoreleasepool {
+            let reader = RangeBackedPDFReader(source: source, totalSize: totalSize, maxBytes: maxDistinctBytes)
+            let info = Unmanaged.passRetained(reader).toOpaque()
+            var callbacks = CGDataProviderDirectCallbacks(
+                version: 0,
+                getBytePointer: nil,
+                releaseBytePointer: nil,
+                getBytesAtPosition: { info, buffer, position, count in
+                    guard let info else { return 0 }
+                    let reader = Unmanaged<RangeBackedPDFReader>.fromOpaque(info).takeUnretainedValue()
+                    return reader.getBytes(at: position, count: count, into: buffer)
+                },
+                releaseInfo: { info in
+                    guard let info else { return }
+                    Unmanaged<RangeBackedPDFReader>.fromOpaque(info).release()
+                }
+            )
+            guard let provider = CGDataProvider(directInfo: info, size: off_t(totalSize), callbacks: &callbacks) else {
+                // Provider non créé → releaseInfo ne sera pas appelé : on libère ici.
+                Unmanaged<RangeBackedPDFReader>.fromOpaque(info).release()
+                return nil
+            }
+            guard let document = CGPDFDocument(provider) else { return nil }
+            let count = document.numberOfPages
+            guard count > 0 else { return PDFRenderResult(pageCount: 0, firstPage: nil) }
+            let firstImage = document.page(at: 1).flatMap { renderFirstPage($0, maxPixel: maxPixel) }
+            return PDFRenderResult(pageCount: count, firstPage: firstImage.map { CGImageBox(image: $0) })
+        }
+    }
+
+    private static func renderFirstPage(_ page: CGPDFPage, maxPixel: Int) -> CGImage? {
+        let cropBox = page.getBoxRect(.cropBox)
+        let usesCrop = !cropBox.isEmpty
+        let rect = usesCrop ? cropBox : page.getBoxRect(.mediaBox)
+        guard rect.width > 0, rect.height > 0 else { return nil }
+
+        let scale = min(CGFloat(maxPixel) / rect.width, CGFloat(maxPixel) / rect.height)
+        let width = max(1, Int((rect.width * scale).rounded()))
+        let height = max(1, Int((rect.height * scale).rounded()))
+
+        let space = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(
+            data: nil, width: width, height: height, bitsPerComponent: 8,
+            bytesPerRow: 0, space: space,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        // Fond blanc (les PDF ont un fond transparent par défaut).
+        ctx.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        // getDrawingTransform mappe la box source vers notre rect cible (échelle
+        // + rotation intégrées, ratio préservé).
+        let transform = page.getDrawingTransform(
+            usesCrop ? .cropBox : .mediaBox,
+            rect: CGRect(x: 0, y: 0, width: width, height: height),
+            rotate: 0, preserveAspectRatio: true
+        )
+        ctx.concatenate(transform)
+        ctx.drawPDFPage(page)
+        return ctx.makeImage()
+    }
+}

--- a/Rclone GUI/Services/ThumbnailService.swift
+++ b/Rclone GUI/Services/ThumbnailService.swift
@@ -84,8 +84,10 @@ public actor ThumbnailService {
     private let memLimit = 300
 
     /// Vignette pour une entrée média. nil ⇒ afficher l'icône de repli.
+    /// Couvre images, vidéos ET PDF (1re page via Remote Lens) — tous partagent
+    /// le même cache mémoire/disque.
     public func thumbnail(for entry: RemoteEntryDTO, remote: String) async -> CGImageBox? {
-        guard MediaFormat.isVisualMedia(entry.name) else { return nil }
+        guard MediaFormat.isVisualMedia(entry.name) || MediaFormat.isPDF(entry.name) else { return nil }
         let key = Self.cacheKey(remote: remote, entry: entry)
 
         if let cached = memCache[key] { return cached }
@@ -153,7 +155,26 @@ public actor ThumbnailService {
         if MediaFormat.isVideo(entry.name) {
             return await generateVideoThumbnail(remote: remote, entry: entry)
         }
+        if MediaFormat.isPDF(entry.name) {
+            return await generatePDFThumbnail(remote: remote, entry: entry)
+        }
         return nil
+    }
+
+    /// Vignette = 1re page du PDF, rendue par plages (RemoteRangePDFProvider),
+    /// sans télécharger tout le fichier.
+    nonisolated static func generatePDFThumbnail(remote: String, entry: RemoteEntryDTO) async -> CGImageBox? {
+        let box: CGImageBox?? = await RemoteRangeReader.withSession(
+            remote: remote, path: entry.pathInRemote
+        ) { source in
+            let total = await source.size() ?? entry.size
+            guard total > 0,
+                  let render = await RemoteRangePDFProvider.render(
+                      source: source, totalSize: total, maxPixel: maxPixel
+                  ) else { return CGImageBox?.none }
+            return render.firstPage
+        }
+        return box ?? nil
     }
 
     nonisolated static func generateImageThumbnail(remote: String, entry: RemoteEntryDTO) async -> CGImageBox? {

--- a/Rclone GUITests/RemoteRangePDFTests.swift
+++ b/Rclone GUITests/RemoteRangePDFTests.swift
@@ -1,0 +1,94 @@
+//
+//  RemoteRangePDFTests.swift
+//  Rclone GUITests
+//
+//  Rendu PDF par accès aléatoire (RemoteRangePDFProvider) sans réseau : on
+//  génère un PDF multi-pages en mémoire, on l'expose via une RangeByteSource
+//  mémoire (éventuellement instrumentée pour compter les lectures par plage),
+//  et on vérifie le compte de pages + le rendu de la 1re page.
+//
+
+import Testing
+import Foundation
+import CoreGraphics
+@testable import Rclone_GUI
+
+private func makeTestPDF(pages: Int, width: CGFloat = 200, height: CGFloat = 300) -> Data? {
+    let data = NSMutableData()
+    guard let consumer = CGDataConsumer(data: data as CFMutableData) else { return nil }
+    var mediaBox = CGRect(x: 0, y: 0, width: width, height: height)
+    guard let ctx = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else { return nil }
+    for i in 0..<pages {
+        ctx.beginPDFPage(nil)
+        ctx.setFillColor(CGColor(red: CGFloat(i) / CGFloat(max(pages, 1)),
+                                 green: 0.4, blue: 0.6, alpha: 1))
+        ctx.fill(mediaBox)
+        ctx.endPDFPage()
+    }
+    ctx.closePDF()
+    return data as Data
+}
+
+/// Compteur thread-safe de lectures (les reads viennent de Task.detached).
+private final class ReadCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    func bump() { lock.lock(); value += 1; lock.unlock() }
+    var count: Int { lock.lock(); defer { lock.unlock() }; return value }
+}
+
+@Suite("RemoteRangePDFProvider — rendu par plages")
+struct RemoteRangePDFTests {
+
+    @Test("Compte les pages et rend la 1re page, downsamplée")
+    func rendersFirstPage() async throws {
+        let pdf = try #require(makeTestPDF(pages: 3))
+        let source = RangeByteSource.inMemory(pdf)
+
+        let result = try #require(
+            await RemoteRangePDFProvider.render(source: source, totalSize: Int64(pdf.count))
+        )
+        #expect(result.pageCount == 3)
+        let page = try #require(result.firstPage)
+        #expect(page.image.width > 0)
+        #expect(page.image.height > 0)
+        #expect(page.image.width <= 400)
+        #expect(page.image.height <= 400)
+    }
+
+    @Test("Lit bien via la RangeByteSource (accès par plages, pas un pull unique)")
+    func readsThroughRangeSource() async throws {
+        let pdf = try #require(makeTestPDF(pages: 2))
+        let base = RangeByteSource.inMemory(pdf)
+        let counter = ReadCounter()
+        let instrumented = RangeByteSource(
+            size: { await base.size() },
+            read: { range in
+                counter.bump()
+                return await base.read(range)
+            }
+        )
+
+        let result = await RemoteRangePDFProvider.render(
+            source: instrumented, totalSize: Int64(pdf.count)
+        )
+        #expect(result?.pageCount == 2)
+        // CoreGraphics a demandé au moins une plage via notre source.
+        #expect(counter.count >= 1)
+    }
+
+    @Test("Octets non-PDF → pas de document (nil ou sans 1re page)")
+    func garbageIsRejected() async {
+        let junk = Data(repeating: 0x25, count: 800)   // « %%%… » : pas un vrai PDF
+        let result = await RemoteRangePDFProvider.render(
+            source: .inMemory(junk), totalSize: 800
+        )
+        #expect(result == nil || result?.firstPage == nil)
+    }
+
+    @Test("Taille nulle → nil")
+    func zeroSize() async {
+        let result = await RemoteRangePDFProvider.render(source: .inMemory(Data()), totalSize: 0)
+        #expect(result == nil)
+    }
+}


### PR DESCRIPTION
PR 3/4 de **Remote Lens** (RG-17). Le morceau le plus technique : rendre la **1re page d'un PDF distant sans le télécharger**.

CoreGraphics lit le PDF via un `CGDataProvider` à **accès aléatoire** dont le callback `getBytesAtPosition` est adossé à une `RangeByteSource` (bridge loopback range). CG ne demande que le **xref** (fin de fichier) + les objets de la 1re page → lecture partielle quelle que soit la taille.

- **`RemoteRangePDFProvider`** : reader adossé à `RangeByteSource` (blocs 64 Ko cachés, plafond 16 Mo distincts anti PDF-pathologique). Le callback CG est **synchrone** alors que les reads sont **async** → tout le rendu tourne sur un **thread OS dédié** qui attend chaque plage via `DispatchSemaphore` (jamais le main ni le pool coopératif ; URLSession complète sur ses threads → pas de deadlock). Rendu 1re page cross-platform (`CGContext`, fond blanc, `getDrawingTransform`), downsamplé 400 px.
- **`RemoteLensService.buildPDFPreview`** : `pageCount` + 1re page (remplace le stub PR2), cache partagé.
- **`ThumbnailService`** : branche PDF (guard élargi + `generatePDFThumbnail`) → les 1res pages PDF transitent par le **même** cache LRU/disque que les vignettes image/vidéo.

Tests : 4 nouveaux (PDF généré **en mémoire** → `pageCount` + rendu 1re page ; source **instrumentée** prouvant l'accès par plages ; rejet d'octets non-PDF ; taille nulle). Suite : **209 passed / 0 failed**. Build Release iOS **et** macOS : SUCCEEDED.