### PR TITLE
fix(folders): la suppression / mise à la corbeille ne partait jamais

### DIFF
--- a/Rclone GUI/Views/Folders/FolderView.swift
+++ b/Rclone GUI/Views/Folders/FolderView.swift
@@ -386,21 +386,20 @@ struct FolderView: View {
                     get: { deleteTarget != nil },
                     set: { if !$0 { deleteTarget = nil } }
                 ),
-                titleVisibility: .visible
-            ) {
+                titleVisibility: .visible,
+                presenting: deleteTarget
+            ) { target in
                 Button("Mettre à la corbeille") {
-                    Task { await performDelete(permanent: false) }
+                    Task { await performDelete(target, permanent: false) }
                 }
                 Button("Supprimer définitivement", role: .destructive) {
-                    Task { await performDelete(permanent: true) }
+                    Task { await performDelete(target, permanent: true) }
                 }
                 Button("Annuler", role: .cancel) { deleteTarget = nil }
-            } message: {
-                if let target = deleteTarget {
-                    Text(target.isDirectory
-                         ? "Le dossier et tout son contenu peuvent être restaurés depuis la corbeille pendant 30 jours, ou supprimés définitivement."
-                         : "Le fichier peut être restauré depuis la corbeille pendant 30 jours, ou supprimé définitivement.")
-                }
+            } message: { target in
+                Text(target.isDirectory
+                     ? "Le dossier et tout son contenu peuvent être restaurés depuis la corbeille pendant 30 jours, ou supprimés définitivement."
+                     : "Le fichier peut être restauré depuis la corbeille pendant 30 jours, ou supprimé définitivement.")
             }
             .alert("Info", isPresented: Binding(
                 get: { transientMessage != nil },
@@ -447,8 +446,12 @@ struct FolderView: View {
         deleteTarget.map { "Supprimer « \($0.name) » ?" } ?? "Supprimer ?"
     }
 
-    private func performDelete(permanent: Bool) async {
-        guard let target = deleteTarget else { return }
+    /// La cible est passée en paramètre — surtout pas relue depuis `deleteTarget`.
+    /// SwiftUI ferme le dialog avant que le `Task` de l'action ne s'exécute, ce
+    /// qui déclenche le `set:` du binding `isPresented` et remet `deleteTarget`
+    /// à nil : un `guard let target = deleteTarget` échouait alors en silence et
+    /// la suppression ne partait jamais (aucun appel rclone, aucun log).
+    private func performDelete(_ target: RemoteEntryDTO, permanent: Bool) async {
         deleteTarget = nil
         do {
             if permanent {

--- a/Rclone GUITests/DestructiveDialogCaptureTests.swift
+++ b/Rclone GUITests/DestructiveDialogCaptureTests.swift
@@ -1,0 +1,118 @@
+//
+//  DestructiveDialogCaptureTests.swift
+//  Rclone GUITests
+//
+//  Garde-fou de non-régression pour le bug « Supprimer / Corbeille ne fait
+//  rien » remonté en 2.0 sur FolderView (aucune suppression, aucun log).
+//
+//  Cause : le closure d'action du `confirmationDialog` lançait un `Task` qui
+//  relisait la cible depuis le `@State private var deleteTarget`. SwiftUI ferme
+//  le dialog avant que ce `Task` ne s'exécute, ce qui déclenche le `set:` du
+//  binding `isPresented` (`deleteTarget = nil`) ; le `guard let target =
+//  deleteTarget` échouait alors en silence — pas d'appel rclone, pas de log,
+//  donc un bug invisible côté diagnostic.
+//
+//  L'invariant : dans un dialog destructif, la cible doit être CAPTURÉE au
+//  moment du tap (via `presenting:` ou un `if let` synchrone dans le closure du
+//  bouton) et passée en paramètre — jamais relue depuis l'état différé.
+//
+//  Ce test lit le source (via `#filePath`) car le défaut vit dans le câblage
+//  SwiftUI lui-même : aucun helper pur ne peut l'attraper, et les UI tests ne
+//  tournent pas dans cette infra.
+//
+
+import Foundation
+import Testing
+
+/// Racine du dépôt, déduite du chemin de ce fichier de test.
+private var repoRoot: URL {
+    URL(fileURLWithPath: #filePath)      // …/Rclone GUITests/DestructiveDialogCaptureTests.swift
+        .deletingLastPathComponent()     // …/Rclone GUITests
+        .deletingLastPathComponent()     // …/
+}
+
+/// Lit un source Swift **débarrassé de ses commentaires** : on veut vérifier le
+/// code, pas la prose. (Sans ça, un commentaire qui *décrit* le pattern fautif —
+/// comme celui qui documente ce correctif dans FolderView — ferait échouer le test.)
+private func source(_ relativePath: String) throws -> String {
+    let url = repoRoot.appending(path: relativePath)
+    let raw = try String(contentsOf: url, encoding: .utf8)
+    return stripComments(raw)
+}
+
+/// Retire les commentaires `//` de fin de ligne et les blocs `/* … */`.
+/// Volontairement simple : suffisant pour ces sources (pas de `//` en littéral).
+private func stripComments(_ source: String) -> String {
+    var out = ""
+    var inBlock = false
+    for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+        var text = String(line)
+        if inBlock {
+            guard let end = text.range(of: "*/") else { continue }
+            text = String(text[end.upperBound...])
+            inBlock = false
+        }
+        while let start = text.range(of: "/*") {
+            if let end = text.range(of: "*/", range: start.upperBound..<text.endIndex) {
+                text.replaceSubrange(start.lowerBound..<end.upperBound, with: "")
+            } else {
+                text = String(text[..<start.lowerBound])
+                inBlock = true
+                break
+            }
+        }
+        if let lineComment = text.range(of: "//") {
+            text = String(text[..<lineComment.lowerBound])
+        }
+        out += text + "\n"
+    }
+    return out
+}
+
+@Suite("Dialogs destructifs — capture de la cible")
+struct DestructiveDialogCaptureTests {
+
+    @Test("FolderView : le dialog de suppression passe sa cible via presenting:")
+    func folderViewUsesPresenting() throws {
+        let src = try source("Rclone GUI/Views/Folders/FolderView.swift")
+        #expect(src.contains("presenting: deleteTarget"),
+                "Le confirmationDialog de suppression doit utiliser `presenting: deleteTarget` pour capturer la cible au tap.")
+    }
+
+    @Test("FolderView : performDelete reçoit la cible, ne la relit pas depuis le @State")
+    func performDeleteTakesTargetAsParameter() throws {
+        let src = try source("Rclone GUI/Views/Folders/FolderView.swift")
+
+        // La régression exacte : la cible relue dans le corps async.
+        #expect(!src.contains("guard let target = deleteTarget"),
+                "performDelete ne doit pas relire `deleteTarget` — il est déjà nil quand le Task s'exécute.")
+
+        // La signature corrigée prend la cible en entrée.
+        #expect(src.contains("private func performDelete(_ target: RemoteEntryDTO, permanent: Bool) async"),
+                "performDelete doit recevoir la cible en paramètre.")
+
+        // Aucun appel ne doit repasser par la variante sans cible.
+        #expect(!src.contains("performDelete(permanent:"),
+                "Plus aucun appel ne doit s'appuyer sur l'état différé.")
+    }
+
+    @Test("Les écrans de suppression capturent tous leur cible avant le Task")
+    func allDestructiveScreensCaptureTarget() throws {
+        // Écrans du repo qui suppriment un élément désigné par un @State optionnel.
+        // Chacun doit soit utiliser `presenting:`, soit faire un `if let` synchrone
+        // dans le closure du bouton (pattern de TrashView).
+        let screens = [
+            "Rclone GUI/Views/Folders/FolderView.swift",
+            "Rclone GUI/Views/Files/FilesRootView.swift",
+            "Rclone GUI/Views/Settings/TrashView.swift",
+        ]
+
+        for path in screens {
+            let src = try source(path)
+            let capturesViaPresenting = src.contains("presenting:")
+            let capturesSynchronously = src.contains("if let entry = pending")
+            #expect(capturesViaPresenting || capturesSynchronously,
+                    "\(path) doit capturer la cible du dialog avant de lancer son Task.")
+        }
+    }
+}


### PR DESCRIPTION
## Symptôme

Remonté par un utilisateur en 2.0 : supprimer un dossier ne fait rien — ni via **Supprimer définitivement**, ni via **Mettre à la corbeille**. Le dossier reste présent et **aucune ligne n'apparaît dans les logs**.

## Cause

Le closure d'action du `confirmationDialog` de `FolderView` lançait un `Task` qui **relisait** la cible depuis le `@State deleteTarget` :

```swift
Button("Mettre à la corbeille") { Task { await performDelete(permanent: false) } }
...
guard let target = deleteTarget else { return }   // déjà nil
```

SwiftUI ferme le dialog avant que le `Task` ne s'exécute, ce qui déclenche le `set:` du binding `isPresented` (`deleteTarget = nil`). Le `guard` échouait donc **en silence** : aucun appel rclone, aucun log — d'où un bug invisible côté diagnostic, ce qui explique le « rien dans les logs » du rapport.

Chemins déjà corrects (non affectés) :
- **mode sélection multiple** → lit `selection`, que le dialog ne remet pas à nil ;
- **suppression de remote** (`FilesRootView`, `RemoteManagementView`) → `presenting:` ;
- **corbeille** (`TrashView`) → `if let` synchrone dans le closure du bouton.

`FolderView` était le seul écran à lire sa cible de façon différée.

## Correctif

Le dialog passe sa cible via `presenting:` et `performDelete(_:permanent:)` la reçoit en paramètre — alignement sur le pattern déjà en place dans le reste du repo.

## Tests

`DestructiveDialogCaptureTests` — garde-fou de non-régression vérifiant que les écrans destructifs **capturent** leur cible au tap plutôt que de la relire depuis un état différé.

Validé dans les deux sens :
- **rouge** sur le code d'origine (`folderViewUsesPresenting`, `performDeleteTakesTargetAsParameter`) ;
- **vert** après le correctif.

Suite complète : **212 passed, 0 failed, 0 skipped** (iOS 27.0, `-parallel-testing-enabled NO`).