### PR TITLE
fix(remotes): remote « fantôme » ni modifiable ni supprimable

### DIFF
--- a/Rclone GUI/Services/RcloneConfigEditor.swift
+++ b/Rclone GUI/Services/RcloneConfigEditor.swift
@@ -19,6 +19,7 @@ enum RcloneConfigEditor {
     enum ConfigError: LocalizedError, Equatable {
         case duplicateRemote(String)
         case remoteNotFound(String)
+        case deletionFailed(String)
         case invalidRemoteName
         case invalidType
         case invalidOptionKey(String)
@@ -30,6 +31,8 @@ enum RcloneConfigEditor {
                 return String(localized: "Le remote « \(name) » existe déjà.")
             case .remoteNotFound(let name):
                 return String(localized: "Le remote « \(name) » n’existe plus.")
+            case .deletionFailed(let name):
+                return String(localized: "Le remote « \(name) » est toujours présent après la suppression. Redémarre l’app puis réessaie ; si ça persiste, envoie les logs depuis Réglages → Logs.")
             case .invalidRemoteName:
                 return String(localized: "Choisis un nom de remote sans :, [, ], / ni retour à la ligne.")
             case .invalidType:
@@ -68,12 +71,49 @@ enum RcloneConfigEditor {
     /// Reads one remote section from the decrypted config without exposing
     /// the result to logs or UI. Sensitive values are returned only so the
     /// edit flow can distinguish an existing secret from a missing one.
+    ///
+    /// Deux sources coexistent et peuvent diverger : le store chiffré (ce que
+    /// l'app persiste) et le rclone.conf runtime (ce que le moteur connaît, et
+    /// ce que la liste des remotes affiche via `config/listremotes`). Le wizard
+    /// écrit la section via `config/create` dès l'étape « Tester » et ne la
+    /// re-chiffre dans le store qu'à la finalisation : un remote abandonné
+    /// après un test raté n'existe donc que côté moteur. Lire le seul store
+    /// faisait échouer l'édition d'un remote pourtant listé (« Impossible de
+    /// charger le remote »). On retombe donc sur `config/dump`.
     static func remoteConfig(named name: String) async throws -> RemoteConfigSnapshot? {
-        guard let data = try await ConfigStore.shared.load() else { return nil }
-        guard let text = String(data: data, encoding: .utf8) else {
-            throw ConfigError.invalidUTF8
+        if let data = try await ConfigStore.shared.load() {
+            guard let text = String(data: data, encoding: .utf8) else {
+                throw ConfigError.invalidUTF8
+            }
+            if let stored = remoteConfig(in: text, named: name) {
+                return stored
+            }
         }
-        return remoteConfig(in: text, named: name)
+        return await engineRemoteConfig(named: name)
+    }
+
+    /// Reconstruit un snapshot depuis le `config/dump` du moteur. Utilisé quand
+    /// la section n'est (pas encore) dans le store chiffré. Best-effort : un
+    /// moteur indisponible renvoie `nil`, l'appelant traduira en
+    /// `remoteNotFound`.
+    static func engineRemoteConfig(named rawName: String) async -> RemoteConfigSnapshot? {
+        let target = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !target.isEmpty,
+              let dump = try? await RcloneCore.shared.configDump(),
+              let section = dump[target] else {
+            return nil
+        }
+        return snapshot(fromDumpSection: section, named: target)
+    }
+
+    /// Traduit une section de `config/dump` en snapshot (pur, testable).
+    static func snapshot(
+        fromDumpSection section: [String: String],
+        named name: String
+    ) -> RemoteConfigSnapshot {
+        var options = section
+        let type = options.removeValue(forKey: "type") ?? "unknown"
+        return RemoteConfigSnapshot(name: name, type: type, options: options)
     }
 
     static func remoteConfig(in text: String, named rawName: String) -> RemoteConfigSnapshot? {
@@ -155,16 +195,62 @@ enum RcloneConfigEditor {
     /// Supprime un remote de rclone.conf (retire la section `[name]` et son
     /// corps), réécrit le store chiffré, puis recharge le moteur et le
     /// manifest FileProvider. Les données distantes ne sont pas touchées.
+    ///
+    /// La suppression est menée des DEUX côtés, puis vérifiée :
+    ///
+    /// 1. store chiffré — la section est retirée du texte INI persisté ;
+    /// 2. moteur — `config/delete` retire la même section du rclone.conf
+    ///    runtime, seul endroit où vit un remote écrit par `config/create`
+    ///    mais jamais finalisé (test de connexion raté puis wizard fermé) ;
+    /// 3. vérification — si le nom survit au listing, on lève.
+    ///
+    /// Signalé en 2.1 : un remote dans cet état revenait après chaque tentative
+    /// de suppression, sans erreur ni ligne de log (le store n'ayant pas la
+    /// section, le retrait était un no-op et l'ancien code rendait la main en
+    /// silence — voire sortait avant même de recharger quand aucun store
+    /// n'existait encore).
     static func deleteRemote(name: String) async throws {
-        let existingData = try await ConfigStore.shared.load()
-        guard let existingData,
-              let existingText = String(data: existingData, encoding: .utf8) else {
-            // Pas de config → rien à supprimer.
-            return
+        let target = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !target.isEmpty else { throw ConfigError.invalidRemoteName }
+
+        if let existingData = try await ConfigStore.shared.load(),
+           let existingText = String(data: existingData, encoding: .utf8) {
+            let updatedText = configText(existingText, removingSectionNamed: target)
+            try await ConfigStore.shared.save(Data(updatedText.utf8))
         }
-        let updatedText = configText(existingText, removingSectionNamed: name)
-        try await ConfigStore.shared.save(Data(updatedText.utf8))
+
+        struct DeleteInput: Encodable { let name: String }
+        if let payload = try? JSONEncoder().encode(DeleteInput(name: target)),
+           let json = String(data: payload, encoding: .utf8) {
+            do {
+                _ = try await RcloneCore.shared.rpcRaw("config/delete", json)
+            } catch {
+                // Un remote absent du runtime fait échouer config/delete : ce
+                // n'est pas fatal, l'étape 3 tranche.
+                await LogService.shared.log(
+                    .debug,
+                    category: "config",
+                    message: "config/delete « \(target) » : \(error.localizedDescription)"
+                )
+            }
+        }
+
         await refreshRuntimeAndNotify()
+
+        let remaining = (try? await RcloneCore.shared.listRemoteNames()) ?? []
+        guard !remaining.contains(target) else {
+            await LogService.shared.log(
+                .error,
+                category: "config",
+                message: "Remote « \(target) » toujours listé après suppression"
+            )
+            throw ConfigError.deletionFailed(target)
+        }
+        await LogService.shared.log(
+            .info,
+            category: "config",
+            message: "Remote « \(target) » supprimé de la configuration"
+        )
     }
 
     /// Retourne le texte INI privé de la section `[rawName]` (en-tête + lignes

--- a/Rclone GUI/Views/Files/FilesRootView.swift
+++ b/Rclone GUI/Views/Files/FilesRootView.swift
@@ -35,6 +35,7 @@ struct FilesRootView: View {
     @State private var vaultError: String?
     /// Remote en attente de confirmation de suppression.
     @State private var remoteToDelete: RemoteSummaryDTO?
+    @State private var actionError: String?
 
     enum LoadState: Equatable {
         case idle
@@ -77,6 +78,18 @@ struct FilesRootView: View {
                 Button("OK") { vaultError = nil }
             } message: {
                 Text(vaultError ?? "")
+            }
+            .alert(
+                "Action impossible",
+                isPresented: Binding(
+                    get: { actionError != nil },
+                    set: { if !$0 { actionError = nil } }
+                ),
+                presenting: actionError
+            ) { _ in
+                Button("OK", role: .cancel) { actionError = nil }
+            } message: { message in
+                Text(message)
             }
             .confirmationDialog(
                 "Supprimer ce remote ?",
@@ -525,7 +538,10 @@ struct FilesRootView: View {
             spacesLoading.remove(remote.name)
             await load(force: true)
         } catch {
-            loadState = .failed(error.localizedDescription)
+            // Une suppression qui échoue ne rend pas la liste illisible : elle
+            // est bien chargée, c'est l'action qui a raté. `loadState = .failed`
+            // remplaçait tous les remotes par un écran « Erreur de chargement ».
+            actionError = error.localizedDescription
         }
     }
 

--- a/Rclone GUI/Views/Settings/AddRemote/AddRemoteWizard.swift
+++ b/Rclone GUI/Views/Settings/AddRemote/AddRemoteWizard.swift
@@ -80,6 +80,13 @@ struct AddRemoteWizard: View {
                     }
                 }
         }
+        // Dès que « Tester » a écrit la section dans le rclone.conf runtime,
+        // le glissement vers le bas est bloqué : il ferme la feuille SANS
+        // passer par handleCancel(), donc sans le config/delete de nettoyage.
+        // La section restait alors orpheline — visible dans la liste (le moteur
+        // la connaît) mais absente du store chiffré. C'est l'origine des
+        // remotes « ni modifiables ni supprimables » remontés en 2.1.
+        .interactiveDismissDisabled(state.remoteWasPreCreated)
         .task { await prepareWizard() }
     }
 

--- a/Rclone GUITests/GhostRemoteTests.swift
+++ b/Rclone GUITests/GhostRemoteTests.swift
@@ -1,0 +1,272 @@
+//
+//  GhostRemoteTests.swift
+//  Rclone GUITests
+//
+//  Garde-fous pour les remotes « fantômes » remontés en 2.1 : un remote visible
+//  dans la liste, mais ni modifiable (« Impossible de charger le remote ») ni
+//  supprimable (aucun effet, aucune erreur).
+//
+//  Cause — deux sources de vérité divergentes :
+//
+//    • la LISTE vient du moteur rclone (config/listremotes → rclone.conf
+//      runtime, dans Caches/) ;
+//    • l'ÉDITION et la SUPPRESSION lisaient le seul store chiffré.
+//
+//  Le wizard écrit la section via config/create dès l'étape « Tester » et ne la
+//  re-chiffre dans le store qu'à la finalisation. Un remote abandonné après un
+//  test de connexion raté (SMB injoignable, par ex.) n'existait donc que côté
+//  moteur : l'édition ne le trouvait pas, et la suppression retirait une
+//  section absente puis rendait la main sans erreur.
+//
+//  Les invariants vérifiés ici :
+//    1. retirer une section absente est un no-op — la suppression ne peut donc
+//       PAS reposer sur le seul store (c'est la cause racine, en dur) ;
+//    2. deleteRemote passe aussi par le moteur (config/delete) et VÉRIFIE le
+//       listing derrière, au lieu de sortir en silence ;
+//    3. remoteConfig(named:) retombe sur config/dump quand le store n'a pas la
+//       section ;
+//    4. le wizard ne peut plus être fermé au doigt tant qu'une section
+//       pré-créée n'est pas nettoyée ;
+//    5. un échec de suppression n'efface plus la liste des remotes.
+//
+//  Les points 2 à 5 vivent dans le câblage (appels RPC, modificateurs SwiftUI)
+//  qu'aucun helper pur n'expose : ils sont vérifiés en lisant le source, comme
+//  DestructiveDialogCaptureTests.
+//
+
+import Foundation
+import Testing
+@testable import Rclone_GUI
+
+// MARK: - Lecture de source
+
+/// Racine du dépôt, déduite du chemin de ce fichier de test.
+private var repoRoot: URL {
+    URL(fileURLWithPath: #filePath)      // …/Rclone GUITests/GhostRemoteTests.swift
+        .deletingLastPathComponent()     // …/Rclone GUITests
+        .deletingLastPathComponent()     // …/
+}
+
+/// Lit un source Swift **débarrassé de ses commentaires** : on vérifie le code,
+/// pas la prose. Sans ça les commentaires qui documentent ce correctif — ils
+/// citent `config/delete`, `loadState = .failed`… — feraient passer les
+/// assertions positives à tort et échouer les négatives.
+private func source(_ relativePath: String) throws -> String {
+    let raw = try String(contentsOf: repoRoot.appending(path: relativePath), encoding: .utf8)
+    return stripComments(raw)
+}
+
+/// Retire les commentaires `//` de fin de ligne et les blocs `/* … */`.
+/// Volontairement simple : suffisant pour ces sources (pas de `//` en littéral).
+private func stripComments(_ source: String) -> String {
+    var out = ""
+    var inBlock = false
+    for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+        var text = String(line)
+        if inBlock {
+            guard let end = text.range(of: "*/") else { continue }
+            text = String(text[end.upperBound...])
+            inBlock = false
+        }
+        while let start = text.range(of: "/*") {
+            if let end = text.range(of: "*/", range: start.upperBound..<text.endIndex) {
+                text.replaceSubrange(start.lowerBound..<end.upperBound, with: "")
+            } else {
+                text = String(text[..<start.lowerBound])
+                inBlock = true
+            }
+        }
+        if let comment = text.range(of: "//") {
+            text = String(text[..<comment.lowerBound])
+        }
+        out += text + "\n"
+    }
+    return out
+}
+
+/// Extrait le corps d'une fonction à partir de sa signature, en équilibrant les
+/// accolades. Évite qu'un test passe grâce à du code situé ailleurs dans le
+/// fichier.
+private func functionBody(_ source: String, startingWith signature: String) throws -> String {
+    guard let start = source.range(of: signature) else {
+        throw ExtractionError.signatureNotFound(signature)
+    }
+    guard let open = source[start.upperBound...].firstIndex(of: "{") else {
+        throw ExtractionError.bodyNotFound(signature)
+    }
+    var depth = 0
+    var body = ""
+    for character in source[open...] {
+        if character == "{" { depth += 1 }
+        if depth > 0 { body.append(character) }
+        if character == "}" {
+            depth -= 1
+            if depth == 0 { return body }
+        }
+    }
+    throw ExtractionError.bodyNotFound(signature)
+}
+
+private enum ExtractionError: Error {
+    case signatureNotFound(String)
+    case bodyNotFound(String)
+}
+
+// MARK: - 1. Cause racine : le store seul ne suffit pas
+
+@Suite("Remotes fantômes — divergence store / moteur")
+struct GhostRemoteDivergenceTests {
+
+    @Test("Retirer une section absente du store est un no-op")
+    func removingAbsentSectionIsNoop() {
+        // Le store ne connaît que `drive` : le remote SMB a été écrit par
+        // config/create dans le rclone.conf runtime et jamais re-chiffré.
+        let store = """
+        [drive]
+        type = drive
+        scope = drive
+        """
+
+        let updated = RcloneConfigEditor.configText(store, removingSectionNamed: "smb-nas")
+
+        // Le texte est inchangé — d'où l'absence totale d'effet perçue par
+        // l'utilisateur si la suppression s'arrête là.
+        #expect(updated == store)
+        #expect(RcloneConfigEditor.sectionNames(in: updated) == ["drive"])
+    }
+
+    @Test("Une section présente est bien retirée avec tout son corps")
+    func removesSectionAndBody() {
+        let store = """
+        [drive]
+        type = drive
+
+        [smb-nas]
+        type = smb
+        host = 192.168.1.20
+        user = lucas
+
+        [s3]
+        type = s3
+        """
+
+        let updated = RcloneConfigEditor.configText(store, removingSectionNamed: "smb-nas")
+
+        #expect(RcloneConfigEditor.sectionNames(in: updated) == ["drive", "s3"])
+        #expect(!updated.contains("192.168.1.20"))
+        #expect(!updated.contains("user = lucas"))
+        #expect(updated.contains("[s3]"))
+    }
+
+    @Test("Le snapshot moteur sépare le type des options éditables")
+    func snapshotFromDumpSection() {
+        let snapshot = RcloneConfigEditor.snapshot(
+            fromDumpSection: [
+                "type": "smb",
+                "host": "192.168.1.20",
+                "user": "lucas",
+                "pass": "obscured",
+            ],
+            named: "smb-nas"
+        )
+
+        #expect(snapshot.name == "smb-nas")
+        #expect(snapshot.type == "smb")
+        #expect(snapshot.options["host"] == "192.168.1.20")
+        #expect(snapshot.options["user"] == "lucas")
+        // `type` ne doit jamais réapparaître comme option de formulaire.
+        #expect(snapshot.options["type"] == nil)
+    }
+
+    @Test("Une section sans type reste exploitable")
+    func snapshotWithoutType() {
+        let snapshot = RcloneConfigEditor.snapshot(
+            fromDumpSection: ["host": "nas.local"],
+            named: "orphelin"
+        )
+
+        #expect(snapshot.type == "unknown")
+        #expect(snapshot.options["host"] == "nas.local")
+    }
+
+    @Test("L'échec de suppression porte un message actionnable")
+    func deletionFailureIsDescribed() {
+        let message = RcloneConfigEditor.ConfigError.deletionFailed("smb-nas").errorDescription
+        #expect(message?.contains("smb-nas") == true)
+        #expect(message?.isEmpty == false)
+    }
+}
+
+// MARK: - 2 à 5. Câblage
+
+@Suite("Remotes fantômes — câblage")
+struct GhostRemoteWiringTests {
+
+    private static let editorPath = "Rclone GUI/Services/RcloneConfigEditor.swift"
+
+    @Test("deleteRemote supprime aussi côté moteur")
+    func deleteAlsoHitsEngine() throws {
+        let body = try functionBody(
+            source(Self.editorPath),
+            startingWith: "static func deleteRemote(name: String)"
+        )
+
+        // Sans ça, un remote qui n'existe que dans le rclone.conf runtime
+        // survit à sa propre suppression.
+        #expect(body.contains("config/delete"))
+    }
+
+    @Test("deleteRemote vérifie le résultat au lieu de sortir en silence")
+    func deleteVerifiesOutcome() throws {
+        let body = try functionBody(
+            source(Self.editorPath),
+            startingWith: "static func deleteRemote(name: String)"
+        )
+
+        // Le remote doit avoir disparu du listing, sinon on lève.
+        #expect(body.contains("listRemoteNames"))
+        #expect(body.contains("deletionFailed"))
+
+        // Le store reste mis à jour, et le moteur rechargé derrière — l'ancien
+        // code sortait avant ces deux étapes quand aucun store n'existait.
+        #expect(body.contains("ConfigStore.shared.save"))
+        #expect(body.contains("refreshRuntimeAndNotify"))
+    }
+
+    @Test("L'édition retombe sur le moteur quand le store n'a pas la section")
+    func editFallsBackToEngine() throws {
+        let body = try functionBody(
+            source(Self.editorPath),
+            startingWith: "static func remoteConfig(named name: String)"
+        )
+
+        #expect(body.contains("engineRemoteConfig"))
+
+        // Le `guard let data = … else { return nil }` d'origine court-circuitait
+        // tout le reste dès que le store était absent.
+        #expect(!body.contains("guard let data = try await ConfigStore.shared.load() else { return nil }"))
+    }
+
+    @Test("Le wizard ne peut pas être fermé au doigt sur une section pré-créée")
+    func wizardBlocksInteractiveDismiss() throws {
+        let wizard = try source("Rclone GUI/Views/Settings/AddRemote/AddRemoteWizard.swift")
+
+        // Le swipe-down ferme la feuille sans passer par handleCancel(), donc
+        // sans le config/delete de nettoyage : c'est ce qui fabriquait les
+        // sections orphelines.
+        #expect(wizard.contains(".interactiveDismissDisabled(state.remoteWasPreCreated)"))
+    }
+
+    @Test("Un échec de suppression n'efface pas la liste des remotes")
+    func failedDeletionKeepsList() throws {
+        let body = try functionBody(
+            source("Rclone GUI/Views/Files/FilesRootView.swift"),
+            startingWith: "private func performDelete(_ remote: RemoteSummaryDTO)"
+        )
+
+        // `loadState = .failed` remplaçait tous les remotes par un écran
+        // « Erreur de chargement » alors que la liste était bien chargée.
+        #expect(!body.contains("loadState = .failed"))
+        #expect(body.contains("actionError"))
+    }
+}


### PR DESCRIPTION
Signalé par un utilisateur : après un échec de connexion à un partage SMB, le remote reste dans la liste, **« Modifier » refuse de l'ouvrir** et **« Supprimer » ne fait rien** — sans le moindre message d'erreur. Un second remote se comporte pareil.

## Cause

Deux sources de vérité qui divergent :

| Écran | Source lue |
|---|---|
| Liste des remotes | **moteur rclone** → `config/listremotes` (rclone.conf runtime, dans `Caches/`) |
| Édition | **store chiffré** |
| Suppression | **store chiffré** |

Le wizard écrit la section via `config/create` dès l'étape « Tester » et ne la re-chiffre dans le store qu'à la finalisation (`RecapAndTestView:470`). Une section abandonnée après un test raté n'existe donc que côté moteur :

- `remoteConfig(named:)` renvoyait `nil` → « Impossible de charger le remote » ;
- `deleteRemote` retirait une section absente du store, et sortait même **avant de recharger** quand aucun store n'existait encore — aucun appel moteur, aucune erreur, aucun log.

Ces sections orphelines étaient faciles à fabriquer : fermer la feuille du wizard d'un glissement vers le bas court-circuite `handleCancel()`, donc le `config/delete` de nettoyage.

## Correctifs

- **`deleteRemote`** supprime des deux côtés (store + `config/delete` moteur), puis **vérifie** que le nom a disparu du listing — sinon `ConfigError.deletionFailed` remonte à l'UI. Les deux issues sont journalisées (le rapport précédent était indiagnosticable faute de log).
- **`remoteConfig(named:)`** retombe sur `config/dump` quand le store n'a pas la section : un remote listé est désormais toujours éditable.
- **Le wizard** bloque le dismiss interactif tant qu'une section pré-créée n'a pas été nettoyée.
- **`FilesRootView`** : un échec de suppression ouvre une alerte au lieu de remplacer toute la liste par un écran « Erreur de chargement ».

## Tests

`GhostRemoteTests` — le no-op de suppression sur une section absente (la cause racine, en dur), le découpage du snapshot issu de `config/dump`, et cinq garde-fous de câblage (appel moteur, vérification, fallback d'édition, dismiss bloqué, liste préservée).

**Suite complète : 224 passed, 0 failed, 0 skipped.**

## Hors périmètre

Le même rapport signale des textes restés en français dans les réglages : 384 clés de `Localizable.xcstrings` n'ont aucune traduction anglaise, dont tout l'écran « Gérer les remotes ». Traité séparément.