### PR TITLE
feat(lens): UI Remote Lens — feuille Aperçu + écran détail enrichi (RG-17)

### DIFF
--- a/Rclone GUI/Views/Files/FileDetailView.swift
+++ b/Rclone GUI/Views/Files/FileDetailView.swift
@@ -23,10 +23,15 @@ struct FileDetailView: View {
     var onShare: (() -> Void)? = nil
     var onPin: (() -> Void)? = nil
 
+    /// Aperçu Remote Lens (vignette réelle + EXIF/PDF), chargé à l'ouverture
+    /// pour les fichiers éligibles (images, PDF) par range requests.
+    @State private var lensPreview: RemoteLensPreview?
+
     var body: some View {
         Form {
             Section {
                 heroPreview
+                    .overlay { lensThumbnailOverlay }
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     .listRowBackground(Color.clear)
             }
@@ -48,6 +53,13 @@ struct FileDetailView: View {
                 infoRow(title: "Taille", value: sizeLabel)
                 infoRow(title: "Modifié", value: dateLabel)
                 infoRow(title: "Chemin", value: entry.pathInRemote.isEmpty ? "—" : entry.pathInRemote)
+            }
+
+            if let image = lensPreview?.image, !image.isEmpty {
+                lensImageSection(image)
+            }
+            if let pdf = lensPreview?.pdf, pdf.pageCount != nil {
+                lensPDFSection(pdf)
             }
 
             Section("Sécurité") {
@@ -105,7 +117,62 @@ struct FileDetailView: View {
                 }
             }
         }
+        .task(id: entry.id) {
+            guard MediaFormat.hasLens(entry.name) else { return }
+            lensPreview = await RemoteLensService.shared.preview(for: entry, remote: remote)
+        }
     }
+
+    // MARK: - Remote Lens
+
+    @ViewBuilder
+    private var lensThumbnailOverlay: some View {
+        if let box = lensPreview?.thumbnail {
+            RemoteLensImage(cgImage: box.image)
+                .scaledToFill()
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .allowsHitTesting(false)
+        }
+    }
+
+    private func lensImageSection(_ m: RemoteImageMetadata) -> some View {
+        Section("Informations média") {
+            if let w = m.pixelWidth, let h = m.pixelHeight {
+                infoRow(title: "Dimensions", value: "\(w) × \(h) px")
+            }
+            if let make = m.cameraMake, let model = m.cameraModel {
+                infoRow(title: "Appareil", value: "\(make) \(model)")
+            } else if let model = m.cameraModel {
+                infoRow(title: "Appareil", value: model)
+            }
+            if let lens = m.lensModel { infoRow(title: "Objectif", value: lens) }
+            if let date = m.captureDate {
+                infoRow(title: "Prise le", value: Self.mediaDateFormatter.string(from: date))
+            }
+            if let exp = m.exposure { infoRow(title: "Exposition", value: exp) }
+            if let f = m.fNumber { infoRow(title: "Ouverture", value: f) }
+            if let iso = m.iso { infoRow(title: "Sensibilité", value: iso) }
+            if let focal = m.focalLength { infoRow(title: "Focale", value: focal) }
+            if let lat = m.latitude, let lon = m.longitude {
+                infoRow(title: "Position", value: RemoteLensPlan.formatCoordinate(lat: lat, lon: lon))
+            }
+        }
+    }
+
+    private func lensPDFSection(_ m: RemotePDFMetadata) -> some View {
+        Section("Informations média") {
+            if let count = m.pageCount { infoRow(title: "Pages", value: "\(count)") }
+            if let title = m.title { infoRow(title: "Titre", value: title) }
+            if let author = m.author { infoRow(title: "Auteur", value: author) }
+        }
+    }
+
+    private static let mediaDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f
+    }()
 
     private var heroPreview: some View {
         ZStack {

--- a/Rclone GUI/Views/Files/RemoteLensSheet.swift
+++ b/Rclone GUI/Views/Files/RemoteLensSheet.swift
@@ -1,0 +1,165 @@
+//
+//  RemoteLensSheet.swift
+//  Rclone GUI — Views/Files
+//
+//  Feuille d'aperçu « Remote Lens » : vignette / 1re page en tête, puis les
+//  métadonnées (EXIF pour les images, pages pour les PDF), obtenues en lisant
+//  seulement les octets nécessaires (RemoteLensService, range requests).
+//
+
+import SwiftUI
+import CoreGraphics
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+struct RemoteLensSheet: View {
+    let remote: String
+    let entry: RemoteEntryDTO
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var preview: RemoteLensPreview?
+    @State private var isLoading = true
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading {
+                    ProgressView("Analyse de l'aperçu…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let preview {
+                    content(preview)
+                } else {
+                    ContentUnavailableView(
+                        "Aperçu indisponible",
+                        systemImage: "eye.slash",
+                        description: Text("Impossible de lire un aperçu de ce fichier.")
+                    )
+                }
+            }
+            .navigationTitle(entry.name)
+            .rgInlineNavTitle()
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("OK") { dismiss() }
+                }
+            }
+        }
+        .task(id: entry.id) {
+            isLoading = true
+            preview = await RemoteLensService.shared.preview(for: entry, remote: remote)
+            isLoading = false
+        }
+    }
+
+    @ViewBuilder
+    private func content(_ preview: RemoteLensPreview) -> some View {
+        Form {
+            Section {
+                thumbnail(preview)
+                    .frame(maxWidth: .infinity)
+                    .listRowBackground(Color.clear)
+            }
+
+            if let note = preview.note {
+                Section {
+                    Label(note, systemImage: "info.circle")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let image = preview.image, !image.isEmpty {
+                imageMetadataSection(image)
+            }
+            if let pdf = preview.pdf {
+                pdfMetadataSection(pdf)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func thumbnail(_ preview: RemoteLensPreview) -> some View {
+        if let box = preview.thumbnail {
+            RemoteLensImage(cgImage: box.image)
+                .scaledToFit()
+                .frame(maxHeight: 280)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .padding(.vertical, 4)
+        } else {
+            Image(systemName: preview.kind == .pdf ? "doc.richtext" : "photo")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+                .frame(height: 160)
+        }
+    }
+
+    private func imageMetadataSection(_ m: RemoteImageMetadata) -> some View {
+        Section("Informations image") {
+            if let w = m.pixelWidth, let h = m.pixelHeight {
+                row("Dimensions", "\(w) × \(h) px")
+            }
+            if let make = m.cameraMake, let model = m.cameraModel {
+                row("Appareil", "\(make) \(model)")
+            } else if let model = m.cameraModel {
+                row("Appareil", model)
+            }
+            if let lens = m.lensModel { row("Objectif", lens) }
+            if let date = m.captureDate { row("Prise le", Self.dateFormatter.string(from: date)) }
+            if let exp = m.exposure { row("Exposition", exp) }
+            if let f = m.fNumber { row("Ouverture", f) }
+            if let iso = m.iso { row("Sensibilité", iso) }
+            if let focal = m.focalLength { row("Focale", focal) }
+            if let lat = m.latitude, let lon = m.longitude {
+                row("Position", RemoteLensPlan.formatCoordinate(lat: lat, lon: lon))
+            }
+        }
+    }
+
+    private func pdfMetadataSection(_ m: RemotePDFMetadata) -> some View {
+        Section("Informations PDF") {
+            if let count = m.pageCount {
+                row("Pages", "\(count)")
+            }
+            if let title = m.title { row("Titre", title) }
+            if let author = m.author { row("Auteur", author) }
+        }
+    }
+
+    private func row(_ title: LocalizedStringKey, _ value: String) -> some View {
+        HStack {
+            Text(title).foregroundStyle(.primary)
+            Spacer(minLength: 8)
+            Text(value)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f
+    }()
+}
+
+/// Image cross-platform depuis un CGImage (UIImage / NSImage).
+struct RemoteLensImage: View {
+    let cgImage: CGImage
+
+    var body: some View {
+        #if canImport(UIKit)
+        Image(uiImage: UIImage(cgImage: cgImage))
+            .resizable()
+        #elseif canImport(AppKit)
+        Image(nsImage: NSImage(cgImage: cgImage, size: CGSize(width: cgImage.width, height: cgImage.height)))
+            .resizable()
+        #else
+        Image(systemName: "photo").resizable()
+        #endif
+    }
+}

--- a/Rclone GUI/Views/Folders/EntryActionsMenu.swift
+++ b/Rclone GUI/Views/Folders/EntryActionsMenu.swift
@@ -32,6 +32,7 @@ struct EntryActionsMenu: View {
     @Binding var moveTarget: RemoteEntryDTO?
     @Binding var downloadTarget: RemoteEntryDTO?
     @Binding var externalOpenTarget: RemoteEntryDTO?
+    @Binding var lensTarget: RemoteEntryDTO?
 
     var body: some View {
         Group {
@@ -45,6 +46,16 @@ struct EntryActionsMenu: View {
                 } label: {
                     Label(Self.isMediaFile(entry.name) ? "Lire dans l'app" : "Ouvrir dans l'app",
                           systemImage: Self.isMediaFile(entry.name) ? "play.circle" : "doc.viewfinder")
+                }
+
+                // Aperçu « Remote Lens » : vignette + EXIF / 1re page PDF, lus
+                // par range requests sans télécharger tout le fichier.
+                if MediaFormat.hasLens(entry.name) {
+                    Button {
+                        lensTarget = entry
+                    } label: {
+                        Label("Aperçu", systemImage: "eye")
+                    }
                 }
 
                 Button {

--- a/Rclone GUI/Views/Folders/FolderView.swift
+++ b/Rclone GUI/Views/Folders/FolderView.swift
@@ -32,6 +32,7 @@ struct FolderView: View {
     @State private var externalOpenTarget: RemoteEntryDTO?
     @State private var moveTarget: RemoteEntryDTO?
     @State private var downloadTarget: RemoteEntryDTO?
+    @State private var lensTarget: RemoteEntryDTO?
     @State private var remoteTransferRequest: RemoteBatchTransferRequest?
     @State private var availableRemotes: [String] = []
     @State private var deleteIsRecursive = false
@@ -296,6 +297,10 @@ struct FolderView: View {
                 openingEntryID = nil
             }) { entry in
                 RemotePreviewHost(remote: remote, entry: entry)
+            }
+            .sheet(item: $lensTarget) { entry in
+                RemoteLensSheet(remote: remote, entry: entry)
+                    .rgMediumDetents()
             }
             .sheet(item: $externalOpenTarget, onDismiss: {
                 openingEntryID = nil
@@ -607,7 +612,8 @@ struct FolderView: View {
                     previewTarget: $previewTarget,
                     moveTarget: $moveTarget,
                     downloadTarget: $downloadTarget,
-                    externalOpenTarget: $externalOpenTarget
+                    externalOpenTarget: $externalOpenTarget,
+                    lensTarget: $lensTarget
                 )
             }
         }
@@ -652,7 +658,8 @@ struct FolderView: View {
                         previewTarget: $previewTarget,
                         moveTarget: $moveTarget,
                         downloadTarget: $downloadTarget,
-                        externalOpenTarget: $externalOpenTarget
+                        externalOpenTarget: $externalOpenTarget,
+                        lensTarget: $lensTarget
                     )
                 }
             }
@@ -687,7 +694,8 @@ struct FolderView: View {
                     previewTarget: $previewTarget,
                     moveTarget: $moveTarget,
                     downloadTarget: $downloadTarget,
-                    externalOpenTarget: $externalOpenTarget
+                    externalOpenTarget: $externalOpenTarget,
+                    lensTarget: $lensTarget
                 )
             }
         }

--- a/Rclone GUI/Views/Settings/RoadmapView.swift
+++ b/Rclone GUI/Views/Settings/RoadmapView.swift
@@ -20,6 +20,7 @@ struct RoadmapView: View {
         let id = UUID()
         let name: LocalizedStringKey
         let date: String   // locale-neutral, e.g. "07/2026", "Q1 2027"
+        var done: Bool = false
     }
 
     var body: some View {
@@ -38,7 +39,7 @@ struct RoadmapView: View {
                 Item(name: "Glass Engine", date: "09/2026"),
             ])
             horizon(label: "Moyen terme", window: "10–12 / 2026", tint: .blue, items: [
-                Item(name: "Remote Lens", date: "10/2026"),
+                Item(name: "Remote Lens", date: "10/2026", done: true),
                 Item(name: "Sealed Share", date: "10/2026"),
                 Item(name: "Recherche sémantique on-device", date: "11/2026"),
                 Item(name: "Règles de sync", date: "11/2026"),
@@ -73,12 +74,19 @@ struct RoadmapView: View {
         Section {
             ForEach(items) { it in
                 HStack(spacing: 10) {
-                    Text(it.name).font(.callout)
+                    if it.done {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    }
+                    Text(it.name)
+                        .font(.callout)
+                        .foregroundStyle(it.done ? .secondary : .primary)
                     Spacer(minLength: 8)
-                    Text(it.date)
+                    Text(it.done ? String(localized: "Livré") : it.date)
                         .font(.caption.weight(.semibold))
                         .monospacedDigit()
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(it.done ? .green : .secondary)
                 }
             }
         } header: {

--- a/Rclone GUI/Views/Shared/PlatformModifiers.swift
+++ b/Rclone GUI/Views/Shared/PlatformModifiers.swift
@@ -44,6 +44,18 @@ extension View {
         #endif
     }
 
+    /// `presentationDetents([.medium, .large])` on iOS, no-op on macOS (modal
+    /// windows have no detents). Never call `.presentationDetents` unguarded —
+    /// it is iOS-only and breaks the macOS build.
+    @ViewBuilder
+    func rgMediumDetents() -> some View {
+        #if os(iOS)
+        self.presentationDetents([.medium, .large])
+        #else
+        self
+        #endif
+    }
+
     /// `fullScreenCover(item:)` on iOS (unavailable on macOS); falls back to a
     /// `sheet(item:)` on macOS, where modal windows are the native equivalent.
     @ViewBuilder


### PR DESCRIPTION
PR 4/4 de **Remote Lens** (RG-17) — la couche UI qui clôt la feature.

- **`RemoteLensSheet`** : feuille compacte (vignette / 1re page en tête + métadonnées EXIF ou PDF), chargée via `RemoteLensService`, repli `ContentUnavailableView`. `RemoteLensImage` = image cross-platform (UIImage/NSImage).
- **`EntryActionsMenu`** : item **« Aperçu »** (icône œil) pour `MediaFormat.hasLens` (images + PDF), nouveau binding `lensTarget` câblé aux 3 call sites.
- **`FolderView`** : `@State lensTarget` + `.sheet(item:)` avec `rgMediumDetents`. Le tap par défaut reste inchangé (l'aperçu est un « peek » explicite).
- **`FileDetailView`** : le hero affiche la **vraie vignette / 1re page** (overlay) + nouvelle section **« Informations média »** (EXIF ou pages PDF), chargées dans un `.task`.
- **`PlatformModifiers`** : `rgMediumDetents()` (detents iOS, no-op macOS — jamais `.presentationDetents` non gardé).
- **`RoadmapView`** : « Remote Lens » marqué **livré** (checkmark).

Vues exclues de la couverture unitaire (règle projet) ; la logique est couverte par les 20 tests des PR1-3. Suite : **209 passed / 0 failed**. Build Release iOS **et macOS** : SUCCEEDED (la feuille cross-platform compile sur les deux).