### PR TITLE
fix(fileprovider): navigation impossible dans Fichiers quand l'app est fermée

### DIFF
--- a/Rclone GUI.xcodeproj/project.pbxproj
+++ b/Rclone GUI.xcodeproj/project.pbxproj
@@ -109,6 +109,13 @@
 			);
 			target = 278FAAAB2FAF741D0019F255 /* RcloneFileProvider */;
 		};
+		27D1A4012FD1B00100AB1201 /* Exceptions for "RcloneFileProvider" folder in "Rclone GUITests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AppGroupBridge.swift,
+			);
+			target = 2796AC822FAE017500640D86 /* Rclone GUITests */;
+		};
 		2796AC952FAE017500640D86 /* Exceptions for "Rclone GUI" folder in "Rclone GUI" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -130,6 +137,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				278FAAD22FAF741D0019F255 /* Exceptions for "RcloneFileProvider" folder in "RcloneFileProvider" target */,
+				27D1A4012FD1B00100AB1201 /* Exceptions for "RcloneFileProvider" folder in "Rclone GUITests" target */,
 			);
 			path = RcloneFileProvider;
 			sourceTree = "<group>";

--- a/Rclone GUI/Services/FileProviderFetchService.swift
+++ b/Rclone GUI/Services/FileProviderFetchService.swift
@@ -130,6 +130,21 @@ public final class FileProviderFetchService {
             message: "FetchService list \(pending.remote):\(pending.path)"
         )
 
+        // Accusé de réception immédiat, avant tout appel réseau : c'est le seul
+        // signal qui permet à l'extension de distinguer « app active mais listing
+        // lent » de « app suspendue, personne ne répondra ». Sans lui elle attend
+        // le timeout complet et Fichiers.app reste bloqué sur un spinner.
+        let statusURL = pendingURL.appendingPathExtension("status")
+        writeFetchStatus(
+            stage: "running",
+            jobID: nil,
+            bytesTransferred: 0,
+            bytesTotal: 0,
+            message: nil,
+            to: statusURL
+        )
+        defer { try? FileManager.default.removeItem(at: statusURL) }
+
         do {
             let entries = try await RemoteService.shared.list(
                 remote: pending.remote,

--- a/Rclone GUITests/FileProviderRelayTests.swift
+++ b/Rclone GUITests/FileProviderRelayTests.swift
@@ -1,0 +1,220 @@
+//
+//  FileProviderRelayTests.swift
+//  Rclone GUITests
+//
+//  Tests du relais de listing entre l'extension FileProvider et l'app
+//  principale. Le bug d'origine : en ouvrant un dossier jamais visité depuis
+//  Fichiers.app, l'extension déléguait le listing à l'app principale et pollait
+//  60 s. Or Rclone GUI est suspendue dès que Fichiers est au premier plan, et
+//  une notification Darwin ne réveille pas un process suspendu — personne ne
+//  répondait. Fichiers restait sur un spinner jusqu'à ce que l'utilisateur
+//  bascule manuellement sur l'app, ce qui débloquait le relais.
+//
+//  Le correctif ajoute un accusé de réception (`.status`) écrit par l'app dès
+//  la prise en charge, et un `activationTimeout` court côté extension : sans
+//  ack, on tranche « app inactive » et on liste depuis l'extension.
+//
+
+import Foundation
+import Testing
+@testable import Rclone_GUI
+
+@Suite("FileProvider — décision d'attente du relais de listing")
+struct FileProviderRelayPollDecisionTests {
+
+    /// t0 fixe : toutes les dates des tests en dérivent, aucun appel à Date().
+    private let startedAt = Date(timeIntervalSinceReferenceDate: 800_000_000)
+    private let activationTimeout: TimeInterval = 1.5
+
+    private func decide(
+        manifestMTime: Date? = nil,
+        errorMessage: String? = nil,
+        sawAck: Bool = false,
+        elapsed: TimeInterval
+    ) -> FileProviderBridge.RelayPollDecision {
+        FileProviderBridge.relayPollDecision(
+            manifestMTime: manifestMTime,
+            errorMessage: errorMessage,
+            sawAck: sawAck,
+            startedAt: startedAt,
+            now: startedAt.addingTimeInterval(elapsed),
+            activationTimeout: activationTimeout
+        )
+    }
+
+    // MARK: - Non-régression du bug
+
+    @Test("RÉGRESSION : app suspendue (aucun ack) → appInactive avant le timeout complet")
+    func inactiveAppIsDetectedEarly() {
+        // Le scénario exact du bug : rien n'arrive jamais côté App Group.
+        #expect(decide(elapsed: 1.6) == .appInactive)
+        // Et surtout : bien avant les 60 s de timeout du relais.
+        #expect(decide(elapsed: 59) == .appInactive)
+    }
+
+    @Test("Avant activationTimeout, on laisse sa chance à l'app principale")
+    func waitsUntilActivationTimeout() {
+        #expect(decide(elapsed: 0) == .keepWaiting(sawAck: false))
+        #expect(decide(elapsed: 1.4) == .keepWaiting(sawAck: false))
+    }
+
+    @Test("Pile sur activationTimeout on attend encore : seul un dépassement tranche")
+    func boundaryIsExclusive() {
+        #expect(decide(elapsed: activationTimeout) == .keepWaiting(sawAck: false))
+    }
+
+    // MARK: - App active
+
+    @Test("Ack reçu : on attend le manifest sans jamais conclure à l'inactivité")
+    func ackSuppressesInactivity() {
+        #expect(decide(sawAck: true, elapsed: 2) == .keepWaiting(sawAck: true))
+        #expect(decide(sawAck: true, elapsed: 59) == .keepWaiting(sawAck: true))
+    }
+
+    @Test("Manifest réécrit après le début de la requête → prêt")
+    func freshManifestWins() {
+        let fresh = startedAt.addingTimeInterval(0.5)
+        #expect(decide(manifestMTime: fresh, sawAck: true, elapsed: 0.6) == .manifestReady)
+    }
+
+    @Test("Un manifest antérieur à la requête ne compte pas comme une réponse")
+    func staleManifestIsIgnored() {
+        let stale = startedAt.addingTimeInterval(-30)
+        #expect(decide(manifestMTime: stale, sawAck: true, elapsed: 1) == .keepWaiting(sawAck: true))
+    }
+
+    /// Course réelle : l'app répond en moins d'un tour de boucle (200 ms) et son
+    /// `defer` a déjà effacé l'ack. Sans la priorité au manifest, on conclurait
+    /// à tort « app inactive » et on relisterait pour rien.
+    @Test("Manifest prêt sans ack visible → prêt, pas inactif")
+    func manifestBeatsMissingAck() {
+        let fresh = startedAt.addingTimeInterval(0.1)
+        #expect(decide(manifestMTime: fresh, sawAck: false, elapsed: 5) == .manifestReady)
+    }
+
+    @Test("Échec signalé par l'app principale → propagé tel quel")
+    func errorIsPropagated() {
+        #expect(decide(errorMessage: "quota exceeded", sawAck: true, elapsed: 1) == .failed("quota exceeded"))
+    }
+
+    @Test("Une erreur ne masque pas un manifest déjà écrit")
+    func manifestTakesPrecedenceOverError() {
+        let fresh = startedAt.addingTimeInterval(0.5)
+        #expect(decide(manifestMTime: fresh, errorMessage: "boom", elapsed: 1) == .manifestReady)
+    }
+
+    @Test("Une erreur arrivée avant activationTimeout prime sur l'inactivité")
+    func errorBeatsInactivity() {
+        #expect(decide(errorMessage: "boom", sawAck: false, elapsed: 10) == .failed("boom"))
+    }
+}
+
+@Suite("FileProvider — contrat IPC entre extension et app principale")
+struct FileProviderIPCContractTests {
+
+    /// L'extension attend l'ack à `pendingFetchStatusURL(requestID:)`, l'app
+    /// l'écrit à `<pending>.json` + extension `status`. Si les deux chemins
+    /// divergent, l'ack n'est jamais vu et le spinner revient — en silence.
+    @Test("Les deux côtés désignent le même fichier d'accusé de réception")
+    func ackPathsMatch() {
+        let requestID = "F1B0C0DE-0000-4000-8000-00000000ABCD"
+
+        let extensionSide = FileProviderBridge.pendingFetchStatusURL(requestID: requestID)
+        // Reproduit le calcul de FileProviderFetchService : le pending est
+        // découvert par scan du répertoire, puis suffixé.
+        let appSide = AppGroup.pendingFetchesDir
+            .appending(path: requestID)
+            .appendingPathExtension("json")
+            .appendingPathExtension("status")
+
+        #expect(extensionSide.standardizedFileURL == appSide.standardizedFileURL)
+        #expect(extensionSide.lastPathComponent == "\(requestID).json.status")
+    }
+
+    @Test("Les deux côtés désignent le même répertoire de requêtes")
+    func pendingDirectoriesMatch() {
+        #expect(
+            FileProviderBridge.pendingFetchesDir.standardizedFileURL
+                == AppGroup.pendingFetchesDir.standardizedFileURL
+        )
+    }
+
+    @Test("Le statut écrit par l'app est décodable par l'extension")
+    func statusDecodesAcrossTargets() throws {
+        let appStatus = AppGroupFetchStatus(
+            stage: "running",
+            jobID: nil,
+            bytesTransferred: 0,
+            bytesTotal: 0,
+            updatedAt: Date(timeIntervalSinceReferenceDate: 800_000_000),
+            message: nil
+        )
+        let data = try JSONEncoder().encode(appStatus)
+        let decoded = try JSONDecoder().decode(FetchStatus.self, from: data)
+
+        #expect(decoded.stage == "running")
+        #expect(decoded.bytesTotal == 0)
+        #expect(decoded.updatedAt == appStatus.updatedAt)
+    }
+}
+
+@Suite("FileProvider — manifest de dossier écrit par l'extension")
+struct FileProviderFolderManifestTests {
+
+    private func entry(name: String, isDirectory: Bool = false) -> FolderManifestEntry {
+        FolderManifestEntry(
+            path: "Docs/\(name)",
+            name: name,
+            isDirectory: isDirectory,
+            size: isDirectory ? 0 : 4_096,
+            modTime: Date(timeIntervalSinceReferenceDate: 799_000_000),
+            mimeType: isDirectory ? nil : "application/pdf"
+        )
+    }
+
+    /// L'extension écrit désormais le cache elle-même quand elle liste en direct.
+    /// Le format doit rester lisible par le chemin de lecture existant, sinon le
+    /// dossier réapparaîtrait vide au passage suivant.
+    @Test("Round-trip du manifest écrit en repli direct")
+    func manifestRoundTrips() throws {
+        let entries = [entry(name: "Rapport.pdf"), entry(name: "Archives", isDirectory: true)]
+
+        let data = try JSONEncoder().encode(entries)
+        let decoded = try JSONDecoder().decode([FolderManifestEntry].self, from: data)
+
+        #expect(decoded.count == 2)
+        #expect(decoded[0].name == "Rapport.pdf")
+        #expect(decoded[0].path == "Docs/Rapport.pdf")
+        #expect(decoded[0].isDirectory == false)
+        #expect(decoded[0].size == 4_096)
+        #expect(decoded[0].mimeType == "application/pdf")
+        #expect(decoded[1].isDirectory == true)
+        #expect(decoded[1].mimeType == nil)
+        #expect(decoded[0].modTime == entries[0].modTime)
+    }
+
+    @Test("La clé de fichier manifest est stable et sans séparateur de chemin")
+    func manifestKeyIsFilesystemSafe() {
+        let url = FileProviderBridge.folderManifestURL(remote: "r2 vitalys", path: "Docs/Sous-dossier")
+        let component = url.lastPathComponent
+
+        #expect(component.hasSuffix(".json"))
+        // Le nom encode remote+chemin : aucun "/" ne doit survivre, sinon
+        // l'écriture viserait un sous-répertoire inexistant.
+        #expect(!component.dropLast(5).contains("/"))
+        #expect(
+            url.deletingLastPathComponent().standardizedFileURL
+                == FileProviderBridge.folderManifestsDir.standardizedFileURL
+        )
+    }
+
+    @Test("Deux dossiers distincts n'écrivent pas dans le même manifest")
+    func manifestKeysAreDistinct() {
+        let a = FileProviderBridge.folderManifestURL(remote: "drive", path: "Docs")
+        let b = FileProviderBridge.folderManifestURL(remote: "drive", path: "Photos")
+        let c = FileProviderBridge.folderManifestURL(remote: "autre", path: "Docs")
+
+        #expect(a != b)
+        #expect(a != c)
+    }
+}

--- a/RcloneFileProvider/AppGroupBridge.swift
+++ b/RcloneFileProvider/AppGroupBridge.swift
@@ -502,10 +502,19 @@ public enum FileProviderBridge {
     /// folder manifest dans App Group. L'extension polle l'apparition du
     /// manifest. Évite d'appeler RcloneProviderClient.list dans la .appex
     /// (Go runtime + crypt → jetsam OOM sur les gros dossiers).
+    ///
+    /// `activationTimeout` borne l'attente d'un signe de vie de l'app principale :
+    /// celle-ci écrit un `.status` d'accusé de réception dès qu'elle prend la
+    /// requête en charge. Sans cet ack, l'app est suspendue ou fermée (une notif
+    /// Darwin ne réveille pas un process suspendu) et le relais n'aboutira jamais
+    /// — on jette alors une erreur marquée `appInactiveErrorKey` pour que
+    /// l'appelant liste lui-même, au lieu de figer Fichiers.app sur un spinner
+    /// jusqu'au timeout complet.
     public static func requestFolderManifestViaMainApp(
         remote: String,
         path: String,
-        timeout: TimeInterval
+        timeout: TimeInterval,
+        activationTimeout: TimeInterval = 1.5
     ) async throws {
         try ensureDirectoriesExist()
         let manifestURL = folderManifestURL(remote: remote, path: path)
@@ -529,48 +538,138 @@ public enum FileProviderBridge {
             kind: "list"
         )
         let pendingURL = pendingFetchURL(requestID: requestID)
+        let statusURL = pendingFetchStatusURL(requestID: requestID)
         let data = try JSONEncoder().encode(pending)
         try data.write(to: pendingURL, options: [.atomic])
+        try? FileManager.default.removeItem(at: statusURL)
 
         appendDiagnostic("ipc list request id=\(requestID) remote=\(redact(remote)) path=\(redact(path))")
         postDarwinNotification(notificationFetchRequest)
 
         let deadline = Date().addingTimeInterval(timeout)
         let startTime = Date()
+        let errorURL = pendingURL.appendingPathExtension("error")
+        var didSeeAck = false
         while Date() < deadline {
             try Task.checkCancellation()
 
-            if let attrs = try? FileManager.default.attributesOfItem(atPath: manifestURL.path),
-               let mtime = attrs[.modificationDate] as? Date,
-               mtime > startTime {
-                appendDiagnostic("ipc list ready id=\(requestID)")
-                try? FileManager.default.removeItem(at: pendingURL)
-                return
-            }
+            let decision = relayPollDecision(
+                manifestMTime: fileModificationDate(at: manifestURL),
+                errorMessage: (try? Data(contentsOf: errorURL)).flatMap { String(data: $0, encoding: .utf8) },
+                sawAck: didSeeAck || FileManager.default.fileExists(atPath: statusURL.path),
+                startedAt: startTime,
+                now: Date(),
+                activationTimeout: activationTimeout
+            )
 
-            let errorURL = pendingURL.appendingPathExtension("error")
-            if let errorData = try? Data(contentsOf: errorURL),
-               let message = String(data: errorData, encoding: .utf8) {
+            switch decision {
+            case .manifestReady:
+                appendDiagnostic("ipc list ready id=\(requestID)")
+                cleanupFetchIPC(pendingURL: pendingURL)
+                return
+
+            case .failed(let message):
                 appendDiagnostic("ipc list error id=\(requestID) message=\(message)")
-                try? FileManager.default.removeItem(at: pendingURL)
-                try? FileManager.default.removeItem(at: errorURL)
+                cleanupFetchIPC(pendingURL: pendingURL)
                 throw NSError(
                     domain: NSFileProviderErrorDomain,
                     code: NSFileProviderError.serverUnreachable.rawValue,
                     userInfo: [NSLocalizedDescriptionKey: message]
                 )
+
+            case .appInactive:
+                appendDiagnostic("ipc list activation timeout id=\(requestID)")
+                cleanupFetchIPC(pendingURL: pendingURL)
+                throw NSError(
+                    domain: NSFileProviderErrorDomain,
+                    code: NSFileProviderError.serverUnreachable.rawValue,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Lancez Rclone GUI puis réessayez (l'app n'est pas active).",
+                        Self.appInactiveErrorKey: true,
+                    ]
+                )
+
+            case .keepWaiting(let sawAck):
+                if sawAck, !didSeeAck {
+                    didSeeAck = true
+                    appendDiagnostic("ipc list ack id=\(requestID)")
+                }
             }
 
             try? await Task.sleep(for: .milliseconds(200))
         }
 
-        try? FileManager.default.removeItem(at: pendingURL)
+        cleanupFetchIPC(pendingURL: pendingURL)
         appendDiagnostic("ipc list timeout id=\(requestID)")
         throw NSError(
             domain: NSFileProviderErrorDomain,
             code: NSFileProviderError.serverUnreachable.rawValue,
             userInfo: [NSLocalizedDescriptionKey: "Lancez Rclone GUI puis réessayez (listing indisponible)."]
         )
+    }
+
+    /// Issue d'un tour de la boucle d'attente du relais de listing.
+    public enum RelayPollDecision: Equatable, Sendable {
+        /// L'app principale a (ré)écrit le manifest après le début de la requête.
+        case manifestReady
+        /// L'app principale a signalé un échec.
+        case failed(String)
+        /// Aucun signe de vie passé `activationTimeout` : l'app est suspendue ou
+        /// fermée, inutile d'attendre le timeout complet.
+        case appInactive
+        /// On continue d'attendre ; `sawAck` mémorise si l'ack a été observé.
+        case keepWaiting(sawAck: Bool)
+    }
+
+    /// Décision pure d'un tour de boucle, extraite pour être testable sans
+    /// dépendre du système de fichiers ni d'une vraie app principale.
+    ///
+    /// L'ordre des cas compte : un manifest déjà écrit l'emporte sur l'absence
+    /// d'ack, sinon un listing plus rapide que le premier tour de boucle (l'ack
+    /// est effacé dès que l'app a fini) serait pris à tort pour une app inactive.
+    public static func relayPollDecision(
+        manifestMTime: Date?,
+        errorMessage: String?,
+        sawAck: Bool,
+        startedAt: Date,
+        now: Date,
+        activationTimeout: TimeInterval
+    ) -> RelayPollDecision {
+        if let manifestMTime, manifestMTime > startedAt {
+            return .manifestReady
+        }
+        if let errorMessage {
+            return .failed(errorMessage)
+        }
+        if !sawAck, now.timeIntervalSince(startedAt) > activationTimeout {
+            return .appInactive
+        }
+        return .keepWaiting(sawAck: sawAck)
+    }
+
+    private static func fileModificationDate(at url: URL) -> Date? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+            return nil
+        }
+        return attrs[.modificationDate] as? Date
+    }
+
+    /// Écrit le folder manifest depuis l'extension (repli hors-ligne quand l'app
+    /// principale n'est pas active). Même emplacement et même encodage que
+    /// `FileProviderManager.writeFolderManifest` côté app, pour que les deux
+    /// chemins alimentent le même cache.
+    public static func writeFolderManifest(
+        remote: String,
+        path: String,
+        entries: [FolderManifestEntry]
+    ) {
+        do {
+            try ensureDirectoriesExist()
+            let data = try JSONEncoder().encode(entries)
+            try data.write(to: folderManifestURL(remote: remote, path: path), options: [.atomic])
+        } catch {
+            appendDiagnostic("write folder manifest failed remote=\(redact(remote)) path=\(redact(path)) error=\(error.localizedDescription)")
+        }
     }
 }
 

--- a/RcloneFileProvider/RcloneEnumerator.swift
+++ b/RcloneFileProvider/RcloneEnumerator.swift
@@ -141,6 +141,31 @@ public final class RcloneEnumerator: NSObject, NSFileProviderEnumerator {
                 FileProviderBridge.appendDiagnostic("enumerate \(decoded.remote):\(decoded.path) IPC done but manifest missing")
                 observer.didEnumerate([])
                 observer.finishEnumerating(upTo: nil)
+            } catch let relayError as NSError where FileProviderBridge.errorMeansAppInactive(relayError) {
+                // App principale suspendue ou fermée : elle ne répondra jamais au
+                // relais et Fichiers.app resterait sur un spinner jusqu'à ce que
+                // l'utilisateur bascule sur l'app. On liste alors depuis
+                // l'extension — un operations/list non récursif est bien plus
+                // léger que le download qui motivait le passage par l'app.
+                FileProviderBridge.appendDiagnostic("relay app inactive → listing direct \(decoded.remote):\(decoded.path)")
+                do {
+                    let entries = try await RcloneProviderClient.shared.list(
+                        remote: decoded.remote,
+                        path: decoded.path
+                    )
+                    FileProviderBridge.writeFolderManifest(
+                        remote: decoded.remote,
+                        path: decoded.path,
+                        entries: entries.map(Self.manifestEntry)
+                    )
+                    FileProviderBridge.appendDiagnostic("enumerate \(decoded.remote):\(decoded.path) direct count=\(entries.count)")
+                    observer.didEnumerate(items(for: entries, parentIdentifier: itemIdentifier, remote: decoded.remote))
+                    observer.finishEnumerating(upTo: nil)
+                } catch {
+                    fileProviderLog.error("direct listing \(decoded.remote, privacy: .public):\(decoded.path, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+                    FileProviderBridge.appendDiagnostic("enumerate \(decoded.remote):\(decoded.path) direct failed: \(error.localizedDescription)")
+                    observer.finishEnumeratingWithError(error)
+                }
             } catch {
                 fileProviderLog.error("enumerating \(decoded.remote, privacy: .public):\(decoded.path, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
                 FileProviderBridge.appendDiagnostic("enumerate \(decoded.remote):\(decoded.path) failed: \(error.localizedDescription)")
@@ -291,6 +316,19 @@ public final class RcloneEnumerator: NSObject, NSFileProviderEnumerator {
             isDirectory: true,
             size: 0,
             modTime: Date.distantPast
+        )
+    }
+
+    /// Convertit une entrée listée en direct par l'extension vers le format du
+    /// cache disque partagé avec l'app principale.
+    static func manifestEntry(_ entry: FPRemoteEntry) -> FolderManifestEntry {
+        FolderManifestEntry(
+            path: entry.path,
+            name: entry.name,
+            isDirectory: entry.isDirectory,
+            size: entry.size,
+            modTime: entry.modTime,
+            mimeType: entry.mimeType
         )
     }
 


### PR DESCRIPTION
## Symptôme

Impossible de naviguer dans l'app Fichiers : un spinner tourne et ne disparaît
qu'en basculant manuellement sur Rclone GUI.

## Cause

`RcloneEnumerator.enumerateItems` sert un dossier depuis le folder manifest en
cache. Quand ce manifest est absent — c'est-à-dire à **chaque première visite
d'un dossier** — il délègue le listing à l'app principale
(`requestFolderManifestViaMainApp`) : écriture d'une requête dans l'App Group,
notification Darwin, puis polling pendant 60 s.

Sauf que Rclone GUI est suspendue dès que Fichiers passe au premier plan, et
une notification Darwin ne réveille pas un process suspendu. Personne ne
traitait la requête, l'énumération n'appelait jamais `finishEnumerating`, et
Fichiers restait sur son spinner. Basculer sur l'app la réveillait, le
`FileProviderFetchService` traitait la requête en attente et écrivait le
manifest — d'où le déblocage exactement au changement d'app.

`fetchContents` gérait déjà ce cas (repli direct via `errorMeansAppInactive`,
PR #79) ; le chemin d'énumération, lui, n'avait aucun repli.

## Correctif

- **Accusé de réception** : `handleListRequest` écrit un `.status` dès la prise
  en charge, avant tout appel réseau. C'est le seul signal permettant de
  distinguer « app active mais listing lent » de « app suspendue ».
- **Détection rapide** : sans ack passé `activationTimeout` (1,5 s),
  l'extension jette une erreur marquée `appInactiveErrorKey` au lieu d'attendre
  les 60 s.
- **Repli local** : l'énumérateur liste alors lui-même via
  `RcloneProviderClient.list` (`operations/list` non récursif — bien plus léger
  que le download qui motivait le passage par l'app) et écrit le manifest, donc
  Fichiers navigue sans qu'on ait à ouvrir l'app.

L'ordre des cas compte : un manifest déjà écrit prime sur l'absence d'ack,
sinon un listing plus rapide qu'un tour de boucle (l'ack étant effacé en fin de
traitement) passerait à tort pour une app inactive.

## Tests

Décision d'attente extraite en fonction pure `relayPollDecision`, testée sans
horloge ni système de fichiers :

- **10 cas unitaires** dont la non-régression du bug (aucun ack → `appInactive`
  bien avant le timeout), la borne d'activation, la priorité manifest > ack
  manquant, et la propagation d'erreur.
- **3 cas d'intégration** sur le contrat IPC : les deux cibles désignent le même
  fichier d'ack et le même répertoire de requêtes, et le statut écrit par l'app
  est décodable par l'extension. Un divergence de chemin ferait revenir le
  spinner en silence.
- **3 cas** sur le manifest écrit par l'extension : round-trip d'encodage,
  clé de fichier sans séparateur de chemin, unicité par dossier.

Suite complète sur simulateur iOS 27 : **230 tests, 230 passés, 0 échec, 0 ignoré**.