### PR TITLE
fix(ui): listes coincées en boucle de layout récursive (crash iOS 26)

### DIFF
--- a/Rclone GUI/Views/Folders/EntryRowView.swift
+++ b/Rclone GUI/Views/Folders/EntryRowView.swift
@@ -54,9 +54,15 @@ struct EntryRowView: View {
                         .truncationMode(.middle)
                 }
 
-                if let active = activeTransfer {
-                    transferProgressLine(for: active)
-                } else {
+                // Hauteur de row CONSTANTE quel que soit l'état transfert :
+                // la ligne normale reste dans le layout (opacity 0) et la
+                // ligne transfert se superpose ; la barre de progression est
+                // en overlay hors flux (voir plus bas). Une hauteur de cellule
+                // qui bascule au fil des re-renders (@Query ~500 ms pendant un
+                // batch) fait osciller le self-sizing du UICollectionView de
+                // la List → « stuck in a recursive layout loop » (crash fatal
+                // du _UICollectionViewFeedbackLoopDebugger depuis iOS 18).
+                ZStack(alignment: .leading) {
                     HStack(spacing: 7) {
                         Text(secondaryLine)
                             .font(.caption)
@@ -65,6 +71,11 @@ struct EntryRowView: View {
                         if !entry.isDirectory {
                             AppStatusBadge(title: fileKindLabel, tint: iconColor)
                         }
+                    }
+                    .opacity(activeTransfer == nil ? 1 : 0)
+
+                    if let active = activeTransfer {
+                        transferCaptionLine(for: active)
                     }
                 }
             }
@@ -83,34 +94,28 @@ struct EntryRowView: View {
             }
         }
         .padding(.vertical, 6)
+        .overlay(alignment: .bottom) {
+            if let active = activeTransfer, active.bytesTotal > 0 {
+                ProgressView(
+                    value: progressValue(for: active),
+                    total: progressTotal(for: active)
+                )
+                .progressViewStyle(.linear)
+                .tint(transferColor(for: active.kind))
+            }
+        }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityText)
     }
 
-    @ViewBuilder
-    private func transferProgressLine(for transfer: Transfer) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 6) {
-                Image(systemName: transferIcon(for: transfer.kind))
-                    .foregroundStyle(transferColor(for: transfer.kind))
-                Text(transferLabel(for: transfer))
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(transferColor(for: transfer.kind))
-            }
-            if transfer.bytesTotal > 0 {
-                ProgressView(
-                    value: progressValue(for: transfer),
-                    total: progressTotal(for: transfer)
-                )
-                .progressViewStyle(.linear)
-                .tint(transferColor(for: transfer.kind))
-            } else {
-                ProgressView()
-                    .progressViewStyle(.linear)
-                    .tint(transferColor(for: transfer.kind))
-            }
+    private func transferCaptionLine(for transfer: Transfer) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: transferIcon(for: transfer.kind))
+            Text(transferLabel(for: transfer))
+                .lineLimit(1)
         }
-        .padding(.top, 2)
+        .font(.caption.weight(.medium))
+        .foregroundStyle(transferColor(for: transfer.kind))
     }
 
     private func transferIcon(for kind: TransferKind) -> String {

--- a/Rclone GUI/Views/Player/AudioMiniBar.swift
+++ b/Rclone GUI/Views/Player/AudioMiniBar.swift
@@ -65,12 +65,14 @@ struct AudioMiniBar: View {
     var body: some View {
         if audio.isActive {
             VStack(spacing: 0) {
-                GeometryReader { geo in
-                    ZStack(alignment: .leading) {
-                        Rectangle().fill(.quaternary)
-                        Rectangle().fill(RG.accent)
-                            .frame(width: geo.size.width * progress)
-                    }
+                // Pas de GeometryReader dans un safeAreaInset : la barre est
+                // re-rendue chaque seconde (tick elapsed/duration) et une
+                // mesure → état au-dessus d'une List self-sizing peut nourrir
+                // une boucle de layout. scaleEffect n'influence pas le layout.
+                ZStack(alignment: .leading) {
+                    Rectangle().fill(.quaternary)
+                    Rectangle().fill(RG.accent)
+                        .scaleEffect(x: progress, y: 1, anchor: .leading)
                 }
                 .frame(height: 2)
 

--- a/Rclone GUI/Views/Settings/PhotoSyncSettingsView.swift
+++ b/Rclone GUI/Views/Settings/PhotoSyncSettingsView.swift
@@ -34,6 +34,18 @@ struct PhotoSyncSettingsView: View {
     @AppStorage("photosync.notificationsEnabled") private var notificationsEnabled = false
     @AppStorage("photoSync.autoSyncOnImport") private var autoSyncOnImport = true
 
+    private var metricPills: [AppMetricPillGrid.Item] {
+        var items: [AppMetricPillGrid.Item] = [
+            .init(value: "\(stats.pending)", label: "attente", systemImage: "clock", tint: .orange),
+            .init(value: "\(stats.active)", label: "actifs", systemImage: "bolt.fill", tint: .blue),
+            .init(value: "\(stats.completed)", label: "terminés", systemImage: "checkmark.circle", tint: .green),
+        ]
+        if stats.skipped > 0 {
+            items.append(.init(value: "\(stats.skipped)", label: "ignorées", systemImage: "minus.circle", tint: .gray))
+        }
+        return items
+    }
+
     var body: some View {
         Form {
             Section {
@@ -43,14 +55,7 @@ struct PhotoSyncSettingsView: View {
                     systemImage: "photo.stack",
                     tint: RG.photoSync.accent
                 ) {
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 92), spacing: 10)], spacing: 10) {
-                        AppMetricPill(value: "\(stats.pending)", label: "attente", systemImage: "clock", tint: .orange)
-                        AppMetricPill(value: "\(stats.active)", label: "actifs", systemImage: "bolt.fill", tint: .blue)
-                        AppMetricPill(value: "\(stats.completed)", label: "terminés", systemImage: "checkmark.circle", tint: .green)
-                        if stats.skipped > 0 {
-                            AppMetricPill(value: "\(stats.skipped)", label: "ignorées", systemImage: "minus.circle", tint: .gray)
-                        }
-                    }
+                    AppMetricPillGrid(items: metricPills)
 
                     if shouldShowProgressBar {
                         progressBar

--- a/Rclone GUI/Views/Shared/AppUIComponents.swift
+++ b/Rclone GUI/Views/Shared/AppUIComponents.swift
@@ -138,6 +138,44 @@ struct AppMetricPill: View {
     }
 }
 
+/// Grille éagère de `AppMetricPill` (2 colonnes). Surtout pas de LazyVGrid
+/// `.adaptive` dans une row de List/Form : le nombre de colonnes y dépend de
+/// la largeur proposée pendant le self-sizing du UICollectionView sous-jacent,
+/// ce qui peut osciller → « stuck in a recursive layout loop », crash fatal du
+/// _UICollectionViewFeedbackLoopDebugger depuis iOS 18.
+struct AppMetricPillGrid: View {
+    struct Item {
+        let value: String
+        let label: LocalizedStringKey
+        var systemImage: String
+        var tint: Color = .accentColor
+    }
+
+    let items: [Item]
+
+    var body: some View {
+        Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 10) {
+            ForEach(Array(stride(from: 0, to: items.count, by: 2)), id: \.self) { start in
+                GridRow {
+                    pill(items[start])
+                    if start + 1 < items.count {
+                        pill(items[start + 1])
+                    }
+                }
+            }
+        }
+    }
+
+    private func pill(_ item: Item) -> some View {
+        AppMetricPill(
+            value: item.value,
+            label: item.label,
+            systemImage: item.systemImage,
+            tint: item.tint
+        )
+    }
+}
+
 struct AppMetricTile: View {
     let value: String
     let label: LocalizedStringKey

--- a/Rclone GUI/Views/Transfers/TransfersView.swift
+++ b/Rclone GUI/Views/Transfers/TransfersView.swift
@@ -689,13 +689,15 @@ private struct PhotoSyncActivityCard: View {
     private var metricsGrid: some View {
         // D3 : `AppMetricPill` partagé (au lieu du `PhotoSyncMetric`
         // local dupliqué). Aligne le rendu Transferts avec PhotoSyncSettings
-        // qui utilise déjà `AppMetricPill`.
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 88), spacing: 10)], spacing: 10) {
-            AppMetricPill(value: "\(summary?.pendingCount ?? 0)", label: "attente", systemImage: "clock", tint: .orange)
-            AppMetricPill(value: "\(summary?.activeCount ?? 0)", label: "actifs", systemImage: "bolt.fill", tint: .blue)
-            AppMetricPill(value: "\(summary?.completedCount ?? 0)", label: "terminés", systemImage: "checkmark.circle", tint: .green)
-            AppMetricPill(value: "\(summary?.failedCount ?? 0)", label: "échecs", systemImage: "exclamationmark.triangle", tint: .red)
-        }
+        // qui utilise déjà `AppMetricPill`. Grille éagère obligatoire : cette
+        // card vit dans une row de la List et se re-rend chaque seconde
+        // pendant une sync (cf. AppMetricPillGrid).
+        AppMetricPillGrid(items: [
+            .init(value: "\(summary?.pendingCount ?? 0)", label: "attente", systemImage: "clock", tint: .orange),
+            .init(value: "\(summary?.activeCount ?? 0)", label: "actifs", systemImage: "bolt.fill", tint: .blue),
+            .init(value: "\(summary?.completedCount ?? 0)", label: "terminés", systemImage: "checkmark.circle", tint: .green),
+            .init(value: "\(summary?.failedCount ?? 0)", label: "échecs", systemImage: "exclamationmark.triangle", tint: .red),
+        ])
         .animation(.spring(duration: 0.35, bounce: 0.18), value: summary?.completedCount)
         .animation(.spring(duration: 0.35, bounce: 0.18), value: summary?.failedCount)
     }


### PR DESCRIPTION
## Contexte

Rapport de crash reçu (2.1 build 143, iOS 26.5.2) : `Fatal error` UIKit — un `UpdateCoalescingCollectionView` (le `UICollectionView` qui adosse une `List` SwiftUI) « stuck in a recursive layout loop », abattu par le `_UICollectionViewFeedbackLoopDebugger` (`UIKitCore/_UICollectionViewFeedbackLoopDebugger.swift:93`). Le message système : « self-sizing views do not return consistent sizes, or the collection view's frame/bounds/contentOffset is being constantly adjusted ».

Contexte au moment du crash : liste insetGrouped plein écran (375×812), inset haut 156 pt (nav bar + barre de recherche), une sync/transfert venait de tourner (`NOTICE: Bandwidth limit reset` + `ERROR : Entry doesn't belong in directory ""` côté moteur juste avant).

## Cause

Le code contenait plusieurs déclencheurs documentés de cette boucle de layout (cf. forums Apple, crash reproductible depuis iOS 18) :

1. **`LazyVGrid(GridItem(.adaptive))` à l'intérieur d'un conteneur adossé à `UICollectionView`** — le nombre de colonnes dépend de la largeur proposée pendant le self-sizing de la cellule, ce qui peut osciller sans converger. Présent à deux endroits :
   - `TransfersView.metricsGrid` (card PhotoSync dans la `List`, re-rendue **chaque seconde** pendant une sync, avec animations spring) ;
   - `PhotoSyncSettingsView` (hero card dans le `Form`).
2. **Rows de `FolderView` à hauteur instable** : `EntryRowView` bascule entre une ligne caption et un bloc progression plus haut dès qu'un transfert touche la row ; pendant un batch (`@Query` invalide le body ~toutes les 500 ms) les hauteurs de cellules changent en continu. Le label de progression pouvait en plus passer sur 2 lignes selon sa largeur (pas de `lineLimit`).
3. **`GeometryReader` dans le `safeAreaInset` bas** (`AudioMiniBar`, re-rendue chaque seconde par le tick lecteur) au-dessus des Lists self-sizing.

## Correctif

- **`AppMetricPillGrid`** (nouveau, `AppUIComponents.swift`) : grille **éagère** 2 colonnes (`Grid`), layout déterministe quelle que soit la largeur proposée. Remplace les deux `LazyVGrid(.adaptive)` dans `TransfersView` et `PhotoSyncSettingsView`.
- **`EntryRowView`** : hauteur de row **invariante** à l'état transfert — la ligne normale reste dans le layout (opacity 0), la ligne transfert se superpose en `ZStack`, et la barre de progression passe en `overlay` bas **hors flux de layout** ; `lineLimit(1)` sur le label de progression. (Cas indéterminé `bytesTotal == 0` : plus de barre linéaire indéterminée, le glyphe « syncing » en fin de row communique déjà l'activité.)
- **`AudioMiniBar`** : barre de progression sans `GeometryReader` — `scaleEffect(x:anchor:.leading)`, qui n'influence pas le layout.

Non touché : `HandoffSendView` (LazyVGrid à 3 colonnes `.flexible` fixes, contenu statique — pas le motif à risque) ; les LazyVGrid de `HomeView`/`FolderView.gridContent` vivent dans des `ScrollView` (non adossées à `UICollectionView`).

## Tests

- Build simulateur OK.
- Suite `Rclone GUITests` complète (résultat réel dans la conversation de dev).
- Pas de tests unitaires ajoutés : changement 100 % `Views/` (rendu SwiftUI déclaratif, exclu de la couverture par décision du 2026-07-07) ; aucune logique métier nouvelle testable isolément.
